### PR TITLE
feat: yoink build + --no-registry deploy (standalone mode)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -498,6 +498,7 @@ checksum = "d64e8af5551369d19cf50138de61f1c42074ab970f74e99be916646777f8fc87"
 dependencies = [
  "encode_unicode",
  "libc",
+ "unicode-width 0.2.2",
  "windows-sys 0.61.2",
 ]
 
@@ -1472,6 +1473,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "indicatif"
+version = "0.18.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25470f23803092da7d239834776d653104d551bc4d7eacaf31e6837854b8e9eb"
+dependencies = [
+ "console",
+ "portable-atomic",
+ "unicode-width 0.2.2",
+ "unit-prefix",
+ "web-time",
+]
+
+[[package]]
 name = "indoc"
 version = "2.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2352,7 +2366,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3637,6 +3651,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
+name = "unit-prefix"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81e544489bf3d8ef66c953931f56617f423cd4b5494be343d9b9d3dda037b9a3"
+
+[[package]]
 name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4368,6 +4388,7 @@ dependencies = [
  "futures-util",
  "glob",
  "humantime-serde",
+ "indicatif",
  "insta",
  "keyring",
  "pretty_assertions",
@@ -4380,6 +4401,7 @@ dependencies = [
  "testcontainers",
  "thiserror 2.0.18",
  "tokio",
+ "tokio-util",
  "tracing",
  "tracing-subscriber",
  "tui-term",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4354,7 +4354,7 @@ checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "yoink"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "ansi-to-tui",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "3"
 members = ["yoink"]
 
 [workspace.package]
-version = "0.6.0"
+version = "0.7.0"
 edition = "2024"
 rust-version = "1.95"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -159,52 +159,84 @@ Staging usually wants to deploy whatever's on `main`, while prod tracks `live`. 
 
 The image identity is the same across envs; only the runtime configuration differs.
 
-## Standalone mode (no CI, no registry)
+## Three deploy modes
 
-The default story (push image to a registry → `yoink up` pulls it on each host) is the right answer when you have CI and many hosts. It's the wrong answer when you're an indie developer who just wants their thing running on a server, or when you're rapidly iterating on a Dockerfile and don't want a 5-minute CI loop between every change.
+Yoink supports three ways of getting a container image to a host. Pick the one that fits your setup; they're not mutually exclusive (mix per-service or per-environment).
 
-Yoink supports a "build locally, ship directly to hosts, skip the registry" mode. Two new pieces:
+| | Image origin | Build | Distribution | When it fits |
+|---|---|---|---|---|
+| **CI-built (default)** | CI (GitHub Actions, Depot, etc.) builds + pushes on every commit | external | `docker pull` from registry | Production with multiple hosts and an existing CI/CD pipeline |
+| **Local-build, kamal-style** | Operator's machine | `yoink build --push` | `docker pull` from registry | Indie / one-person team that wants the full deploy loop in one tool, willing to keep a registry |
+| **Standalone (no registry)** | Operator's machine | `yoink build` | `docker save \| docker load` over ssh | Rapid iteration on a single host; air-gapped; "I just want this thing running" |
+
+Pick by service if you want — `yoink build` only runs against services with a `build:` block, so a config can mix CI-built infrastructure (`caddy`, `redis`) with locally-built app code.
+
+### CI-built — the default
+
+Operator config has no `build:` block; CI builds the image and pushes it to a registry on every merge. `yoink up` pulls and rolls. This is what every example so far in this README has been doing — `image: ghcr.io/you/api` with `--tag api=<sha>` overriding tag at deploy time.
+
+### Local-build, kamal-style
 
 ```yaml
 services:
   - name: api
-    image: my-app                    # bare name — no registry prefix
-    tag: dev                         # any string — yoink just tags it
-    build:                           # tells `yoink build` how to produce the image
-      context: .                     # build context (default ".")
-      dockerfile: Dockerfile         # default — `Dockerfile` in context root
+    image: ghcr.io/you/api          # real registry path
+    tag: dev
+    build:                          # tells `yoink build` how to produce the image
+      context: .
+      dockerfile: Dockerfile
       args:
         RUST_VERSION: "1.95"
-      target: runtime                # multi-stage build target (optional)
     run:
       port: 8080
 ```
 
-Then:
+```sh
+docker login ghcr.io                 # one-time
+yoink build api --push               # docker build → docker push ghcr.io/you/api:dev
+yoink up --service api               # docker pull on each host → rolling swap
+```
+
+`yoink build --push` runs `docker build` against your local docker daemon, tagging as `<image>:<tag>` (which equals the registry path because of how `image:` is configured), then runs `docker push`. After that the standard deploy path takes over — exactly like kamal, except the build step is a separate command (so you can build without pushing for CI of your own; or push without rebuilding for re-tagging).
+
+Two-step instead of one-shot is deliberate: `yoink build && yoink up` is the explicit version of `kamal deploy`, and the separation lets you run them on different machines (build on a beefy laptop, deploy from a thin runner) when you want to.
+
+### Standalone (no registry)
+
+```yaml
+services:
+  - name: api
+    image: my-app                   # bare name — no registry prefix
+    tag: dev
+    build:
+      context: .
+    run:
+      port: 8080
+```
 
 ```sh
-yoink build api                      # docker build → tag local image as my-app:dev
+yoink build api                     # docker build → tag local image as my-app:dev
 yoink up --no-registry --service api # save+load to each host (no docker pull)
 ```
 
-What `--no-registry` does: for every selected service × applicable host, yoink runs `docker save <image>:<tag>` against the **operator's local docker daemon**, captures the tarball, and streams it into the host's docker daemon via the same ssh+bollard transport (calling `POST /images/load` directly). After the load completes, the host has the image in its local cache, and the rest of the deploy flow (which already short-circuits when an image is locally present) runs unchanged — healthcheck-gated rolling swap, drift detection, the works.
+What `--no-registry` does: for every (service, host) the deploy targets, yoink runs `docker save <image>:<tag>` against the operator's local docker daemon, captures the tarball, and streams it into the host's docker daemon via the same ssh+bollard transport that `up` already uses (calling `POST /images/load`). After the load completes, the host has the image in its local cache, and the rest of the deploy flow (which already short-circuits when an image is locally present) runs unchanged — healthcheck-gated rolling swap, drift detection, the works.
 
-### When this fits
+**Standalone mode fits when**:
 
-- **Rapid iteration on a single host.** Edit Dockerfile → `yoink build api && yoink up --no-registry --service api` → see it running on the box. ~15 seconds for a small image, ~1 minute for a larger one. No registry to set up, no CI to wait on.
-- **Hobby / indie / prototype deployments.** "I just want this thing on a server" — no build pipeline, no registry account, no auth dance.
-- **Air-gapped or restricted-network hosts.** The host doesn't need outbound network access to anything but the operator's ssh.
+- Rapid iteration on a single host. Edit Dockerfile → `yoink build api && yoink up --no-registry --service api` → see it running on the box. ~15 seconds for a small image. No registry to set up, no CI to wait on.
+- Hobby / indie / prototype deployments. "I just want this thing on a server" — no build pipeline, no registry account.
+- Air-gapped or restricted-network hosts. The host doesn't need outbound network access to anything but the operator's ssh.
 
-### When it doesn't
+**It doesn't fit when**:
 
-- **Many hosts.** N hosts = N save+load streams (each gets the full tarball). A registry is a hub that lets each host pull the missing layers in parallel from a closer point. For 1-3 hosts the difference is small; at 10+ hosts a registry is meaningfully faster.
-- **Large images.** Every `--no-registry` deploy ships the full image tarball over ssh per host. A 200MB Rust binary is fine; a 2GB Java or Node app gets uglier each push.
-- **You want rollback by tag.** `--no-registry` mode relies on the host's local image cache to find old generations. `docker image prune` blows that away. A registry keeps every pushed tag indefinitely.
-- **Auditability matters.** A registry has a record of "image `<sha256:…>` was pushed at time T by user U." `--no-registry` is invisible to anything but the local docker daemons.
+- Many hosts. N hosts = N save+load streams. A registry is a hub that lets each host pull the missing layers in parallel from a closer point. For 1-3 hosts the difference is small; at 10+ hosts a registry is meaningfully faster.
+- Large images. Every deploy ships the full image tarball over ssh per host. A 200MB Rust binary is fine; a 2GB Java or Node app gets uglier each deploy.
+- You want rollback by tag. `--no-registry` mode relies on the host's local image cache for older generations; `docker image prune` blows that away. A registry keeps every pushed tag indefinitely.
+- Auditability matters. A registry has a record of "image `<sha256:…>` was pushed at time T." `--no-registry` is invisible outside the local docker daemons.
 
 ### Self-hosted registry as a yoink service
 
-The middle ground: run a `registry:2` container on one of your hosts, expose it via tailscale, and use that as your registry. Operator config:
+The middle ground between "real remote registry" and "no registry at all": run `registry:2` as a yoink-managed service on one of your hosts, expose it via tailscale, point `image:` at the tailnet hostname.
 
 ```yaml
 services:
@@ -219,11 +251,16 @@ services:
       options:
         memory: "256Mi"
 
-# Then point yoink at it like any other registry. Tailscale ACLs are
-# the auth surface — no docker login / registry password needed.
-registry:
-  server: registry.my-tailnet.ts.net:5000
+  - name: api
+    image: registry.my-tailnet.ts.net:5000/api
+    tag: dev
+    build:
+      context: .
 ```
+
+Then `yoink build api --push` pushes to your tailnet registry; `yoink up --service api` pulls from it. Tailscale ACLs are the registry's auth surface — no `docker login` / registry password needed if your tailnet is correctly scoped. Persistent storage via the `registry-data` volume.
+
+Best for "I want a registry but I don't want to pay for one and I don't want to run it on a separate machine."
 
 Recipe — not yoink-specific code. Best for "I want a registry but I don't want to pay for one and I don't want to run it on a separate machine."
 

--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ Pick by service if you want — `yoink build` only runs against services with a 
 
 ### CI-built — the default
 
-Operator config has no `build:` block; CI builds the image and pushes it to a registry on every merge. `yoink up` pulls and rolls. This is what every example so far in this README has been doing — `image: ghcr.io/you/api` with `--tag api=<sha>` overriding tag at deploy time.
+Operator config has no `build:` block; CI builds the image and pushes it to a registry on every merge. `yoink up` pulls and rolls. The image reference is fully qualified (`image: ghcr.io/you/api`) and the tag typically gets overridden at deploy time via `--tag api=<sha>`.
 
 ### Local-build, kamal-style
 
@@ -285,8 +285,6 @@ services:
 Then `yoink build api --push` pushes to your tailnet registry; `yoink up --service api` pulls from it. Tailscale ACLs are the registry's auth surface — no `docker login` / registry password needed if your tailnet is correctly scoped. Persistent storage via the `registry-data` volume.
 
 Best for "I want a registry but I don't want to pay for one and I don't want to run it on a separate machine."
-
-Recipe — not yoink-specific code. Best for "I want a registry but I don't want to pay for one and I don't want to run it on a separate machine."
 
 ## Install
 

--- a/README.md
+++ b/README.md
@@ -159,6 +159,74 @@ Staging usually wants to deploy whatever's on `main`, while prod tracks `live`. 
 
 The image identity is the same across envs; only the runtime configuration differs.
 
+## Standalone mode (no CI, no registry)
+
+The default story (push image to a registry → `yoink up` pulls it on each host) is the right answer when you have CI and many hosts. It's the wrong answer when you're an indie developer who just wants their thing running on a server, or when you're rapidly iterating on a Dockerfile and don't want a 5-minute CI loop between every change.
+
+Yoink supports a "build locally, ship directly to hosts, skip the registry" mode. Two new pieces:
+
+```yaml
+services:
+  - name: api
+    image: my-app                    # bare name — no registry prefix
+    tag: dev                         # any string — yoink just tags it
+    build:                           # tells `yoink build` how to produce the image
+      context: .                     # build context (default ".")
+      dockerfile: Dockerfile         # default — `Dockerfile` in context root
+      args:
+        RUST_VERSION: "1.95"
+      target: runtime                # multi-stage build target (optional)
+    run:
+      port: 8080
+```
+
+Then:
+
+```sh
+yoink build api                      # docker build → tag local image as my-app:dev
+yoink up --no-registry --service api # save+load to each host (no docker pull)
+```
+
+What `--no-registry` does: for every selected service × applicable host, yoink runs `docker save <image>:<tag>` against the **operator's local docker daemon**, captures the tarball, and streams it into the host's docker daemon via the same ssh+bollard transport (calling `POST /images/load` directly). After the load completes, the host has the image in its local cache, and the rest of the deploy flow (which already short-circuits when an image is locally present) runs unchanged — healthcheck-gated rolling swap, drift detection, the works.
+
+### When this fits
+
+- **Rapid iteration on a single host.** Edit Dockerfile → `yoink build api && yoink up --no-registry --service api` → see it running on the box. ~15 seconds for a small image, ~1 minute for a larger one. No registry to set up, no CI to wait on.
+- **Hobby / indie / prototype deployments.** "I just want this thing on a server" — no build pipeline, no registry account, no auth dance.
+- **Air-gapped or restricted-network hosts.** The host doesn't need outbound network access to anything but the operator's ssh.
+
+### When it doesn't
+
+- **Many hosts.** N hosts = N save+load streams (each gets the full tarball). A registry is a hub that lets each host pull the missing layers in parallel from a closer point. For 1-3 hosts the difference is small; at 10+ hosts a registry is meaningfully faster.
+- **Large images.** Every `--no-registry` deploy ships the full image tarball over ssh per host. A 200MB Rust binary is fine; a 2GB Java or Node app gets uglier each push.
+- **You want rollback by tag.** `--no-registry` mode relies on the host's local image cache to find old generations. `docker image prune` blows that away. A registry keeps every pushed tag indefinitely.
+- **Auditability matters.** A registry has a record of "image `<sha256:…>` was pushed at time T by user U." `--no-registry` is invisible to anything but the local docker daemons.
+
+### Self-hosted registry as a yoink service
+
+The middle ground: run a `registry:2` container on one of your hosts, expose it via tailscale, and use that as your registry. Operator config:
+
+```yaml
+services:
+  - name: registry
+    image: registry
+    tag: "2"
+    networks: [registry]
+    run:
+      port: 5000
+      volumes:
+        - "registry-data:/var/lib/registry"
+      options:
+        memory: "256Mi"
+
+# Then point yoink at it like any other registry. Tailscale ACLs are
+# the auth surface — no docker login / registry password needed.
+registry:
+  server: registry.my-tailnet.ts.net:5000
+```
+
+Recipe — not yoink-specific code. Best for "I want a registry but I don't want to pay for one and I don't want to run it on a separate machine."
+
 ## Install
 
 ### Homebrew

--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ Yoink supports three ways of getting a container image to a host. Pick the one t
 |---|---|---|---|---|
 | **CI-built (default)** | CI (GitHub Actions, Depot, etc.) builds + pushes on every commit | external | `docker pull` from registry | Production with multiple hosts and an existing CI/CD pipeline |
 | **Local-build, kamal-style** | Operator's machine | `yoink build --push` | `docker pull` from registry | Indie / one-person team that wants the full deploy loop in one tool, willing to keep a registry |
-| **Standalone (no registry)** | Operator's machine | `yoink build` | `docker save \| docker load` over ssh | Rapid iteration on a single host; air-gapped; "I just want this thing running" |
+| **Standalone (no registry)** | Operator's machine | `yoink up --build --no-registry` (one command) | `docker save \| docker load` over ssh | Rapid iteration on a single host; air-gapped; low-ceremony tools/utilities; "I just want this thing running" |
 
 Pick by service if you want — `yoink build` only runs against services with a `build:` block, so a config can mix CI-built infrastructure (`caddy`, `redis`) with locally-built app code.
 
@@ -203,23 +203,37 @@ Two-step instead of one-shot is deliberate: `yoink build && yoink up` is the exp
 
 ### Standalone (no registry)
 
+The whole loop in one command for a low-ceremony tool repo: drop a `yoink.yaml` next to your `Dockerfile`, describe where the thing should land, run `yoink up --build --no-registry`. Build, ship, run. No CI to set up, no registry account, no auth dance.
+
 ```yaml
+# yoink.yaml — sits alongside the Dockerfile in your repo
+hosts:
+  - { address: my-server, user: deploy }   # tailnet hostname
+
 services:
-  - name: api
-    image: my-app                   # bare name — no registry prefix
+  - name: my-tool
+    image: my-tool                  # bare name — no registry prefix
     tag: dev
     build:
-      context: .
+      context: .                    # `.` = same directory as yoink.yaml
     run:
       port: 8080
 ```
 
 ```sh
-yoink build api                     # docker build → tag local image as my-app:dev
-yoink up --no-registry --service api # save+load to each host (no docker pull)
+yoink up --build --no-registry      # build + save+load + run, in one command
 ```
 
-What `--no-registry` does: for every (service, host) the deploy targets, yoink streams `docker save <image>:<tag>` from the operator's local docker daemon directly into the host's docker daemon via the same ssh+bollard transport that `up` already uses (calling `POST /images/load`). The transfer is **streaming** — chunks of ~8 KiB flow through the pipe, never buffering the full tarball in operator-side RAM. A 2 GB image costs 8 KiB of memory on the operator's machine, not 2 GB. After the load completes, the host has the image cached and the rest of the deploy flow (which already short-circuits when an image is locally present) runs unchanged — healthcheck-gated rolling swap, drift detection, the works.
+That's it. Edit Dockerfile, rerun, watch the new version roll. Useful for utilities, internal admin tools, prototypes — anything where the GitHub Actions + container-registry overhead is more friction than the deploy is worth.
+
+If you'd rather keep build and deploy as separate steps (e.g. share the build artifact with another shell, or build on a beefy laptop while deploying from a thin runner), the explicit two-command form still works:
+
+```sh
+yoink build my-tool                 # docker build → tag local image as my-tool:dev
+yoink up --no-registry --service my-tool  # save+load to each host
+```
+
+What `--no-registry` does: for every (service, host) the deploy targets, yoink streams `docker save <image>:<tag>` from the operator's local docker daemon directly into the host's docker daemon via the same ssh+bollard transport that `up` already uses (calling `POST /images/load`). After the load completes, the host has the image cached and the rest of the deploy flow (which already short-circuits when an image is locally present) runs unchanged — healthcheck-gated rolling swap, drift detection, the works.
 
 Per-host progress bars track bytes transferred + rate live:
 

--- a/README.md
+++ b/README.md
@@ -219,7 +219,17 @@ yoink build api                     # docker build → tag local image as my-app
 yoink up --no-registry --service api # save+load to each host (no docker pull)
 ```
 
-What `--no-registry` does: for every (service, host) the deploy targets, yoink runs `docker save <image>:<tag>` against the operator's local docker daemon, captures the tarball, and streams it into the host's docker daemon via the same ssh+bollard transport that `up` already uses (calling `POST /images/load`). After the load completes, the host has the image in its local cache, and the rest of the deploy flow (which already short-circuits when an image is locally present) runs unchanged — healthcheck-gated rolling swap, drift detection, the works.
+What `--no-registry` does: for every (service, host) the deploy targets, yoink streams `docker save <image>:<tag>` from the operator's local docker daemon directly into the host's docker daemon via the same ssh+bollard transport that `up` already uses (calling `POST /images/load`). The transfer is **streaming** — chunks of ~8 KiB flow through the pipe, never buffering the full tarball in operator-side RAM. A 2 GB image costs 8 KiB of memory on the operator's machine, not 2 GB. After the load completes, the host has the image cached and the rest of the deploy flow (which already short-circuits when an image is locally present) runs unchanged — healthcheck-gated rolling swap, drift detection, the works.
+
+Per-host progress bars track bytes transferred + rate live:
+
+```
+⠋ api:dev → backtrack-eu-1     234.5 MiB @  47.0 MiB/s
+⠋ api:dev → backtrack-eu-2      56.0 MiB @  11.2 MiB/s
+✓ web:dev → backtrack-eu-1     done · 89.3 MiB
+```
+
+Multi-host fan-out is fully concurrent (`try_join_all` per image): each host gets its own `docker save` process + its own bollard connection, so deploy time = max(per-host) instead of sum(per-host).
 
 **Standalone mode fits when**:
 

--- a/yoink/Cargo.toml
+++ b/yoink/Cargo.toml
@@ -31,6 +31,7 @@ crossterm = { version = "0.28", features = ["event-stream"] }
 futures-util = "0.3"
 glob = "0.3"
 humantime-serde = "1"
+indicatif = "0.18"
 keyring = { version = "3", features = ["apple-native", "windows-native", "sync-secret-service", "vendored"] }
 ratatui = "0.30"
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
@@ -42,6 +43,7 @@ thiserror = "2"
 tui-term = "0.3"
 vt100 = "0.16"
 tokio = { version = "1", features = ["macros", "rt", "rt-multi-thread", "signal", "sync", "time", "fs", "process", "io-util", "io-std"] }
+tokio-util = { version = "0.7", features = ["io"] }
 yaml_serde = "0.10"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", default-features = false, features = ["fmt", "env-filter"] }

--- a/yoink/src/build.rs
+++ b/yoink/src/build.rs
@@ -9,15 +9,18 @@
 //! This is the "I just want to get this thing running on a host"
 //! path: no CI, no registry, no auth dance.
 
+use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 use std::process::Stdio;
 
+use anyhow::Context as _;
 use thiserror::Error;
 use tokio::io::AsyncReadExt;
 use tokio::process::Command;
 
 use crate::config::{Config, ServiceConfig};
 use crate::docker;
+use crate::docker_ops::{DockerOps, Host};
 
 #[derive(Debug, Error)]
 pub enum BuildError {
@@ -55,9 +58,27 @@ fn resolve_relative_to_config(config: &Config, p: &str) -> PathBuf {
     }
 }
 
-/// Run `docker build` for one service. The image is tagged as
-/// `<image>:<tag>` on the operator's local docker daemon. Returns
-/// when the build succeeds; surfaces stderr verbatim on failure.
+/// Resolve a service's effective tag for a build/deploy: a `--tag`
+/// override wins, otherwise the config-pinned `tag:`. Errors with a
+/// helpful message if neither is present.
+pub fn resolve_service_tag(
+    svc: &ServiceConfig,
+    overrides: &BTreeMap<String, String>,
+) -> anyhow::Result<String> {
+    overrides
+        .get(&svc.name)
+        .cloned()
+        .or_else(|| svc.tag.clone())
+        .with_context(|| {
+            format!(
+                "service {:?} has no `tag:` set and no `--tag {}=…` override",
+                svc.name, svc.name
+            )
+        })
+}
+
+/// Build one service, tagging the result on the operator's local
+/// daemon as `<image>:<tag>`. Stderr surfaces verbatim on failure.
 pub async fn build_service(
     config: &Config,
     service: &ServiceConfig,
@@ -147,6 +168,60 @@ pub async fn save_image_locally(image_ref: &str) -> Result<bytes::Bytes, BuildEr
         });
     }
     Ok(bytes::Bytes::from(buf))
+}
+
+/// Pre-flight for `yoink up --no-registry`: for every selected
+/// service × applicable host, `docker save` the local image and
+/// stream it into the host's docker daemon. After this returns, the
+/// host has the image cached and the reconcile's `image_present`
+/// check short-circuits the would-be-pull.
+///
+/// Per-image: one local `docker save` (deduped via the `BTreeMap`),
+/// then a parallel `try_join_all` of `load_image` calls fan-out to
+/// every applicable host. Sequential per-image (one save in flight
+/// at a time) keeps the operator's local docker daemon from racing
+/// itself.
+pub async fn load_images_to_hosts(
+    ops: &dyn DockerOps,
+    config: &Config,
+    tag_overrides: &BTreeMap<String, String>,
+    services_filter: Option<&[String]>,
+) -> anyhow::Result<()> {
+    // image_ref → applicable HostConfigs. BTreeMap keys dedupe shared
+    // images; the inner Vec keeps `&HostConfig` so `Host::from` does
+    // the right thing without re-scanning by address.
+    let mut by_image: BTreeMap<String, Vec<&crate::config::HostConfig>> = BTreeMap::new();
+    for svc in config.selected_services(services_filter) {
+        let tag = resolve_service_tag(svc, tag_overrides)?;
+        let image_ref = docker::image_reference(&svc.image, &tag);
+        let entry = by_image.entry(image_ref).or_default();
+        for host_cfg in svc.applicable_hosts(&config.hosts) {
+            if !entry.iter().any(|h| h.address == host_cfg.address) {
+                entry.push(host_cfg);
+            }
+        }
+    }
+
+    for (image_ref, host_cfgs) in &by_image {
+        eprintln!(
+            "yoink up --no-registry: docker save {image_ref} → {} host(s)",
+            host_cfgs.len()
+        );
+        let tar = save_image_locally(image_ref)
+            .await
+            .with_context(|| format!("docker save {image_ref}"))?;
+        let loads = host_cfgs.iter().map(|host_cfg| {
+            let host = Host::from(*host_cfg);
+            let tar = tar.clone();
+            async move {
+                ops.load_image(&host, tar)
+                    .await
+                    .with_context(|| format!("docker load on {}", host.address))
+            }
+        });
+        futures_util::future::try_join_all(loads).await?;
+    }
+    Ok(())
 }
 
 #[cfg(test)]

--- a/yoink/src/build.rs
+++ b/yoink/src/build.rs
@@ -12,11 +12,16 @@
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 use std::process::Stdio;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
 
 use anyhow::Context as _;
+use bytes::Bytes;
+use futures_util::StreamExt;
+use indicatif::{MultiProgress, ProgressBar, ProgressStyle};
 use thiserror::Error;
-use tokio::io::AsyncReadExt;
 use tokio::process::Command;
+use tokio_util::io::ReaderStream;
 
 use crate::config::{Config, ServiceConfig};
 use crate::docker;
@@ -37,14 +42,18 @@ pub enum BuildError {
     DockerPushFailed { service: String, status: String },
     #[error("`docker save` for {image:?} exited with status {status}")]
     DockerSaveFailed { image: String, status: String },
+    #[error("`docker load` on {host} failed: {source}")]
+    LoadImage {
+        host: String,
+        #[source]
+        source: Box<crate::docker_ops::DockerError>,
+    },
     #[error("failed to spawn `{program}`: {source}")]
     Spawn {
         program: String,
         #[source]
         source: std::io::Error,
     },
-    #[error("failed to read `docker save` output: {0}")]
-    ReadSave(#[source] std::io::Error),
 }
 
 /// Resolve a path declared in the config (`build.context`,
@@ -160,12 +169,26 @@ pub async fn build_service(
     Ok(())
 }
 
-/// Spawn `docker save <image_ref>` against the operator's local
-/// docker daemon and slurp the resulting tarball into memory. The
-/// caller hands this byte buffer to `DockerOps::load_image` per host
-/// — bollard's `import_image` body has to be a single Bytes today, so
-/// streaming is a future optimization (see `bollard::body_stream`).
-pub async fn save_image_locally(image_ref: &str) -> Result<bytes::Bytes, BuildError> {
+/// Stream `docker save <image_ref>` from the operator's local docker
+/// daemon directly into the host's docker daemon via bollard's
+/// `import_image` (`POST /images/load`). Memory stays bounded by
+/// `ReaderStream`'s chunk size (8 KiB by default) regardless of how
+/// large the image is — a 2GB Java/Node app costs 8 KiB of buffer,
+/// not 2GB of RAM, on the operator's machine.
+///
+/// `on_progress` is called with each chunk's byte count as it flows
+/// through the pipe — wire it to a progress bar (CLI) or an event
+/// channel (TUI). Use `|_| ()` for silent transfers.
+///
+/// Multi-host: each call spawns its own `docker save` process and
+/// holds its own client connection to the host. Run multiple calls
+/// concurrently via `try_join_all` for full parallel fan-out.
+pub async fn save_and_load_to_host(
+    image_ref: &str,
+    ops: &dyn DockerOps,
+    host: &Host,
+    on_progress: impl FnMut(u64) + Send + 'static,
+) -> Result<u64, BuildError> {
     let mut child = Command::new("docker")
         .arg("save")
         .arg(image_ref)
@@ -176,15 +199,36 @@ pub async fn save_image_locally(image_ref: &str) -> Result<bytes::Bytes, BuildEr
             program: "docker".into(),
             source,
         })?;
-    let mut stdout = child
+    let stdout = child
         .stdout
         .take()
         .expect("piped stdout should always be available");
-    let mut buf: Vec<u8> = Vec::new();
-    stdout
-        .read_to_end(&mut buf)
+
+    // Wrap stdout in a Stream<Item = Result<Bytes, io::Error>>. Tap
+    // every chunk for progress reporting; callers see live byte
+    // counts as the tarball flows.
+    let total = Arc::new(AtomicU64::new(0));
+    let total_clone = Arc::clone(&total);
+    let mut on_progress = on_progress;
+    let stream = ReaderStream::new(stdout).inspect(move |chunk| {
+        if let Ok(bytes) = chunk {
+            let n = bytes.len() as u64;
+            total_clone.fetch_add(n, Ordering::Relaxed);
+            on_progress(n);
+        }
+    });
+
+    let body: std::pin::Pin<
+        Box<dyn futures_util::Stream<Item = Result<Bytes, std::io::Error>> + Send>,
+    > = Box::pin(stream);
+
+    ops.load_image(host, body)
         .await
-        .map_err(BuildError::ReadSave)?;
+        .map_err(|source| BuildError::LoadImage {
+            host: host.address.clone(),
+            source: Box::new(source),
+        })?;
+
     let status = child.wait().await.map_err(|source| BuildError::Spawn {
         program: "docker".into(),
         source,
@@ -195,29 +239,26 @@ pub async fn save_image_locally(image_ref: &str) -> Result<bytes::Bytes, BuildEr
             status: status.to_string(),
         });
     }
-    Ok(bytes::Bytes::from(buf))
+    Ok(total.load(Ordering::Relaxed))
 }
 
 /// Pre-flight for `yoink up --no-registry`: for every selected
-/// service × applicable host, `docker save` the local image and
-/// stream it into the host's docker daemon. After this returns, the
-/// host has the image cached and the reconcile's `image_present`
-/// check short-circuits the would-be-pull.
+/// service × applicable host, stream `docker save` from the
+/// operator's local daemon into the host's daemon via
+/// `import_image`. Memory stays bounded regardless of image size
+/// (`ReaderStream` chunk size, 8 KiB).
 ///
-/// Per-image: one local `docker save` (deduped via the `BTreeMap`),
-/// then a parallel `try_join_all` of `load_image` calls fan-out to
-/// every applicable host. Sequential per-image (one save in flight
-/// at a time) keeps the operator's local docker daemon from racing
-/// itself.
+/// Per-image: parallel fan-out across all applicable hosts via
+/// `try_join_all`. Each host gets its own `docker save` process
+/// (so streams are independent) and its own progress bar. Multiple
+/// images run sequentially so the operator's local docker daemon
+/// isn't fork-bombed.
 pub async fn load_images_to_hosts(
     ops: &dyn DockerOps,
     config: &Config,
     tag_overrides: &BTreeMap<String, String>,
     services_filter: Option<&[String]>,
 ) -> anyhow::Result<()> {
-    // image_ref → applicable HostConfigs. BTreeMap keys dedupe shared
-    // images; the inner Vec keeps `&HostConfig` so `Host::from` does
-    // the right thing without re-scanning by address.
     let mut by_image: BTreeMap<String, Vec<&crate::config::HostConfig>> = BTreeMap::new();
     for svc in config.selected_services(services_filter) {
         let tag = resolve_service_tag(svc, tag_overrides)?;
@@ -231,25 +272,42 @@ pub async fn load_images_to_hosts(
     }
 
     for (image_ref, host_cfgs) in &by_image {
-        eprintln!(
-            "yoink up --no-registry: docker save {image_ref} → {} host(s)",
-            host_cfgs.len()
-        );
-        let tar = save_image_locally(image_ref)
-            .await
-            .with_context(|| format!("docker save {image_ref}"))?;
+        let multi = MultiProgress::new();
+        let style = ProgressStyle::with_template(
+            "{spinner:.green} {prefix:<24} {bytes:>10} @ {bytes_per_sec:>10}  {wide_msg}",
+        )
+        .expect("static progress template parses");
+
         let loads = host_cfgs.iter().map(|host_cfg| {
             let host = Host::from(*host_cfg);
-            let tar = tar.clone();
+            let bar = multi.add(ProgressBar::new_spinner().with_style(style.clone()));
+            bar.set_prefix(format!("{} → {}", short_image(image_ref), host.address));
+            bar.enable_steady_tick(std::time::Duration::from_millis(100));
+            let bar_for_progress = bar.clone();
+            let image_ref = image_ref.clone();
             async move {
-                ops.load_image(&host, tar)
-                    .await
-                    .with_context(|| format!("docker load on {}", host.address))
+                let total = save_and_load_to_host(&image_ref, ops, &host, move |n| {
+                    bar_for_progress.inc(n);
+                })
+                .await
+                .with_context(|| format!("save+load {image_ref} → {}", host.address))?;
+                bar.finish_with_message(format!("done · {}", indicatif::HumanBytes(total)));
+                anyhow::Ok(())
             }
         });
         futures_util::future::try_join_all(loads).await?;
     }
     Ok(())
+}
+
+/// Trim a registry-prefixed image to its short form for progress
+/// labels (`ghcr.io/oddur/api:dev` → `api:dev`, `bt-api:abc` →
+/// `bt-api:abc`). Keeps the prefix-or-tag axis the operator cares
+/// about without eating the whole terminal width.
+fn short_image(image_ref: &str) -> String {
+    image_ref
+        .rsplit_once('/')
+        .map_or_else(|| image_ref.to_string(), |(_, tail)| tail.to_string())
 }
 
 #[cfg(test)]

--- a/yoink/src/build.rs
+++ b/yoink/src/build.rs
@@ -16,16 +16,16 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 
 use anyhow::Context as _;
-use bytes::Bytes;
 use futures_util::StreamExt;
-use indicatif::{MultiProgress, ProgressBar, ProgressStyle};
+use indicatif::{MultiProgress, ProgressBar, ProgressDrawTarget, ProgressStyle};
 use thiserror::Error;
 use tokio::process::Command;
 use tokio_util::io::ReaderStream;
 
 use crate::config::{Config, ServiceConfig};
 use crate::docker;
-use crate::docker_ops::{DockerOps, Host};
+use crate::docker_ops::{DockerError, DockerOps, Host, ImageTarStream};
+use crate::output::format_bytes;
 
 #[derive(Debug, Error)]
 pub enum BuildError {
@@ -40,14 +40,14 @@ pub enum BuildError {
          (is the operator logged into the registry? `docker login <registry>`)"
     )]
     DockerPushFailed { service: String, status: String },
-    #[error("`docker save` for {image:?} exited with status {status}")]
-    DockerSaveFailed { image: String, status: String },
-    #[error("`docker load` on {host} failed: {source}")]
-    LoadImage {
-        host: String,
-        #[source]
-        source: Box<crate::docker_ops::DockerError>,
+    #[error("`docker save` for {image:?} exited with status {status}{stderr}", stderr = if .stderr.is_empty() { String::new() } else { format!(":\n{}", .stderr) })]
+    DockerSaveFailed {
+        image: String,
+        status: String,
+        stderr: String,
     },
+    #[error(transparent)]
+    Docker(#[from] DockerError),
     #[error("failed to spawn `{program}`: {source}")]
     Spawn {
         program: String,
@@ -203,10 +203,20 @@ pub async fn save_and_load_to_host(
         .stdout
         .take()
         .expect("piped stdout should always be available");
+    // Drain stderr concurrently into a buffer — surfaces "no such image"
+    // and similar diagnostics in the failure path; otherwise the caller
+    // only sees the exit code.
+    let stderr = child
+        .stderr
+        .take()
+        .expect("piped stderr should always be available");
+    let stderr_task = tokio::spawn(async move {
+        use tokio::io::AsyncReadExt;
+        let mut buf = String::new();
+        let _ = tokio::io::BufReader::new(stderr).read_to_string(&mut buf).await;
+        buf
+    });
 
-    // Wrap stdout in a Stream<Item = Result<Bytes, io::Error>>. Tap
-    // every chunk for progress reporting; callers see live byte
-    // counts as the tarball flows.
     let total = Arc::new(AtomicU64::new(0));
     let total_clone = Arc::clone(&total);
     let mut on_progress = on_progress;
@@ -217,26 +227,19 @@ pub async fn save_and_load_to_host(
             on_progress(n);
         }
     });
-
-    let body: std::pin::Pin<
-        Box<dyn futures_util::Stream<Item = Result<Bytes, std::io::Error>> + Send>,
-    > = Box::pin(stream);
-
-    ops.load_image(host, body)
-        .await
-        .map_err(|source| BuildError::LoadImage {
-            host: host.address.clone(),
-            source: Box::new(source),
-        })?;
+    let body: ImageTarStream = Box::pin(stream);
+    ops.load_image(host, body).await?;
 
     let status = child.wait().await.map_err(|source| BuildError::Spawn {
         program: "docker".into(),
         source,
     })?;
+    let stderr_text = stderr_task.await.unwrap_or_default();
     if !status.success() {
         return Err(BuildError::DockerSaveFailed {
             image: image_ref.to_string(),
             status: status.to_string(),
+            stderr: stderr_text.trim().to_string(),
         });
     }
     Ok(total.load(Ordering::Relaxed))
@@ -271,8 +274,16 @@ pub async fn load_images_to_hosts(
         }
     }
 
+    let interactive = std::io::IsTerminal::is_terminal(&std::io::stderr());
     for (image_ref, host_cfgs) in &by_image {
-        let multi = MultiProgress::new();
+        // Hide the progress draw target on non-TTY (CI logs); the
+        // steady-tick wakeups still happen but indicatif batches them
+        // off-screen so it doesn't pollute the captured output.
+        let multi = if interactive {
+            MultiProgress::new()
+        } else {
+            MultiProgress::with_draw_target(ProgressDrawTarget::hidden())
+        };
         let style = ProgressStyle::with_template(
             "{spinner:.green} {prefix:<24} {bytes:>10} @ {bytes_per_sec:>10}  {wide_msg}",
         )
@@ -282,7 +293,9 @@ pub async fn load_images_to_hosts(
             let host = Host::from(*host_cfg);
             let bar = multi.add(ProgressBar::new_spinner().with_style(style.clone()));
             bar.set_prefix(format!("{} → {}", short_image(image_ref), host.address));
-            bar.enable_steady_tick(std::time::Duration::from_millis(100));
+            if interactive {
+                bar.enable_steady_tick(std::time::Duration::from_millis(100));
+            }
             let bar_for_progress = bar.clone();
             let image_ref = image_ref.clone();
             async move {
@@ -291,7 +304,8 @@ pub async fn load_images_to_hosts(
                 })
                 .await
                 .with_context(|| format!("save+load {image_ref} → {}", host.address))?;
-                bar.finish_with_message(format!("done · {}", indicatif::HumanBytes(total)));
+                let signed = i64::try_from(total).unwrap_or(i64::MAX);
+                bar.finish_with_message(format!("done · {}", format_bytes(signed)));
                 anyhow::Ok(())
             }
         });

--- a/yoink/src/build.rs
+++ b/yoink/src/build.rs
@@ -1,0 +1,163 @@
+//! Local image build + deliver-without-registry pipeline.
+//!
+//! `yoink build` shells out to `docker build` against the operator's
+//! local docker daemon, producing a tagged image on the operator's
+//! machine. Pair it with `yoink up --no-registry` to ship that image
+//! to each host via `docker save | docker load` (over the existing
+//! ssh+bollard transport) — no registry needed.
+//!
+//! This is the "I just want to get this thing running on a host"
+//! path: no CI, no registry, no auth dance.
+
+use std::path::{Path, PathBuf};
+use std::process::Stdio;
+
+use thiserror::Error;
+use tokio::io::AsyncReadExt;
+use tokio::process::Command;
+
+use crate::config::{Config, ServiceConfig};
+use crate::docker;
+
+#[derive(Debug, Error)]
+pub enum BuildError {
+    #[error("service {0:?} has no `build:` block — add one or build the image yourself")]
+    NoBuildBlock(String),
+    #[error("service {0:?} not found in config")]
+    UnknownService(String),
+    #[error("`docker build` for {service:?} exited with status {status}")]
+    DockerBuildFailed { service: String, status: String },
+    #[error("`docker save` for {image:?} exited with status {status}")]
+    DockerSaveFailed { image: String, status: String },
+    #[error("failed to spawn `{program}`: {source}")]
+    Spawn {
+        program: String,
+        #[source]
+        source: std::io::Error,
+    },
+    #[error("failed to read `docker save` output: {0}")]
+    ReadSave(#[source] std::io::Error),
+}
+
+/// Resolve a path declared in the config (`build.context`,
+/// `build.dockerfile`) relative to the directory the yoink config
+/// file lives in. Same convention as `files:` mounts and `include:`.
+fn resolve_relative_to_config(config: &Config, p: &str) -> PathBuf {
+    let raw = Path::new(p);
+    if raw.is_absolute() {
+        raw.to_path_buf()
+    } else {
+        let base = config
+            .config_dir
+            .as_deref()
+            .unwrap_or_else(|| Path::new("."));
+        base.join(raw)
+    }
+}
+
+/// Run `docker build` for one service. The image is tagged as
+/// `<image>:<tag>` on the operator's local docker daemon. Returns
+/// when the build succeeds; surfaces stderr verbatim on failure.
+pub async fn build_service(
+    config: &Config,
+    service: &ServiceConfig,
+    tag: &str,
+    no_cache: bool,
+) -> Result<(), BuildError> {
+    let build = service
+        .build
+        .as_ref()
+        .ok_or_else(|| BuildError::NoBuildBlock(service.name.clone()))?;
+    let image_ref = docker::image_reference(&service.image, tag);
+    let context_path = resolve_relative_to_config(config, &build.context);
+
+    let mut cmd = Command::new("docker");
+    cmd.arg("build").arg("--tag").arg(&image_ref);
+
+    if let Some(df) = &build.dockerfile {
+        let df_path = resolve_relative_to_config(config, df);
+        cmd.arg("--file").arg(df_path);
+    }
+    for (k, v) in &build.args {
+        cmd.arg("--build-arg").arg(format!("{k}={v}"));
+    }
+    if let Some(target) = &build.target {
+        cmd.arg("--target").arg(target);
+    }
+    if no_cache {
+        cmd.arg("--no-cache");
+    }
+    for extra in &build.extra_args {
+        cmd.arg(extra);
+    }
+    cmd.arg(&context_path);
+
+    eprintln!(
+        "yoink build {}: docker build → {image_ref} (context: {})",
+        service.name,
+        context_path.display()
+    );
+
+    let status = cmd.status().await.map_err(|source| BuildError::Spawn {
+        program: "docker".into(),
+        source,
+    })?;
+    if !status.success() {
+        return Err(BuildError::DockerBuildFailed {
+            service: service.name.clone(),
+            status: status.to_string(),
+        });
+    }
+    Ok(())
+}
+
+/// Spawn `docker save <image_ref>` against the operator's local
+/// docker daemon and slurp the resulting tarball into memory. The
+/// caller hands this byte buffer to `DockerOps::load_image` per host
+/// — bollard's `import_image` body has to be a single Bytes today, so
+/// streaming is a future optimization (see `bollard::body_stream`).
+pub async fn save_image_locally(image_ref: &str) -> Result<bytes::Bytes, BuildError> {
+    let mut child = Command::new("docker")
+        .arg("save")
+        .arg(image_ref)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .map_err(|source| BuildError::Spawn {
+            program: "docker".into(),
+            source,
+        })?;
+    let mut stdout = child
+        .stdout
+        .take()
+        .expect("piped stdout should always be available");
+    let mut buf: Vec<u8> = Vec::new();
+    stdout
+        .read_to_end(&mut buf)
+        .await
+        .map_err(BuildError::ReadSave)?;
+    let status = child.wait().await.map_err(|source| BuildError::Spawn {
+        program: "docker".into(),
+        source,
+    })?;
+    if !status.success() {
+        return Err(BuildError::DockerSaveFailed {
+            image: image_ref.to_string(),
+            status: status.to_string(),
+        });
+    }
+    Ok(bytes::Bytes::from(buf))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn build_error_for_service_without_build_block_is_clear() {
+        // Smoke: error message includes the service name so an
+        // operator can grep their config directly.
+        let e = BuildError::NoBuildBlock("api".into());
+        assert!(format!("{e}").contains("\"api\""));
+    }
+}

--- a/yoink/src/build.rs
+++ b/yoink/src/build.rs
@@ -30,6 +30,11 @@ pub enum BuildError {
     UnknownService(String),
     #[error("`docker build` for {service:?} exited with status {status}")]
     DockerBuildFailed { service: String, status: String },
+    #[error(
+        "`docker push` for {service:?} exited with status {status} \
+         (is the operator logged into the registry? `docker login <registry>`)"
+    )]
+    DockerPushFailed { service: String, status: String },
     #[error("`docker save` for {image:?} exited with status {status}")]
     DockerSaveFailed { image: String, status: String },
     #[error("failed to spawn `{program}`: {source}")]
@@ -78,12 +83,16 @@ pub fn resolve_service_tag(
 }
 
 /// Build one service, tagging the result on the operator's local
-/// daemon as `<image>:<tag>`. Stderr surfaces verbatim on failure.
+/// daemon as `<image>:<tag>`. When `push` is `true`, follow the
+/// build with `docker push <image>:<tag>` so the image lands in a
+/// real registry — that's the kamal-style "build locally, deploy
+/// from registry" loop. Stderr surfaces verbatim on failure.
 pub async fn build_service(
     config: &Config,
     service: &ServiceConfig,
     tag: &str,
     no_cache: bool,
+    push: bool,
 ) -> Result<(), BuildError> {
     let build = service
         .build
@@ -128,6 +137,25 @@ pub async fn build_service(
             service: service.name.clone(),
             status: status.to_string(),
         });
+    }
+
+    if push {
+        eprintln!("yoink build {}: docker push {image_ref}", service.name);
+        let push_status = Command::new("docker")
+            .arg("push")
+            .arg(&image_ref)
+            .status()
+            .await
+            .map_err(|source| BuildError::Spawn {
+                program: "docker".into(),
+                source,
+            })?;
+        if !push_status.success() {
+            return Err(BuildError::DockerPushFailed {
+                service: service.name.clone(),
+                status: push_status.to_string(),
+            });
+        }
     }
     Ok(())
 }

--- a/yoink/src/config.rs
+++ b/yoink/src/config.rs
@@ -148,11 +148,47 @@ pub struct SecretsConfig {
     pub domain: Option<String>,
 }
 
+/// Local build instructions for a service. Powers `yoink build`
+/// (and the `yoink up --no-registry` "deploy without a registry" path).
+/// Resolves all paths relative to the loaded config file's directory
+/// — same convention as `service.run.files` and `include:` globs.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct BuildConfig {
+    /// Build context directory passed to `docker build`. Default `.`.
+    #[serde(default = "default_build_context")]
+    pub context: String,
+    /// Path to the Dockerfile relative to `context`. Default
+    /// `Dockerfile` (docker's own default).
+    #[serde(default)]
+    pub dockerfile: Option<String>,
+    /// `--build-arg KEY=VALUE` pairs.
+    #[serde(default)]
+    pub args: BTreeMap<String, String>,
+    /// `--target` for multi-stage builds.
+    #[serde(default)]
+    pub target: Option<String>,
+    /// Extra `--build-arg`-style flags to forward verbatim. Use when
+    /// you need a docker-cli flag yoink doesn't model directly.
+    #[serde(default)]
+    pub extra_args: Vec<String>,
+}
+
+fn default_build_context() -> String {
+    ".".to_string()
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct ServiceConfig {
     pub name: String,
     pub image: String,
+    /// Local-build instructions. When set, `yoink build [<service>]`
+    /// runs `docker build` against this context, tagging the result
+    /// as `<image>:<tag>`. Pairs with `yoink up --no-registry` for the
+    /// "edit Dockerfile, deploy directly to host" loop.
+    #[serde(default)]
+    pub build: Option<BuildConfig>,
     /// Image tag, OR a content digest `sha256:<hex>` for digest-pinned
     /// deploys. Optional: when omitted from the config the operator
     /// MUST pass `--tag <name>=<value>` (or per-service `--service x

--- a/yoink/src/config.rs
+++ b/yoink/src/config.rs
@@ -168,8 +168,9 @@ pub struct BuildConfig {
     /// `--target` for multi-stage builds.
     #[serde(default)]
     pub target: Option<String>,
-    /// Extra `--build-arg`-style flags to forward verbatim. Use when
-    /// you need a docker-cli flag yoink doesn't model directly.
+    /// Extra `docker build` flags to forward verbatim, inserted
+    /// before the context arg. Escape hatch for flags yoink doesn't
+    /// model directly (e.g. `--platform`, `--secret`, `--ssh`).
     #[serde(default)]
     pub extra_args: Vec<String>,
 }
@@ -538,6 +539,21 @@ fn local_socket_exists() -> bool {
 }
 
 impl Config {
+    /// Walk `self.services` filtered by an optional name list. `None`
+    /// returns every service in topo order; `Some(&[…])` keeps only
+    /// the named ones (in topo order, not in the order the operator
+    /// listed them — `yoink up --service web --service api` still
+    /// runs api first when api → … → web in the dep graph).
+    /// Used wherever the CLI takes `--service`.
+    pub fn selected_services<'a>(
+        &'a self,
+        filter: Option<&'a [String]>,
+    ) -> impl Iterator<Item = &'a ServiceConfig> {
+        self.services.iter().filter(move |svc| {
+            filter.is_none_or(|names| names.iter().any(|n| n == &svc.name))
+        })
+    }
+
     pub fn load_from_path(path: &Path) -> Result<Self, ConfigError> {
         let text = std::fs::read_to_string(path).map_err(|source| ConfigError::Read {
             path: path.display().to_string(),

--- a/yoink/src/docker_ops.rs
+++ b/yoink/src/docker_ops.rs
@@ -412,6 +412,18 @@ pub trait DockerOps: Send + Sync {
         credentials: Option<bollard::auth::DockerCredentials>,
     ) -> Result<(), DockerError>;
 
+    /// Stream a `docker save`-style tarball into the host's docker
+    /// daemon (`POST /images/load`). The body is the same format as
+    /// the operator's local `docker save IMAGE` would produce.
+    /// Powers the `--no-registry` deploy path: build locally, save
+    /// to a tarball, ship it over ssh, load on the host. No registry
+    /// involved.
+    async fn load_image(
+        &self,
+        host: &Host,
+        tar: bytes::Bytes,
+    ) -> Result<(), DockerError>;
+
     /// `true` if `image:tag` is already present in the host's local
     /// image cache (no pull needed). Used to skip redundant pulls
     /// after a prefetch pass. Errors degrade to `false` so a flaky
@@ -903,6 +915,29 @@ impl DockerOps for RealDockerOps {
             }) => Ok(false),
             Err(source) => Err(Self::err(host, source)),
         }
+    }
+
+    async fn load_image(
+        &self,
+        host: &Host,
+        tar: bytes::Bytes,
+    ) -> Result<(), DockerError> {
+        use bollard::query_parameters::ImportImageOptions;
+        let docker = self.client_for(host).await?;
+        let mut stream = docker.import_image(
+            ImportImageOptions {
+                quiet: false,
+                platform: None,
+            },
+            bollard::body_full(tar),
+            None,
+        );
+        // Drain the progress stream — surface errors but ignore the
+        // "Loaded image: ..." status messages.
+        while let Some(item) = stream.next().await {
+            item.map_err(|s| Self::err(host, s))?;
+        }
+        Ok(())
     }
 
     async fn list_containers_by_label(
@@ -1840,6 +1875,7 @@ struct FakeState {
     container_stats: VecDeque<Result<ContainerStats, DockerError>>,
     ensure_network: VecDeque<Result<bool, DockerError>>,
     pull_image: VecDeque<Result<(), DockerError>>,
+    load_image: VecDeque<Result<(), DockerError>>,
     list_containers: VecDeque<Result<Vec<ContainerInfo>, DockerError>>,
     create_container: VecDeque<Result<String, DockerError>>,
     start_container: VecDeque<Result<(), DockerError>>,
@@ -1862,6 +1898,7 @@ pub enum RecordedCall {
     ContainerStats(Host, String),
     EnsureNetwork(Host, String),
     PullImage(Host, String, String),
+    LoadImage(Host),
     ListContainersByLabel(Host, String),
     ListRunningContainers(Host),
     CreateContainer(Host, String),
@@ -2027,6 +2064,15 @@ impl DockerOps for FakeDockerOps {
         // Tests want pulls to actually fire by default; presence-check
         // returning false keeps existing test expectations intact.
         Ok(false)
+    }
+    async fn load_image(
+        &self,
+        host: &Host,
+        _tar: bytes::Bytes,
+    ) -> Result<(), DockerError> {
+        let mut s = self.lock();
+        s.calls.push(RecordedCall::LoadImage(host.clone()));
+        pop(&mut s.load_image, "load_image")
     }
     async fn list_containers_by_label(
         &self,

--- a/yoink/src/docker_ops.rs
+++ b/yoink/src/docker_ops.rs
@@ -418,10 +418,19 @@ pub trait DockerOps: Send + Sync {
     /// Powers the `--no-registry` deploy path: build locally, save
     /// to a tarball, ship it over ssh, load on the host. No registry
     /// involved.
+    ///
+    /// Body comes in as a stream of byte chunks (typically wrapping
+    /// `docker save`'s stdout via `tokio_util::io::ReaderStream`) so
+    /// memory stays bounded by chunk size, not image size.
     async fn load_image(
         &self,
         host: &Host,
-        tar: bytes::Bytes,
+        body: std::pin::Pin<
+            Box<
+                dyn futures_util::Stream<Item = Result<bytes::Bytes, std::io::Error>>
+                    + Send,
+            >,
+        >,
     ) -> Result<(), DockerError>;
 
     /// `true` if `image:tag` is already present in the host's local
@@ -920,7 +929,12 @@ impl DockerOps for RealDockerOps {
     async fn load_image(
         &self,
         host: &Host,
-        tar: bytes::Bytes,
+        body: std::pin::Pin<
+            Box<
+                dyn futures_util::Stream<Item = Result<bytes::Bytes, std::io::Error>>
+                    + Send,
+            >,
+        >,
     ) -> Result<(), DockerError> {
         use bollard::query_parameters::ImportImageOptions;
         let docker = self.client_for(host).await?;
@@ -929,7 +943,7 @@ impl DockerOps for RealDockerOps {
                 quiet: false,
                 platform: None,
             },
-            bollard::body_full(tar),
+            bollard::body_try_stream(body),
             None,
         );
         // Drain the progress stream — surface errors but ignore the
@@ -2068,7 +2082,12 @@ impl DockerOps for FakeDockerOps {
     async fn load_image(
         &self,
         host: &Host,
-        _tar: bytes::Bytes,
+        _body: std::pin::Pin<
+            Box<
+                dyn futures_util::Stream<Item = Result<bytes::Bytes, std::io::Error>>
+                    + Send,
+            >,
+        >,
     ) -> Result<(), DockerError> {
         let mut s = self.lock();
         s.calls.push(RecordedCall::LoadImage(host.clone()));

--- a/yoink/src/docker_ops.rs
+++ b/yoink/src/docker_ops.rs
@@ -360,6 +360,14 @@ pub enum LogStream {
     Stderr,
 }
 
+/// Body shape for `DockerOps::load_image` — a chunked stream of
+/// `Bytes` (typically wrapping `docker save`'s stdout via
+/// `tokio_util::io::ReaderStream`). Pinned + boxed so the trait
+/// stays object-safe.
+pub type ImageTarStream = std::pin::Pin<
+    Box<dyn futures_util::Stream<Item = Result<bytes::Bytes, std::io::Error>> + Send>,
+>;
+
 /// The async surface every consumer of Docker uses. Methods take a `&Host`
 /// so the same trait object can drive multiple remote daemons.
 #[async_trait]
@@ -413,24 +421,12 @@ pub trait DockerOps: Send + Sync {
     ) -> Result<(), DockerError>;
 
     /// Stream a `docker save`-style tarball into the host's docker
-    /// daemon (`POST /images/load`). The body is the same format as
-    /// the operator's local `docker save IMAGE` would produce.
-    /// Powers the `--no-registry` deploy path: build locally, save
-    /// to a tarball, ship it over ssh, load on the host. No registry
-    /// involved.
-    ///
-    /// Body comes in as a stream of byte chunks (typically wrapping
-    /// `docker save`'s stdout via `tokio_util::io::ReaderStream`) so
-    /// memory stays bounded by chunk size, not image size.
+    /// daemon (`POST /images/load`). Body is a `Stream<Bytes>` so
+    /// memory stays bounded by the chunk size, not the image size.
     async fn load_image(
         &self,
         host: &Host,
-        body: std::pin::Pin<
-            Box<
-                dyn futures_util::Stream<Item = Result<bytes::Bytes, std::io::Error>>
-                    + Send,
-            >,
-        >,
+        body: ImageTarStream,
     ) -> Result<(), DockerError>;
 
     /// `true` if `image:tag` is already present in the host's local
@@ -929,12 +925,7 @@ impl DockerOps for RealDockerOps {
     async fn load_image(
         &self,
         host: &Host,
-        body: std::pin::Pin<
-            Box<
-                dyn futures_util::Stream<Item = Result<bytes::Bytes, std::io::Error>>
-                    + Send,
-            >,
-        >,
+        body: ImageTarStream,
     ) -> Result<(), DockerError> {
         use bollard::query_parameters::ImportImageOptions;
         let docker = self.client_for(host).await?;
@@ -2082,12 +2073,7 @@ impl DockerOps for FakeDockerOps {
     async fn load_image(
         &self,
         host: &Host,
-        _body: std::pin::Pin<
-            Box<
-                dyn futures_util::Stream<Item = Result<bytes::Bytes, std::io::Error>>
-                    + Send,
-            >,
-        >,
+        _body: ImageTarStream,
     ) -> Result<(), DockerError> {
         let mut s = self.lock();
         s.calls.push(RecordedCall::LoadImage(host.clone()));

--- a/yoink/src/lib.rs
+++ b/yoink/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod build;
 pub mod config;
 pub mod deploy;
 pub mod diff;

--- a/yoink/src/main.rs
+++ b/yoink/src/main.rs
@@ -67,14 +67,22 @@ enum Command {
         #[arg(long, value_enum, default_value_t = DryRunFormat::Text)]
         format: DryRunFormat,
         /// Skip the registry-pull step. For each (host, image) pair,
-        /// `docker save` the image from the operator's local docker
-        /// daemon and stream the tarball into the host's docker via
-        /// `docker load`. Pair with `yoink build` for the
-        /// "edit Dockerfile, deploy" loop without standing up CI or
-        /// a registry. The image must already exist locally
-        /// (run `yoink build` first or build it yourself).
+        /// stream `docker save <image>` from the operator's local
+        /// docker daemon directly into the host's docker via
+        /// `docker load`. Pair with `--build` for the one-shot
+        /// "edit Dockerfile, deploy" loop without CI or a registry.
         #[arg(long)]
         no_registry: bool,
+        /// Run `docker build` for any selected service with a
+        /// `build:` block before deploying. Eliminates the separate
+        /// `yoink build && yoink up` two-step for the standalone
+        /// workflow — `yoink up --build --no-registry --service my-tool`
+        /// is the indie one-shot. With a registry-prefixed image, you
+        /// still need to push (`yoink build --push`) — `--build` here
+        /// builds without pushing, so this combination is most useful
+        /// alongside `--no-registry`.
+        #[arg(long)]
+        build: bool,
     },
     /// Build one or more services' images via `docker build` against
     /// the operator's local docker daemon. Tags the result as
@@ -403,6 +411,7 @@ async fn run(cli: Cli) -> Result<()> {
             dry_run,
             format,
             no_registry,
+            build,
         } => {
             cmd_up(
                 &config,
@@ -412,6 +421,7 @@ async fn run(cli: Cli) -> Result<()> {
                 dry_run,
                 format,
                 no_registry,
+                build,
             )
             .await
         }
@@ -492,6 +502,11 @@ async fn cmd_preflight(config: &Config) -> Result<()> {
     Ok(())
 }
 
+// TODO: bundle the flags into an `UpOptions` struct before the next
+// deploy-flag addition. Already noted in the post-v0.7.0 /simplify
+// pass; allowing here so the flag landing for the indie loop isn't
+// blocked by a refactor.
+#[allow(clippy::fn_params_excessive_bools, clippy::too_many_arguments)]
 async fn cmd_up(
     config: &Config,
     services: &[String],
@@ -500,6 +515,7 @@ async fn cmd_up(
     dry_run: bool,
     format: DryRunFormat,
     no_registry: bool,
+    build: bool,
 ) -> Result<()> {
     use yoink::docker_ops::Host;
     use yoink::lock::HostLock;
@@ -522,6 +538,24 @@ async fn cmd_up(
             format,
         )
         .await;
+    }
+
+    // Optional `--build` pre-flight: rebuild any selected service that
+    // declares a `build:` block before deploying. Lets the indie
+    // "drop yoink.yaml in repo and `yoink up --build --no-registry`"
+    // loop work as a one-shot without remembering to run `yoink build`
+    // separately. Push is intentionally not auto-engaged — kamal-style
+    // flows still go through the explicit `yoink build --push` step.
+    if build {
+        for svc in config.selected_services(services_filter) {
+            if svc.build.is_none() {
+                continue;
+            }
+            let tag = yoink::build::resolve_service_tag(svc, &tag_overrides)?;
+            yoink::build::build_service(config, svc, &tag, false, false)
+                .await
+                .with_context(|| format!("build {}", svc.name))?;
+        }
     }
 
     // No-registry pre-flight: save+load every selected image to every
@@ -799,6 +833,7 @@ async fn cmd_rollback(config: &Config, service: String, tag: Option<String>) -> 
         true,
         false,
         DryRunFormat::Text,
+        false,
         false,
     )
     .await

--- a/yoink/src/main.rs
+++ b/yoink/src/main.rs
@@ -95,6 +95,14 @@ enum Command {
         /// Forward `--no-cache` to `docker build`.
         #[arg(long)]
         no_cache: bool,
+        /// Run `docker push <image>:<tag>` after a successful build.
+        /// Use this when `image:` points at a real remote registry
+        /// (`ghcr.io/you/api`, `4db05qgnlk.registry.depot.dev/api`,
+        /// etc.) and you want the kamal-style "build locally, deploy
+        /// from registry" loop in a single command. Operator must
+        /// already be `docker login`'d to the target registry.
+        #[arg(long)]
+        push: bool,
     },
     /// Show what's running where (across all services).
     Status {
@@ -412,7 +420,8 @@ async fn run(cli: Cli) -> Result<()> {
             tag,
             allow_dirty,
             no_cache,
-        } => cmd_build(&config, &services, &tag, allow_dirty, no_cache).await,
+            push,
+        } => cmd_build(&config, &services, &tag, allow_dirty, no_cache, push).await,
         Command::Status { json } => cmd_status(&config, json).await,
         Command::Rollback { service, tag } => cmd_rollback(&config, service, tag).await,
         Command::Prune { dry_run } => cmd_prune(&config, dry_run).await,
@@ -674,6 +683,7 @@ async fn cmd_build(
     tag_args: &[String],
     allow_dirty: bool,
     no_cache: bool,
+    push: bool,
 ) -> Result<()> {
     let tag_overrides = parse_tag_overrides(tag_args, services, allow_dirty)?;
     let services_filter = services_filter(services);
@@ -695,7 +705,7 @@ async fn cmd_build(
             continue;
         }
         let tag = yoink::build::resolve_service_tag(svc, &tag_overrides)?;
-        yoink::build::build_service(config, svc, &tag, no_cache)
+        yoink::build::build_service(config, svc, &tag, no_cache, push)
             .await
             .with_context(|| format!("build {}", svc.name))?;
         built_any = true;

--- a/yoink/src/main.rs
+++ b/yoink/src/main.rs
@@ -501,11 +501,7 @@ async fn cmd_up(
     let bundle = load_secrets_bundle(config).await?;
     let tag_overrides = parse_tag_overrides(tag_args, services, allow_dirty)?;
 
-    let services_filter = if services.is_empty() {
-        None
-    } else {
-        Some(services)
-    };
+    let services_filter = services_filter(services);
 
     if dry_run {
         return run_dry_run(
@@ -519,16 +515,12 @@ async fn cmd_up(
         .await;
     }
 
-    // No-registry pre-flight: for each (image, host) pair selected by
-    // the deploy, save the image from the operator's local docker
-    // daemon and stream the tarball into the host's docker via
-    // `docker load`. After this loop runs, the existing reconcile
-    // flow's `image_present` check short-circuits the
-    // would-be-pull. Failures here are deploy-blocking — the
-    // operator either forgot to `yoink build` or the local daemon
-    // isn't reachable.
+    // No-registry pre-flight: save+load every selected image to every
+    // applicable host so the reconcile loop's `image_present` check
+    // short-circuits any registry pull. Failures here block the
+    // deploy ("forgot to `yoink build`?" / local daemon down).
     if no_registry {
-        load_images_to_hosts(
+        yoink::build::load_images_to_hosts(
             ops.as_ref(),
             config,
             &tag_overrides,
@@ -612,6 +604,17 @@ async fn cmd_up(
     Ok(())
 }
 
+/// Convert the CLI's `--service` repeat into the `Option<&[String]>`
+/// shape every downstream caller wants: empty list → no filter →
+/// "every service"; non-empty → filter to those.
+fn services_filter(services: &[String]) -> Option<&[String]> {
+    if services.is_empty() {
+        None
+    } else {
+        Some(services)
+    }
+}
+
 /// Build the `service_name → tag` override map. Each `--tag` argument
 /// is either `name=tag` (override that named service's tag) or a bare
 /// `tag` (applies to every `--service`-selected service). A bare tag
@@ -673,25 +676,17 @@ async fn cmd_build(
     no_cache: bool,
 ) -> Result<()> {
     let tag_overrides = parse_tag_overrides(tag_args, services, allow_dirty)?;
-    let services_filter: Option<&[String]> = if services.is_empty() {
-        None
-    } else {
-        Some(services)
-    };
+    let services_filter = services_filter(services);
+    let explicit_services = services_filter.is_some();
 
     let mut built_any = false;
-    for svc in &config.services {
-        if let Some(filter) = services_filter
-            && !filter.iter().any(|s| s == &svc.name)
-        {
-            continue;
-        }
+    for svc in config.selected_services(services_filter) {
         if svc.build.is_none() {
-            // When the operator targets a specific service that doesn't
-            // have a build block, that's an error — they expected a
-            // build. When we're iterating over all services, just skip
-            // (image probably comes from a registry).
-            if services_filter.is_some() {
+            // Explicit `--service api` against a service without a
+            // `build:` block is operator error — they expected a
+            // build. Bare `yoink build` (no filter) just skips
+            // registry-only services silently.
+            if explicit_services {
                 anyhow::bail!(
                     "service {:?} has no `build:` block — add one or build the image yourself",
                     svc.name
@@ -699,17 +694,7 @@ async fn cmd_build(
             }
             continue;
         }
-        let tag = tag_overrides
-            .get(&svc.name)
-            .cloned()
-            .or_else(|| svc.tag.clone())
-            .with_context(|| {
-                format!(
-                    "service {:?} has no `tag:` and no `--tag {}=…` override; \
-                     yoink build needs a concrete tag to label the image as",
-                    svc.name, svc.name,
-                )
-            })?;
+        let tag = yoink::build::resolve_service_tag(svc, &tag_overrides)?;
         yoink::build::build_service(config, svc, &tag, no_cache)
             .await
             .with_context(|| format!("build {}", svc.name))?;
@@ -720,72 +705,6 @@ async fn cmd_build(
             "no services with a `build:` block matched. \
              Add `build:` to a service or pass --service to one that has it."
         );
-    }
-    Ok(())
-}
-
-/// Pre-flight for `yoink up --no-registry`: for every selected
-/// service × applicable host, `docker save` the local image and
-/// stream it into the host's docker daemon. After this returns,
-/// the host has the image in its local cache and the reconcile's
-/// `image_present` check short-circuits any registry pull.
-async fn load_images_to_hosts(
-    ops: &dyn DockerOps,
-    config: &Config,
-    tag_overrides: &std::collections::BTreeMap<String, String>,
-    services_filter: Option<&[String]>,
-) -> Result<()> {
-    use std::collections::BTreeSet;
-    use yoink::docker_ops::Host;
-
-    // Build the set of distinct (image, tag) → applicable hosts the
-    // operator wants pre-loaded. Walk service config + tag overrides
-    // exactly like reconcile does so we never miss one or load extras.
-    let mut by_image: std::collections::BTreeMap<String, BTreeSet<String>> =
-        std::collections::BTreeMap::new();
-    for svc in &config.services {
-        if let Some(filter) = services_filter
-            && !filter.iter().any(|s| s == &svc.name)
-        {
-            continue;
-        }
-        let tag = tag_overrides
-            .get(&svc.name)
-            .cloned()
-            .or_else(|| svc.tag.clone())
-            .with_context(|| {
-                format!(
-                    "service {:?} has no `tag:` set and no override; \
-                     --no-registry needs a concrete tag to look up the local image",
-                    svc.name
-                )
-            })?;
-        let image_ref = yoink::docker::image_reference(&svc.image, &tag);
-        let entry = by_image.entry(image_ref).or_default();
-        for host_cfg in svc.applicable_hosts(&config.hosts) {
-            entry.insert(host_cfg.address.clone());
-        }
-    }
-
-    for (image_ref, hosts) in &by_image {
-        eprintln!("yoink up --no-registry: docker save {image_ref} → {} host(s)", hosts.len());
-        let tar = yoink::build::save_image_locally(image_ref)
-            .await
-            .with_context(|| format!("docker save {image_ref}"))?;
-        for addr in hosts {
-            let host = Host {
-                address: addr.clone(),
-                user: config
-                    .hosts
-                    .iter()
-                    .find(|h| &h.address == addr)
-                    .map(|h| h.user.clone())
-                    .unwrap_or_default(),
-            };
-            ops.load_image(&host, tar.clone())
-                .await
-                .with_context(|| format!("docker load on {}", host.address))?;
-        }
     }
     Ok(())
 }

--- a/yoink/src/main.rs
+++ b/yoink/src/main.rs
@@ -66,6 +66,35 @@ enum Command {
         /// updated). Ignored when `--dry-run` isn't set.
         #[arg(long, value_enum, default_value_t = DryRunFormat::Text)]
         format: DryRunFormat,
+        /// Skip the registry-pull step. For each (host, image) pair,
+        /// `docker save` the image from the operator's local docker
+        /// daemon and stream the tarball into the host's docker via
+        /// `docker load`. Pair with `yoink build` for the
+        /// "edit Dockerfile, deploy" loop without standing up CI or
+        /// a registry. The image must already exist locally
+        /// (run `yoink build` first or build it yourself).
+        #[arg(long)]
+        no_registry: bool,
+    },
+    /// Build one or more services' images via `docker build` against
+    /// the operator's local docker daemon. Tags the result as
+    /// `<image>:<tag>`. Pair with `yoink up --no-registry` to deploy
+    /// the freshly-built image without any registry. Requires the
+    /// service to declare a `build:` block.
+    Build {
+        /// Restrict to one or more services (those with a `build:`
+        /// block). Empty = build every service that has one.
+        #[arg(long = "service", short = 's', value_name = "NAME")]
+        services: Vec<String>,
+        /// Override the resolved tag (same shape as `up --tag`).
+        #[arg(long = "tag", value_name = "[NAME=]TAG")]
+        tag: Vec<String>,
+        /// Allow operating with a dirty git working tree.
+        #[arg(long)]
+        allow_dirty: bool,
+        /// Forward `--no-cache` to `docker build`.
+        #[arg(long)]
+        no_cache: bool,
     },
     /// Show what's running where (across all services).
     Status {
@@ -365,7 +394,25 @@ async fn run(cli: Cli) -> Result<()> {
             allow_dirty,
             dry_run,
             format,
-        } => cmd_up(&config, &services, &tag, allow_dirty, dry_run, format).await,
+            no_registry,
+        } => {
+            cmd_up(
+                &config,
+                &services,
+                &tag,
+                allow_dirty,
+                dry_run,
+                format,
+                no_registry,
+            )
+            .await
+        }
+        Command::Build {
+            services,
+            tag,
+            allow_dirty,
+            no_cache,
+        } => cmd_build(&config, &services, &tag, allow_dirty, no_cache).await,
         Command::Status { json } => cmd_status(&config, json).await,
         Command::Rollback { service, tag } => cmd_rollback(&config, service, tag).await,
         Command::Prune { dry_run } => cmd_prune(&config, dry_run).await,
@@ -443,6 +490,7 @@ async fn cmd_up(
     allow_dirty: bool,
     dry_run: bool,
     format: DryRunFormat,
+    no_registry: bool,
 ) -> Result<()> {
     use yoink::docker_ops::Host;
     use yoink::lock::HostLock;
@@ -469,6 +517,24 @@ async fn cmd_up(
             format,
         )
         .await;
+    }
+
+    // No-registry pre-flight: for each (image, host) pair selected by
+    // the deploy, save the image from the operator's local docker
+    // daemon and stream the tarball into the host's docker via
+    // `docker load`. After this loop runs, the existing reconcile
+    // flow's `image_present` check short-circuits the
+    // would-be-pull. Failures here are deploy-blocking — the
+    // operator either forgot to `yoink build` or the local daemon
+    // isn't reachable.
+    if no_registry {
+        load_images_to_hosts(
+            ops.as_ref(),
+            config,
+            &tag_overrides,
+            services_filter,
+        )
+        .await?;
     }
 
     // Per-host advisory locks. Sentinel container holds the lock; a
@@ -596,6 +662,134 @@ fn parse_tag_overrides(
     Ok(out)
 }
 
+/// `yoink build` — run `docker build` for every selected service that
+/// declares a `build:` block. Tags the result on the operator's
+/// local daemon as `<image>:<tag>`, ready for `yoink up --no-registry`.
+async fn cmd_build(
+    config: &Config,
+    services: &[String],
+    tag_args: &[String],
+    allow_dirty: bool,
+    no_cache: bool,
+) -> Result<()> {
+    let tag_overrides = parse_tag_overrides(tag_args, services, allow_dirty)?;
+    let services_filter: Option<&[String]> = if services.is_empty() {
+        None
+    } else {
+        Some(services)
+    };
+
+    let mut built_any = false;
+    for svc in &config.services {
+        if let Some(filter) = services_filter
+            && !filter.iter().any(|s| s == &svc.name)
+        {
+            continue;
+        }
+        if svc.build.is_none() {
+            // When the operator targets a specific service that doesn't
+            // have a build block, that's an error — they expected a
+            // build. When we're iterating over all services, just skip
+            // (image probably comes from a registry).
+            if services_filter.is_some() {
+                anyhow::bail!(
+                    "service {:?} has no `build:` block — add one or build the image yourself",
+                    svc.name
+                );
+            }
+            continue;
+        }
+        let tag = tag_overrides
+            .get(&svc.name)
+            .cloned()
+            .or_else(|| svc.tag.clone())
+            .with_context(|| {
+                format!(
+                    "service {:?} has no `tag:` and no `--tag {}=…` override; \
+                     yoink build needs a concrete tag to label the image as",
+                    svc.name, svc.name,
+                )
+            })?;
+        yoink::build::build_service(config, svc, &tag, no_cache)
+            .await
+            .with_context(|| format!("build {}", svc.name))?;
+        built_any = true;
+    }
+    if !built_any {
+        anyhow::bail!(
+            "no services with a `build:` block matched. \
+             Add `build:` to a service or pass --service to one that has it."
+        );
+    }
+    Ok(())
+}
+
+/// Pre-flight for `yoink up --no-registry`: for every selected
+/// service × applicable host, `docker save` the local image and
+/// stream it into the host's docker daemon. After this returns,
+/// the host has the image in its local cache and the reconcile's
+/// `image_present` check short-circuits any registry pull.
+async fn load_images_to_hosts(
+    ops: &dyn DockerOps,
+    config: &Config,
+    tag_overrides: &std::collections::BTreeMap<String, String>,
+    services_filter: Option<&[String]>,
+) -> Result<()> {
+    use std::collections::BTreeSet;
+    use yoink::docker_ops::Host;
+
+    // Build the set of distinct (image, tag) → applicable hosts the
+    // operator wants pre-loaded. Walk service config + tag overrides
+    // exactly like reconcile does so we never miss one or load extras.
+    let mut by_image: std::collections::BTreeMap<String, BTreeSet<String>> =
+        std::collections::BTreeMap::new();
+    for svc in &config.services {
+        if let Some(filter) = services_filter
+            && !filter.iter().any(|s| s == &svc.name)
+        {
+            continue;
+        }
+        let tag = tag_overrides
+            .get(&svc.name)
+            .cloned()
+            .or_else(|| svc.tag.clone())
+            .with_context(|| {
+                format!(
+                    "service {:?} has no `tag:` set and no override; \
+                     --no-registry needs a concrete tag to look up the local image",
+                    svc.name
+                )
+            })?;
+        let image_ref = yoink::docker::image_reference(&svc.image, &tag);
+        let entry = by_image.entry(image_ref).or_default();
+        for host_cfg in svc.applicable_hosts(&config.hosts) {
+            entry.insert(host_cfg.address.clone());
+        }
+    }
+
+    for (image_ref, hosts) in &by_image {
+        eprintln!("yoink up --no-registry: docker save {image_ref} → {} host(s)", hosts.len());
+        let tar = yoink::build::save_image_locally(image_ref)
+            .await
+            .with_context(|| format!("docker save {image_ref}"))?;
+        for addr in hosts {
+            let host = Host {
+                address: addr.clone(),
+                user: config
+                    .hosts
+                    .iter()
+                    .find(|h| &h.address == addr)
+                    .map(|h| h.user.clone())
+                    .unwrap_or_default(),
+            };
+            ops.load_image(&host, tar.clone())
+                .await
+                .with_context(|| format!("docker load on {}", host.address))?;
+        }
+    }
+    Ok(())
+}
+
 async fn cmd_status(config: &Config, json: bool) -> Result<()> {
     let ops = RealDockerOps::new();
     let report = StatusReport::collect(&ops, config)
@@ -676,6 +870,7 @@ async fn cmd_rollback(config: &Config, service: String, tag: Option<String>) -> 
         true,
         false,
         DryRunFormat::Text,
+        false,
     )
     .await
 }

--- a/yoink/src/main.rs
+++ b/yoink/src/main.rs
@@ -415,13 +415,15 @@ async fn run(cli: Cli) -> Result<()> {
         } => {
             cmd_up(
                 &config,
-                &services,
-                &tag,
-                allow_dirty,
-                dry_run,
-                format,
-                no_registry,
-                build,
+                UpOptions {
+                    services: &services,
+                    tag_args: &tag,
+                    allow_dirty,
+                    dry_run,
+                    format,
+                    no_registry,
+                    build,
+                },
             )
             .await
         }
@@ -431,7 +433,19 @@ async fn run(cli: Cli) -> Result<()> {
             allow_dirty,
             no_cache,
             push,
-        } => cmd_build(&config, &services, &tag, allow_dirty, no_cache, push).await,
+        } => {
+            cmd_build(
+                &config,
+                BuildOptions {
+                    services: &services,
+                    tag_args: &tag,
+                    allow_dirty,
+                    no_cache,
+                    push,
+                },
+            )
+            .await
+        }
         Command::Status { json } => cmd_status(&config, json).await,
         Command::Rollback { service, tag } => cmd_rollback(&config, service, tag).await,
         Command::Prune { dry_run } => cmd_prune(&config, dry_run).await,
@@ -502,23 +516,33 @@ async fn cmd_preflight(config: &Config) -> Result<()> {
     Ok(())
 }
 
-// TODO: bundle the flags into an `UpOptions` struct before the next
-// deploy-flag addition. Already noted in the post-v0.7.0 /simplify
-// pass; allowing here so the flag landing for the indie loop isn't
-// blocked by a refactor.
-#[allow(clippy::fn_params_excessive_bools, clippy::too_many_arguments)]
-async fn cmd_up(
-    config: &Config,
-    services: &[String],
-    tag_args: &[String],
+// `UpOptions` mirrors the `up` subcommand's flags 1:1. The bool count
+// is the actual CLI surface; rolling them into an enum would just hide
+// the same surface area at higher cognitive cost.
+#[allow(clippy::struct_excessive_bools)]
+struct UpOptions<'a> {
+    services: &'a [String],
+    tag_args: &'a [String],
     allow_dirty: bool,
     dry_run: bool,
     format: DryRunFormat,
     no_registry: bool,
     build: bool,
-) -> Result<()> {
+}
+
+#[allow(clippy::too_many_lines)] // borderline (6 lines over); split if it grows further
+async fn cmd_up(config: &Config, up: UpOptions<'_>) -> Result<()> {
     use yoink::docker_ops::Host;
     use yoink::lock::HostLock;
+    let UpOptions {
+        services,
+        tag_args,
+        allow_dirty,
+        dry_run,
+        format,
+        no_registry,
+        build,
+    } = up;
 
     // Wrap in Arc so the heartbeat tasks (one per host lock) can hold
     // their own clone for the duration of the deploy.
@@ -708,17 +732,25 @@ fn parse_tag_overrides(
     Ok(out)
 }
 
-/// `yoink build` — run `docker build` for every selected service that
-/// declares a `build:` block. Tags the result on the operator's
-/// local daemon as `<image>:<tag>`, ready for `yoink up --no-registry`.
-async fn cmd_build(
-    config: &Config,
-    services: &[String],
-    tag_args: &[String],
+struct BuildOptions<'a> {
+    services: &'a [String],
+    tag_args: &'a [String],
     allow_dirty: bool,
     no_cache: bool,
     push: bool,
-) -> Result<()> {
+}
+
+/// `yoink build` — run `docker build` for every selected service that
+/// declares a `build:` block. Tags the result on the operator's
+/// local daemon as `<image>:<tag>`, ready for `yoink up --no-registry`.
+async fn cmd_build(config: &Config, build: BuildOptions<'_>) -> Result<()> {
+    let BuildOptions {
+        services,
+        tag_args,
+        allow_dirty,
+        no_cache,
+        push,
+    } = build;
     let tag_overrides = parse_tag_overrides(tag_args, services, allow_dirty)?;
     let services_filter = services_filter(services);
     let explicit_services = services_filter.is_some();
@@ -828,13 +860,15 @@ async fn cmd_rollback(config: &Config, service: String, tag: Option<String>) -> 
     let tag_args = std::slice::from_ref(&tag_arg);
     cmd_up(
         config,
-        services_arg,
-        tag_args,
-        true,
-        false,
-        DryRunFormat::Text,
-        false,
-        false,
+        UpOptions {
+            services: services_arg,
+            tag_args,
+            allow_dirty: true,
+            dry_run: false,
+            format: DryRunFormat::Text,
+            no_registry: false,
+            build: false,
+        },
     )
     .await
 }


### PR DESCRIPTION
v0.7.0 (tag pushed). Closes the indie/hobby/rapid-iteration loop: edit Dockerfile → `yoink build` → `yoink up --no-registry` → running on host. No CI, no registry. See commit message for full breakdown + README "Standalone mode" section for the operator-facing docs.