### PR TITLE
feat: secure-by-default RunOptions + cpus/pids_limit + k8s strings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4354,7 +4354,7 @@ checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "yoink"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "ansi-to-tui",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "3"
 members = ["yoink"]
 
 [workspace.package]
-version = "0.4.0"
+version = "0.5.0"
 edition = "2024"
 rust-version = "1.95"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -348,8 +348,19 @@ Operator gestures from the dashboard:
 - `P` — prune
 - `!` — shell into container
 - `D` — debug sidecar (alpine in target's pid+net ns)
+- `H` — service deploy history; on a stopped row press `r` to roll back
 - `?` — help overlay
 - `q` — quit
+
+### Pretty logs
+
+Yoink doesn't try to format logs — it just streams whatever the container writes. Pipe it through [`hl`](https://github.com/pamburus/hl) (`brew install pamburus/tap/hl`) for human-friendly highlighting of structured logs (JSON, logfmt, key=value, etc.):
+
+```sh
+yoink logs api -f | hl
+```
+
+In the TUI's per-container logs pane the same trick works — `hl` reads from any pipe, so `yoink tui` users typically keep a side terminal for the noisy services with `yoink logs <svc> -f | hl`.
 
 ## Build & test
 

--- a/README.md
+++ b/README.md
@@ -218,12 +218,69 @@ services:
       healthcheck_timeout: 60s
       drain_timeout: 30s
       options:
-        memory: 512m
-        cap_drop: [ALL]
-        read_only: true
+        memory: "512Mi"
+        cpus: "1.5"
+        # cap_drop / security_opt / read_only / pids_limit all default
+        # to the hardened profile (see "Sane security defaults" below).
+        # Just give the app some scratch space:
         tmpfs: { /tmp: "size=64m,mode=1777" }
         network_aliases: [api]           # caddy-docker-proxy upstream key
 ```
+
+### Sane security defaults
+
+Compose's defaults are dev-friendly, not prod-friendly: every container runs with the full Linux capability set, a writable rootfs, no `pids` cgroup limit, no protection against setuid escalation. Yoink flips those — every service yoink creates is hardened by default. **The only knobs that opt *into* less safety are explicit:**
+
+| field | yoink default | what it gives you | how to opt out |
+|---|---|---|---|
+| `cap_drop` | `["ALL"]` | every Linux capability dropped (no `CAP_NET_ADMIN`, `CAP_SYS_ADMIN`, …) | `cap_drop: []` (full default cap set), or surgically re-add via `cap_add` |
+| `security_opt` | `["no-new-privileges:true"]` | setuid binaries inside the container can't escalate via `execve` | `security_opt: []` |
+| `read_only` | `true` | rootfs mounted read-only — exploits can't drop binaries on disk | `read_only: false` |
+| `pids_limit` | `1024` | bounds the fork-bomb class of exploits | `pids_limit: null` (unlimited), or any positive int |
+| `cpus` | `null` (uncapped) | — | set to `"2"`, `"500m"`, `"1.5"`, etc. — k8s style |
+| `memory` | `null` (uncapped) | — | set to `"512Mi"`, `"1Gi"`, `"512m"`, `"1g"` — k8s + docker styles both accepted |
+
+Surgical opt-outs in practice (from a real prod config):
+
+```yaml
+# caddy needs to bind :80/:443 — re-add NET_BIND_SERVICE only.
+- name: caddy
+  run:
+    cap_drop: [ALL]
+    cap_add:  [NET_BIND_SERVICE]
+    cpus: "0.5"
+    memory: "64Mi"
+
+# pgadmin's image scribbles all over its rootfs at startup — back out
+# of read_only, keep the rest of the hardened defaults.
+- name: pgadmin
+  run:
+    read_only: false
+    cpus: "1"
+    memory: "256Mi"
+
+# Image with stubborn legacy code that needs root + writable /etc.
+- name: legacy-thing
+  run:
+    user: "0:0"
+    read_only: false
+    cap_drop: []
+    security_opt: []
+```
+
+**Read-only rootfs in practice**: the app still needs *somewhere* to write — `/tmp`, sometimes `/run`, occasionally a cache directory. Pair `read_only: true` with `tmpfs:` to give it scratch space without letting it persist:
+
+```yaml
+run:
+  read_only: true
+  tmpfs:
+    /tmp: "size=64m,mode=1777"
+    /var/cache/app: "size=128m,mode=0755"
+```
+
+What yoink **doesn't** do automatically (for now): seccomp/AppArmor profiles beyond docker's defaults, user-namespace remapping (`--userns-remap`), gVisor / Kata runtime selection. Those are host-wide concerns, not per-service config — set them on the docker daemon and yoink containers inherit.
+
+The TUI's container detail (`i` from any container row) shows the effective security profile for each running container under "security & limits" — easy to spot when something's accidentally lax.
 
 ### Authenticating with Infisical
 

--- a/README.md
+++ b/README.md
@@ -354,13 +354,9 @@ Operator gestures from the dashboard:
 
 ### Pretty logs
 
-Yoink doesn't try to format logs — it just streams whatever the container writes. Pipe it through [`hl`](https://github.com/pamburus/hl) (`brew install pamburus/tap/hl`) for human-friendly highlighting of structured logs (JSON, logfmt, key=value, etc.):
+Structured log lines (JSON, logfmt, etc.) are hard to scan as raw text. The TUI's logs pane auto-detects [`hl`](https://github.com/pamburus/hl) (`brew install pamburus/tap/hl`) on the operator's `PATH` and transparently pipes every container's log stream through it before rendering — so JSON keys are colored, timestamps are dim, levels are highlighted, and stack traces stay readable. Falls back to raw output when `hl` isn't installed; no config knob to toggle.
 
-```sh
-yoink logs api -f | hl
-```
-
-In the TUI's per-container logs pane the same trick works — `hl` reads from any pipe, so `yoink tui` users typically keep a side terminal for the noisy services with `yoink logs <svc> -f | hl`.
+The `yoink logs <svc> -f` CLI doesn't auto-pipe (the operator decides their own shell pipeline), but `yoink logs api -f | hl` works the same way.
 
 ## Build & test
 

--- a/yoink/src/config.rs
+++ b/yoink/src/config.rs
@@ -281,28 +281,123 @@ pub struct ServiceRun {
     pub files: Vec<String>,
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq, Deserialize)]
+/// Per-container runtime options. **All security-relevant fields
+/// default to a hardened profile** — drop every Linux capability,
+/// disallow setuid escalation, immutable rootfs. Operators who need
+/// looser settings opt out explicitly:
+///
+/// ```yaml
+/// run:
+///   cap_drop: []                  # opt out of capability drop
+///   security_opt: []              # opt out of no-new-privileges
+///   read_only: false              # opt out of immutable rootfs
+/// ```
+///
+/// `cpus` + `pids_limit` are uncapped by default; both are sane
+/// knobs to bound a runaway container without tuning the whole host.
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct RunOptions {
     #[serde(default)]
     pub network_aliases: Vec<String>,
+    /// Memory limit. K8s-style strings accepted: `"512Mi"`, `"1Gi"`,
+    /// `"512m"`, `"1g"`. Lowercase suffixes are binary
+    /// (`m` = `Mi` = 2²⁰); k8s `Ki`/`Mi`/`Gi` are also binary;
+    /// uppercase `K`/`M`/`G` are binary too (matches docker, not k8s
+    /// — k8s `K`/`M`/`G` are decimal but we follow docker convention).
+    /// `None` → uncapped.
     #[serde(default)]
     pub memory: Option<String>,
+    /// CPU limit, k8s-style. Absolute cores' worth of CPU time —
+    /// **not** a fraction of host CPU. `"2"` on a 32-core box still
+    /// caps this container at 2 cores. Suffixes: `"500m"` =
+    /// 500 millicores = ½ core; bare numbers like `"1.5"` are also
+    /// accepted. `None` → uncapped. Translates to docker's
+    /// `nano_cpus` (1 core = 1e9 ns/sec).
     #[serde(default)]
+    pub cpus: Option<String>,
+    /// Maximum number of pids/threads the container can create.
+    /// **Default: `1024`** — bounds the fork-bomb class of exploits
+    /// while staying well above what most workloads need (Rust
+    /// async, Node, Redis, Caddy all stay under ~50). JVM apps with
+    /// large thread pools may need to bump this; set to `None` for
+    /// unlimited.
+    #[serde(default = "default_pids_limit")]
+    pub pids_limit: Option<i64>,
+    /// Linux capabilities to drop. **Default: `["ALL"]`** — every
+    /// privileged operation is blocked unless re-enabled via
+    /// `cap_add`. Set to `[]` to opt out (only when you know you need
+    /// the full default capability set).
+    #[serde(default = "default_cap_drop")]
     pub cap_drop: Vec<String>,
+    /// Linux capabilities to add back after `cap_drop`. Common
+    /// example: `[NET_BIND_SERVICE]` for a reverse proxy that needs
+    /// :80/:443.
     #[serde(default)]
     pub cap_add: Vec<String>,
-    #[serde(default)]
+    /// Container security options. **Default:
+    /// `["no-new-privileges:true"]`** — blocks setuid binaries inside
+    /// the container from gaining new caps via execve. Set to `[]`
+    /// to opt out (almost never needed).
+    #[serde(default = "default_security_opt")]
     pub security_opt: Vec<String>,
-    #[serde(default)]
+    /// Mount the rootfs read-only. **Default: `true`** — combine
+    /// with `tmpfs:` for any directories the app needs to write to.
+    /// Set to `false` to opt out for images that scribble all over
+    /// their rootfs at runtime (legacy webapps, the pgadmin image,
+    /// etc.).
+    #[serde(default = "default_read_only")]
     pub read_only: bool,
+    /// In-memory mount points (path → mount options). Pairs with
+    /// `read_only: true` to give the app *some* writable space
+    /// without giving up immutability of the rootfs.
     #[serde(default)]
     pub tmpfs: BTreeMap<String, String>,
     #[serde(default)]
     pub restart: Option<String>,
-    /// Override the container's effective user (e.g. `"0:0"` for otel).
+    /// Override the container's effective user (e.g. `"0:0"` for an
+    /// image that genuinely needs root, or `"1000:1000"` for a
+    /// non-root unprivileged uid). When unset, docker honors the
+    /// image's `USER` directive.
     #[serde(default)]
     pub user: Option<String>,
+}
+
+fn default_cap_drop() -> Vec<String> {
+    vec!["ALL".to_string()]
+}
+
+fn default_security_opt() -> Vec<String> {
+    vec!["no-new-privileges:true".to_string()]
+}
+
+fn default_read_only() -> bool {
+    true
+}
+
+// Wrapped in `Option<i64>` because that's what the field expects;
+// clippy's `unnecessary_wraps` lint is wrong here.
+#[allow(clippy::unnecessary_wraps)]
+fn default_pids_limit() -> Option<i64> {
+    Some(1024)
+}
+
+impl Default for RunOptions {
+    fn default() -> Self {
+        Self {
+            network_aliases: Vec::new(),
+            memory: None,
+            cpus: None,
+            pids_limit: default_pids_limit(),
+            cap_drop: default_cap_drop(),
+            cap_add: Vec::new(),
+            security_opt: default_security_opt(),
+            read_only: default_read_only(),
+            tmpfs: BTreeMap::new(),
+            restart: None,
+            user: None,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, Deserialize)]

--- a/yoink/src/docker.rs
+++ b/yoink/src/docker.rs
@@ -34,8 +34,12 @@ pub fn image_reference(image: &str, tag: &str) -> String {
 
 #[derive(Debug, Error)]
 pub enum BuildError {
-    #[error("invalid memory value {0:?}: expected like \"512m\" or \"1g\"")]
+    #[error("invalid memory value {0:?}: expected like \"512m\", \"512Mi\", or \"1Gi\"")]
     Memory(String),
+    #[error(
+        "invalid cpus value {0:?}: expected an absolute core count like \"2\", \"1.5\", or \"500m\""
+    )]
+    Cpus(String),
     #[error("unknown restart policy {0:?}: expected one of no|always|unless-stopped|on-failure")]
     RestartPolicy(String),
     #[error(
@@ -196,8 +200,12 @@ fn build_host_config(
         Some(port_bindings)
     };
 
+    let nano_cpus = options.cpus.as_deref().map(parse_cpus).transpose()?;
+
     Ok(HostConfig {
         memory,
+        nano_cpus,
+        pids_limit: options.pids_limit,
         cap_drop,
         cap_add,
         security_opt,
@@ -256,19 +264,80 @@ pub fn parse_memory(s: &str) -> Result<i64, BuildError> {
     if s.is_empty() {
         return Err(BuildError::Memory(s.to_string()));
     }
-    let (num, mult) = match s.as_bytes().last() {
-        Some(b'b' | b'B') => (&s[..s.len() - 1], 1_i64),
-        Some(b'k' | b'K') => (&s[..s.len() - 1], 1_024_i64),
-        Some(b'm' | b'M') => (&s[..s.len() - 1], 1_024 * 1_024),
-        Some(b'g' | b'G') => (&s[..s.len() - 1], 1_024 * 1_024 * 1_024),
-        Some(c) if c.is_ascii_digit() => (s, 1_i64),
-        _ => return Err(BuildError::Memory(s.to_string())),
+    // K8s-style binary suffixes (Ki/Mi/Gi/Ti) are checked first so a
+    // bare `m` or `M` doesn't shadow them. Docker-style single-letter
+    // suffixes follow.
+    let (num, mult) = if let Some(rest) = strip_suffix_ci(s, "ki") {
+        (rest, 1_024_i64)
+    } else if let Some(rest) = strip_suffix_ci(s, "mi") {
+        (rest, 1_024_i64.pow(2))
+    } else if let Some(rest) = strip_suffix_ci(s, "gi") {
+        (rest, 1_024_i64.pow(3))
+    } else if let Some(rest) = strip_suffix_ci(s, "ti") {
+        (rest, 1_024_i64.pow(4))
+    } else {
+        match s.as_bytes().last() {
+            Some(b'b' | b'B') => (&s[..s.len() - 1], 1_i64),
+            Some(b'k' | b'K') => (&s[..s.len() - 1], 1_024_i64),
+            Some(b'm' | b'M') => (&s[..s.len() - 1], 1_024 * 1_024),
+            Some(b'g' | b'G') => (&s[..s.len() - 1], 1_024 * 1_024 * 1_024),
+            Some(c) if c.is_ascii_digit() => (s, 1_i64),
+            _ => return Err(BuildError::Memory(s.to_string())),
+        }
     };
     let n: i64 = num
         .trim()
         .parse()
         .map_err(|_| BuildError::Memory(s.to_string()))?;
     Ok(n.saturating_mul(mult))
+}
+
+/// Case-insensitive `strip_suffix` that returns the prefix when the
+/// suffix matches at the tail (case-folded ASCII compare). Used by
+/// the memory parser so `Mi`, `MI`, and `mi` all mean the same thing.
+fn strip_suffix_ci<'a>(s: &'a str, suffix: &str) -> Option<&'a str> {
+    if s.len() < suffix.len() {
+        return None;
+    }
+    let (head, tail) = s.split_at(s.len() - suffix.len());
+    if tail.eq_ignore_ascii_case(suffix) {
+        Some(head)
+    } else {
+        None
+    }
+}
+
+/// Parse a k8s-style CPU string into nano-CPUs (the unit
+/// `bollard::HostConfig::nano_cpus` expects). 1 core = 1e9.
+///
+/// Accepted forms:
+///   - `"2"` / `"1.5"` — bare number, absolute cores' worth.
+///   - `"500m"` — millicores (k8s convention; 1000m = 1 core).
+///
+/// Non-positive values are rejected so the operator's intent isn't
+/// silently turned into "uncapped" by the daemon.
+pub fn parse_cpus(s: &str) -> Result<i64, BuildError> {
+    let s = s.trim();
+    if s.is_empty() {
+        return Err(BuildError::Cpus(s.to_string()));
+    }
+    #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+    let nano = if let Some(rest) = s.strip_suffix('m').or_else(|| s.strip_suffix('M')) {
+        let millis: f64 = rest
+            .trim()
+            .parse()
+            .map_err(|_| BuildError::Cpus(s.to_string()))?;
+        (millis * 1_000_000.0) as i64
+    } else {
+        let cores: f64 = s
+            .parse()
+            .map_err(|_| BuildError::Cpus(s.to_string()))?;
+        (cores * 1_000_000_000.0) as i64
+    };
+    if nano <= 0 {
+        return Err(BuildError::Cpus(s.to_string()));
+    }
+    Ok(nano)
 }
 
 /// Parse docker-cli `--publish` strings into a port-bindings map keyed
@@ -350,6 +419,19 @@ pub fn compute_spec_hash(spec: &RunSpec) -> String {
         &mut h,
         "memory",
         opts.memory.as_deref().unwrap_or("").as_bytes(),
+    );
+    feed(
+        &mut h,
+        "cpus",
+        opts.cpus.as_deref().unwrap_or("").as_bytes(),
+    );
+    feed(
+        &mut h,
+        "pids_limit",
+        opts.pids_limit
+            .map(|n| n.to_string())
+            .unwrap_or_default()
+            .as_bytes(),
     );
     feed_list(&mut h, "cap_drop", &opts.cap_drop);
     feed_list(&mut h, "cap_add", &opts.cap_add);
@@ -445,6 +527,8 @@ mod tests {
             env,
             options: RunOptions {
                 memory: Some("512m".into()),
+                cpus: Some("1.5".into()),
+                pids_limit: Some(512),
                 cap_drop: vec!["ALL".into()],
                 cap_add: vec![],
                 security_opt: vec!["no-new-privileges".into()],
@@ -495,17 +579,44 @@ mod tests {
     }
 
     #[test]
-    fn build_container_minimal_spec() {
+    fn build_container_default_options_yields_secure_host_config() {
+        // RunOptions::default() encodes the secure-by-default profile:
+        // every cap dropped, no-new-privileges set, immutable rootfs,
+        // pids_limit bounded; memory + cpus stay uncapped.
         let mut spec = sample_spec();
         spec.options = RunOptions::default();
         let body = build_container(&spec).unwrap();
         let host = body.host_config.unwrap();
         assert_eq!(host.memory, None);
-        assert_eq!(host.cap_drop, None);
+        assert_eq!(host.nano_cpus, None);
+        assert_eq!(host.pids_limit, Some(1024));
+        assert_eq!(host.cap_drop, Some(vec!["ALL".to_string()]));
         assert_eq!(host.cap_add, None);
+        assert_eq!(
+            host.security_opt,
+            Some(vec!["no-new-privileges:true".to_string()])
+        );
+        assert_eq!(host.readonly_rootfs, Some(true));
+        assert_eq!(host.tmpfs, None);
+    }
+
+    #[test]
+    fn build_container_explicit_opt_outs_yield_lax_host_config() {
+        // Operators with a stubborn legacy image opt out per knob.
+        let mut spec = sample_spec();
+        spec.options = RunOptions {
+            cap_drop: vec![],
+            security_opt: vec![],
+            read_only: false,
+            pids_limit: None,
+            ..RunOptions::default()
+        };
+        let body = build_container(&spec).unwrap();
+        let host = body.host_config.unwrap();
+        assert_eq!(host.cap_drop, None);
         assert_eq!(host.security_opt, None);
         assert_eq!(host.readonly_rootfs, Some(false));
-        assert_eq!(host.tmpfs, None);
+        assert_eq!(host.pids_limit, None);
     }
 
     #[test]
@@ -514,6 +625,33 @@ mod tests {
         assert_eq!(parse_memory("512m").unwrap(), 512 * 1024 * 1024);
         assert_eq!(parse_memory("1G").unwrap(), 1024 * 1024 * 1024);
         assert_eq!(parse_memory("64k").unwrap(), 64 * 1024);
+    }
+
+    #[test]
+    fn parse_memory_accepts_k8s_suffixes() {
+        assert_eq!(parse_memory("512Mi").unwrap(), 512 * 1024 * 1024);
+        assert_eq!(parse_memory("1Gi").unwrap(), 1024 * 1024 * 1024);
+        assert_eq!(parse_memory("64Ki").unwrap(), 64 * 1024);
+        // Case-insensitive
+        assert_eq!(parse_memory("2gi").unwrap(), 2 * 1024 * 1024 * 1024);
+    }
+
+    #[test]
+    fn parse_cpus_accepts_bare_and_millicores() {
+        assert_eq!(parse_cpus("2").unwrap(), 2_000_000_000);
+        assert_eq!(parse_cpus("1.5").unwrap(), 1_500_000_000);
+        assert_eq!(parse_cpus("0.5").unwrap(), 500_000_000);
+        assert_eq!(parse_cpus("500m").unwrap(), 500_000_000);
+        assert_eq!(parse_cpus("1500m").unwrap(), 1_500_000_000);
+    }
+
+    #[test]
+    fn parse_cpus_rejects_non_positive_and_garbage() {
+        assert!(parse_cpus("0").is_err());
+        assert!(parse_cpus("-1").is_err());
+        assert!(parse_cpus("0m").is_err());
+        assert!(parse_cpus("abc").is_err());
+        assert!(parse_cpus("").is_err());
     }
 
     #[test]

--- a/yoink/src/docker_ops.rs
+++ b/yoink/src/docker_ops.rs
@@ -296,6 +296,23 @@ pub struct ContainerDetail {
     /// Network names this container is attached to.
     pub networks: Vec<String>,
     pub labels: BTreeMap<String, String>,
+    /// Effective user (`container.config.user`). Empty string when
+    /// the image's USER is in effect.
+    pub user: Option<String>,
+    /// Memory limit in bytes. `None` → uncapped.
+    pub memory_bytes: Option<i64>,
+    /// CPU limit in nano-CPUs (1 core = 1e9). `None` → uncapped.
+    pub nano_cpus: Option<i64>,
+    /// pids cgroup limit. `None` → unlimited.
+    pub pids_limit: Option<i64>,
+    /// Linux capabilities dropped (`["ALL"]` is yoink's secure default).
+    pub cap_drop: Vec<String>,
+    /// Linux capabilities re-added on top of `cap_drop`.
+    pub cap_add: Vec<String>,
+    /// `--security-opt` entries (e.g. `no-new-privileges:true`).
+    pub security_opt: Vec<String>,
+    /// `--read-only` (immutable rootfs).
+    pub read_only: bool,
 }
 
 /// One docker network as the dashboard / `yoink networks` show it.
@@ -1712,6 +1729,24 @@ fn parse_inspect(name: &str, resp: &bollard::models::ContainerInspectResponse) -
         ports,
         mounts,
         networks,
+        user: config
+            .and_then(|c| c.user.clone())
+            .filter(|u| !u.is_empty()),
+        memory_bytes: host_config.and_then(|h| h.memory).filter(|n| *n > 0),
+        nano_cpus: host_config.and_then(|h| h.nano_cpus).filter(|n| *n > 0),
+        pids_limit: host_config.and_then(|h| h.pids_limit).filter(|n| *n > 0),
+        cap_drop: host_config
+            .and_then(|h| h.cap_drop.clone())
+            .unwrap_or_default(),
+        cap_add: host_config
+            .and_then(|h| h.cap_add.clone())
+            .unwrap_or_default(),
+        security_opt: host_config
+            .and_then(|h| h.security_opt.clone())
+            .unwrap_or_default(),
+        read_only: host_config
+            .and_then(|h| h.readonly_rootfs)
+            .unwrap_or(false),
         labels,
     }
 }

--- a/yoink/src/tui/container_detail.rs
+++ b/yoink/src/tui/container_detail.rs
@@ -215,15 +215,77 @@ impl ContainerDetailState {
         let chunks = Layout::default()
             .direction(Direction::Vertical)
             .constraints([
-                Constraint::Percentage(30), // ports
-                Constraint::Percentage(40), // mounts
-                Constraint::Percentage(30), // networks
+                Constraint::Percentage(20), // ports
+                Constraint::Percentage(30), // mounts
+                Constraint::Percentage(20), // networks
+                Constraint::Percentage(30), // security & limits
             ])
             .split(area);
 
         Self::render_list(frame, chunks[0], " ports ", &inspect.ports);
         Self::render_list(frame, chunks[1], " mounts ", &inspect.mounts);
         Self::render_list(frame, chunks[2], " networks ", &inspect.networks);
+        Self::render_security(frame, chunks[3], inspect);
+    }
+
+    /// Surface the secure-by-default profile + any override the
+    /// operator opted into (`memory`, `cpus`, `pids_limit`,
+    /// `cap_drop`/`cap_add`, `security_opt`, `read_only`, `user`).
+    /// When all knobs are uncapped / at default this section is small
+    /// but still useful — it tells you "yes, this container is
+    /// hardened" at a glance.
+    fn render_security(frame: &mut Frame<'_>, area: Rect, inspect: &ContainerDetail) {
+        let mut lines: Vec<Line<'static>> = Vec::new();
+        // Resource caps row.
+        let mem = inspect
+            .memory_bytes
+            .map_or_else(|| "uncapped".into(), format_bytes);
+        #[allow(clippy::cast_precision_loss)]
+        let cpus = inspect.nano_cpus.map_or_else(
+            || "uncapped".into(),
+            |n| format!("{:.2}", n as f64 / 1_000_000_000.0),
+        );
+        let pids = inspect
+            .pids_limit
+            .map_or_else(|| "unlimited".into(), |n| n.to_string());
+        lines.push(kv("memory", &mem));
+        lines.push(kv("cpus", &cpus));
+        lines.push(kv("pids_limit", &pids));
+        lines.push(kv(
+            "user",
+            inspect.user.as_deref().unwrap_or("(image default)"),
+        ));
+        // Security knobs. Each rendered with a marker so the operator
+        // can scan for "is this hardened?" at a glance.
+        let cap_drop = if inspect.cap_drop.is_empty() {
+            "(none — capabilities NOT dropped)".to_string()
+        } else {
+            inspect.cap_drop.join(",")
+        };
+        lines.push(kv("cap_drop", &cap_drop));
+        if !inspect.cap_add.is_empty() {
+            lines.push(kv("cap_add", &inspect.cap_add.join(",")));
+        }
+        let secopt = if inspect.security_opt.is_empty() {
+            "(none — setuid escalation NOT blocked)".to_string()
+        } else {
+            inspect.security_opt.join(",")
+        };
+        lines.push(kv("security_opt", &secopt));
+        lines.push(kv(
+            "read_only",
+            if inspect.read_only {
+                "true (immutable rootfs)"
+            } else {
+                "false (writable rootfs)"
+            },
+        ));
+        let block = Paragraph::new(lines).block(
+            Block::default()
+                .borders(Borders::ALL)
+                .title(" security & limits "),
+        );
+        frame.render_widget(block, area);
     }
 
     fn render_env_labels(frame: &mut Frame<'_>, area: Rect, inspect: &ContainerDetail) {


### PR DESCRIPTION
v0.5.0. See commit message for full breakdown.

TL;DR — yoink containers now ship hardened by default (cap_drop=ALL, no-new-privileges, read_only, pids_limit=1024). Operators opt out per knob. New `cpus` and `pids_limit` fields, k8s-style strings (`500m`, `2Gi`, `512Mi`). TUI container detail gains a 'security & limits' panel.

**Migration**: services that rely on root or writable rootfs need explicit opt-outs in their fragments before bumping. Audit via `yoink up --dry-run` — every service that needs to flip will show as an Update.
