### PR TITLE
feat(tui): service history pane with one-press rollback

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4354,7 +4354,7 @@ checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "yoink"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "ansi-to-tui",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "3"
 members = ["yoink"]
 
 [workspace.package]
-version = "0.3.0"
+version = "0.4.0"
 edition = "2024"
 rust-version = "1.95"
 license = "MIT"

--- a/yoink/src/tui/app.rs
+++ b/yoink/src/tui/app.rs
@@ -80,6 +80,11 @@ pub enum View {
     HostDetail(Host),
     Services,
     ServiceDetail(String),
+    /// Per-service deploy history (every yoink-managed container with
+    /// `yoink.service=<name>` across every host, sorted newest-first).
+    /// `r` on a row triggers the reconcile-confirm modal pinned to
+    /// that row's tag — same flow as `yoink rollback --tag <value>`.
+    ServiceHistory(String),
     Logs,
     ContainerLogs {
         host: Host,
@@ -114,7 +119,7 @@ impl View {
             | View::ContainerLogs { .. }
             | View::ContainerShell { .. }
             | View::ContainerDetail { .. } => 1,
-            View::Services | View::ServiceDetail(_) => 2,
+            View::Services | View::ServiceDetail(_) | View::ServiceHistory(_) => 2,
             View::Logs => 3,
         }
     }
@@ -185,10 +190,18 @@ impl View {
                 "  enter        live logs",
                 "  i            container detail",
                 "  !            shell · D debug sidecar",
+                "  H            deploy history (with rollback)",
                 "  K            SIGKILL container (with confirmation)",
                 "  U            reconcile this service (with confirmation)",
                 "  /            filter substring · esc to clear",
                 "  r            refresh · esc back",
+            ],
+            View::ServiceHistory(_) => vec![
+                "service history",
+                "  ↑↓ / j k     select past deploy",
+                "  r            rollback to selected (with confirmation)",
+                "  R            refresh",
+                "  esc          back to service detail",
             ],
             View::Logs => vec![
                 "logs (multiplexed)",
@@ -230,6 +243,9 @@ impl View {
             View::HostDetail(h) => vec![root, "Hosts".into(), h.address.clone()],
             View::Services => vec![root, "Services".into()],
             View::ServiceDetail(name) => vec![root, "Services".into(), name.clone()],
+            View::ServiceHistory(name) => {
+                vec![root, "Services".into(), name.clone(), "history".into()]
+            }
             View::Logs => vec![root, "Logs".into()],
             View::ContainerLogs { host, container } => vec![
                 root,
@@ -285,6 +301,12 @@ enum Update {
         data: Box<ContainerDetailRefresh>,
     },
     Dashboard(DashboardRefresh),
+    /// Result of `schedule_history_refresh` — per-service container
+    /// list across every host, drives the History pane's table.
+    ServiceHistory {
+        service: String,
+        rows: Vec<super::history::HistoryRow>,
+    },
     /// Push notification from a host's `docker events` stream. Triggers
     /// an immediate refresh of whichever pane is currently visible.
     Event {
@@ -535,6 +557,7 @@ pub struct App {
     pub host_detail: HostDetailState,
     pub services: ServicesState,
     pub service_detail: ServiceDetailState,
+    pub history: super::history::HistoryState,
     pub container_detail: ContainerDetailState,
     pub logs: LogsState,
     /// `Some` while a `ContainerShell` view is active; cleared on exit.
@@ -632,6 +655,7 @@ impl App {
             host_detail: HostDetailState::new(),
             services: ServicesState::new(),
             service_detail: ServiceDetailState::new(),
+            history: super::history::HistoryState::new(),
             container_detail: ContainerDetailState::new(),
             logs: LogsState::new(),
             shell: None,
@@ -1381,10 +1405,33 @@ impl App {
                         self.open_reconcile_modal(&name);
                     }
                 }
+                KeyCode::Char('H') => {
+                    if let Some(name) = self.service_detail.current_service().map(str::to_string) {
+                        self.transition(View::ServiceHistory(name)).await;
+                    }
+                }
                 KeyCode::Esc => self.transition(View::Services).await,
                 KeyCode::Char('r') => self.schedule_dashboard_refresh(),
                 _ => {}
             },
+            View::ServiceHistory(name) => {
+                let svc = name.clone();
+                match key.code {
+                    KeyCode::Up | KeyCode::Char('k') => self.history.select_prev(),
+                    KeyCode::Down | KeyCode::Char('j') => self.history.select_next(),
+                    KeyCode::Char('r') => {
+                        // Rollback the selected row by hijacking the
+                        // existing reconcile-confirm flow with an
+                        // explicit (service, tag) target.
+                        if let Some((service, tag)) = self.history.selected_rollback_target() {
+                            self.reconcile_target = Some((service, tag));
+                        }
+                    }
+                    KeyCode::Esc => self.transition(View::ServiceDetail(svc)).await,
+                    KeyCode::Char('R') => self.schedule_history_refresh(svc),
+                    _ => {}
+                }
+            }
             View::ContainerShell { .. } => {} // handled above
             View::Logs => match key.code {
                 KeyCode::Char('r') => {
@@ -1589,8 +1636,37 @@ impl App {
                 self.service_detail.set_service(name.clone());
                 self.schedule_dashboard_refresh();
             }
+            View::ServiceHistory(name) => {
+                self.history.set_service(name.clone());
+                self.schedule_history_refresh(name.clone());
+            }
         }
         self.view = new_view;
+    }
+
+    /// Fan out across hosts and collect every container labeled
+    /// `yoink.service=<name>` (running + exited). Posts an
+    /// `Update::ServiceHistory` back to the run loop. Mirrors the CLI
+    /// `cmd_history` query.
+    fn schedule_history_refresh(&mut self, service: String) {
+        let ops = self.ops.clone();
+        let hosts: Vec<Host> = self.config.hosts.iter().map(Host::from).collect();
+        let tx = self.update_tx.clone();
+        tokio::spawn(async move {
+            let label = format!("yoink.service={service}");
+            let mut rows: Vec<super::history::HistoryRow> = Vec::new();
+            for host in hosts {
+                if let Ok(containers) = ops.list_containers_by_label(&host, &label).await {
+                    for c in containers {
+                        rows.push(super::history::HistoryRow::from_container(
+                            &host.address,
+                            &c,
+                        ));
+                    }
+                }
+            }
+            let _ = tx.send(Update::ServiceHistory { service, rows });
+        });
     }
 
     /// The background `start_debug_sidecar` / `exec_interactive` task
@@ -1767,6 +1843,9 @@ impl App {
                 self.dashboard.apply(data);
                 self.dashboard_in_flight = false;
             }
+            Update::ServiceHistory { service, rows } => {
+                self.history.apply(&service, rows);
+            }
             Update::Event { host, event } => self.on_docker_event(&host, &event),
         }
     }
@@ -1923,6 +2002,9 @@ impl App {
             View::ServiceDetail(_) => {
                 self.service_detail
                     .render(frame, pane_area, &self.config, secrets.as_deref());
+            }
+            View::ServiceHistory(_) => {
+                self.history.render(frame, pane_area);
             }
             View::Logs | View::ContainerLogs { .. } => {
                 self.logs.render(frame, pane_area, &self.config);

--- a/yoink/src/tui/history.rs
+++ b/yoink/src/tui/history.rs
@@ -1,0 +1,279 @@
+//! Service deploy history pane: lists past + current container
+//! generations for a single service across every host, sorted
+//! newest-first. Pressing `r` on a row triggers the reconcile-confirm
+//! modal pre-populated with that row's tag — the same flow `yoink
+//! rollback --tag <value>` exercises from the CLI.
+//!
+//! Data is the same shape `cmd_history` produces: every container
+//! labeled `yoink.service=<name>` on every configured host. Stopped
+//! containers from previous deploys are exactly the rollback targets,
+//! and they live on the host until `yoink prune` removes them.
+
+use ratatui::Frame;
+use ratatui::layout::{Constraint, Rect};
+use ratatui::widgets::{Block, Borders, Cell, Paragraph, Row, Table, TableState};
+
+use crate::docker_ops::ContainerInfo;
+use crate::output::format_relative_time;
+
+use super::ui::{TABLE_HIGHLIGHT_SYMBOL, bold, pane_layout, state_style, table_highlight_style};
+
+/// One row in the history table — flattened from a host's container
+/// list so the table can render without dipping back into nested
+/// structures.
+#[derive(Debug, Clone)]
+pub struct HistoryRow {
+    pub host: String,
+    pub container: String,
+    pub version: String,
+    pub state: String,
+    pub deployed_by: String,
+    /// Sort key. `yoink.deployed-at` when present, else `created_unix`.
+    /// `0` for ancient containers without either label — those sink
+    /// to the bottom of the list.
+    pub when_unix: i64,
+}
+
+impl HistoryRow {
+    pub fn from_container(host: &str, c: &ContainerInfo) -> Self {
+        Self {
+            host: host.to_string(),
+            container: c.name.clone(),
+            version: c
+                .yoink_version
+                .clone()
+                .unwrap_or_else(|| "?".to_string()),
+            state: c.state.clone(),
+            deployed_by: c
+                .yoink_deployed_by
+                .clone()
+                .unwrap_or_else(|| "?".to_string()),
+            when_unix: c.yoink_deployed_at.or(c.created_unix).unwrap_or(0),
+        }
+    }
+}
+
+#[derive(Default)]
+pub struct HistoryState {
+    /// `Some(name)` once the pane has been opened for a service. Used
+    /// in render to title the pane even before `apply` lands.
+    service: Option<String>,
+    rows: Vec<HistoryRow>,
+    table: TableState,
+    loaded: bool,
+}
+
+impl HistoryState {
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Tell the pane which service we're about to fetch history for.
+    /// Called from `App::transition` *before* the async fetch resolves
+    /// so the render shows "loading…" with the right title.
+    pub fn set_service(&mut self, name: String) {
+        if self.service.as_deref() != Some(name.as_str()) {
+            self.rows.clear();
+            self.table = TableState::default();
+            self.loaded = false;
+        }
+        self.service = Some(name);
+    }
+
+    /// Apply a fresh fetch result. Sorts newest-first and pins the
+    /// selection to the first row when the previous selection no
+    /// longer fits.
+    pub fn apply(&mut self, service: &str, mut rows: Vec<HistoryRow>) {
+        if self.service.as_deref() != Some(service) {
+            // Result raced a different transition — the user moved on.
+            return;
+        }
+        rows.sort_by_key(|r| std::cmp::Reverse(r.when_unix));
+        self.rows = rows;
+        self.loaded = true;
+        if self.rows.is_empty() {
+            self.table.select(None);
+        } else {
+            let cur = self.table.selected().unwrap_or(0);
+            self.table.select(Some(cur.min(self.rows.len() - 1)));
+        }
+    }
+
+    pub fn select_next(&mut self) {
+        if self.rows.is_empty() {
+            return;
+        }
+        let next = self.table.selected().map_or(0, |i| (i + 1) % self.rows.len());
+        self.table.select(Some(next));
+    }
+
+    pub fn select_prev(&mut self) {
+        if self.rows.is_empty() {
+            return;
+        }
+        let prev = self
+            .table
+            .selected()
+            .map_or(0, |i| if i == 0 { self.rows.len() - 1 } else { i - 1 });
+        self.table.select(Some(prev));
+    }
+
+    /// Selected row's `(service, version)` pair — ready to feed into
+    /// the reconcile-confirm modal as a `--tag` override.
+    #[must_use]
+    pub fn selected_rollback_target(&self) -> Option<(String, String)> {
+        let svc = self.service.as_ref()?;
+        let row = self.rows.get(self.table.selected()?)?;
+        // Refuse "rollback to current" — pointless and surprising;
+        // the operator can press `U` from Services to redeploy the
+        // current spec instead.
+        if row.state == "running" {
+            return None;
+        }
+        Some((svc.clone(), row.version.clone()))
+    }
+
+    pub fn render(&mut self, frame: &mut Frame<'_>, area: Rect) {
+        let layout = pane_layout(area);
+        let title = match &self.service {
+            Some(svc) => format!("yoink history · {svc} · ↑↓ select · r rollback · esc back"),
+            None => "yoink history".into(),
+        };
+        let header = Paragraph::new(title).style(bold());
+        frame.render_widget(header, layout[0]);
+
+        let widths = [
+            Constraint::Length(8),  // when
+            Constraint::Length(14), // version
+            Constraint::Length(10), // state
+            Constraint::Length(20), // host
+            Constraint::Length(36), // container
+            Constraint::Min(12),    // deployed-by
+        ];
+        let rows: Vec<Row<'_>> = if !self.loaded {
+            vec![Row::new(vec![Cell::from("(loading…)")])]
+        } else if self.rows.is_empty() {
+            vec![Row::new(vec![Cell::from(
+                "(no history — service has no yoink-managed containers on any host)",
+            )])]
+        } else {
+            self.rows
+                .iter()
+                .map(|r| {
+                    let when = if r.when_unix > 0 {
+                        format_relative_time(Some(r.when_unix))
+                    } else {
+                        "?".into()
+                    };
+                    Row::new(vec![
+                        Cell::from(when),
+                        Cell::from(r.version.clone()),
+                        Cell::from(r.state.clone()).style(state_style(&r.state)),
+                        Cell::from(r.host.clone()),
+                        Cell::from(r.container.clone()),
+                        Cell::from(r.deployed_by.clone()),
+                    ])
+                })
+                .collect()
+        };
+        let table = Table::new(rows, widths)
+            .header(Row::new(vec![
+                Cell::from("when").style(bold()),
+                Cell::from("version").style(bold()),
+                Cell::from("state").style(bold()),
+                Cell::from("host").style(bold()),
+                Cell::from("container").style(bold()),
+                Cell::from("deployed-by").style(bold()),
+            ]))
+            .row_highlight_style(table_highlight_style())
+            .highlight_symbol(TABLE_HIGHLIGHT_SYMBOL)
+            .block(Block::default().borders(Borders::ALL).title("history"));
+        frame.render_stateful_widget(table, layout[1], &mut self.table);
+
+        let footer = Paragraph::new(
+            "↑↓/jk navigate · r rollback to selected (running rows are skipped) · R refresh · esc back",
+        );
+        frame.render_widget(footer, layout[2]);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pretty_assertions::assert_eq;
+
+    fn row(host: &str, version: &str, state: &str, when: i64) -> HistoryRow {
+        HistoryRow {
+            host: host.into(),
+            container: format!("{version}-{host}"),
+            version: version.into(),
+            state: state.into(),
+            deployed_by: "ci".into(),
+            when_unix: when,
+        }
+    }
+
+    #[test]
+    fn apply_sorts_newest_first() {
+        let mut s = HistoryState::new();
+        s.set_service("api".into());
+        s.apply(
+            "api",
+            vec![
+                row("h", "v1", "exited", 100),
+                row("h", "v3", "running", 300),
+                row("h", "v2", "exited", 200),
+            ],
+        );
+        let versions: Vec<&str> = s.rows.iter().map(|r| r.version.as_str()).collect();
+        assert_eq!(versions, vec!["v3", "v2", "v1"]);
+    }
+
+    #[test]
+    fn apply_for_other_service_is_dropped() {
+        let mut s = HistoryState::new();
+        s.set_service("api".into());
+        s.apply("web", vec![row("h", "v1", "running", 100)]);
+        assert!(s.rows.is_empty());
+        assert!(!s.loaded);
+    }
+
+    #[test]
+    fn selected_rollback_target_skips_running_row() {
+        let mut s = HistoryState::new();
+        s.set_service("api".into());
+        s.apply(
+            "api",
+            vec![
+                row("h", "v3", "running", 300),
+                row("h", "v2", "exited", 200),
+            ],
+        );
+        // Default selection is row 0 → running → no target.
+        assert_eq!(s.selected_rollback_target(), None);
+        s.select_next(); // → v2 exited
+        assert_eq!(
+            s.selected_rollback_target(),
+            Some(("api".into(), "v2".into()))
+        );
+    }
+
+    #[test]
+    fn navigation_wraps() {
+        let mut s = HistoryState::new();
+        s.set_service("api".into());
+        s.apply(
+            "api",
+            vec![
+                row("h", "v3", "running", 300),
+                row("h", "v2", "exited", 200),
+            ],
+        );
+        s.select_next();
+        s.select_next();
+        assert_eq!(s.table.selected(), Some(0));
+        s.select_prev();
+        assert_eq!(s.table.selected(), Some(1));
+    }
+}

--- a/yoink/src/tui/mod.rs
+++ b/yoink/src/tui/mod.rs
@@ -4,6 +4,7 @@
 mod app;
 mod container_detail;
 mod dashboard;
+mod history;
 mod host_detail;
 mod hosts;
 mod logs;


### PR DESCRIPTION
Ships as v0.4.0 (tag already pushed). Closes #62.

## What

New top-level TUI view: from any service detail, press `H` to open the deploy history for that service. Lists every yoink-managed container (running + exited) across every host, sorted newest-first, with `when / version / state / host / container / deployed-by` columns.

Press `r` on a stopped row to open the existing reconcile-confirm modal pinned to that row's version → `y` to roll back. Same path `yoink up` uses today, just with an explicit `--tag` override. Refuses to 'rollback' to a currently-running row.

## Test

- `cargo test --lib` — 140 passed (4 new in `tui::history::tests`)
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- Live data path verified via `yoink history api` against backtrack-eu-1 (same query the new pane uses)

## Roadmap

This is v0.4.0 of a sequence:
- v0.4.0 (this) — history + rollback
- v0.4.1 — container actions (kill, restart) keybinds in TUI
- v0.4.2 — networks pane
- v0.4.3 — top pane (CPU/mem)
