### PR TITLE
fix(tui): resilience sweep for unreachable hosts

### DIFF
--- a/docs/content/docs/troubleshooting.md
+++ b/docs/content/docs/troubleshooting.md
@@ -25,6 +25,31 @@ The lock auto-expires after ~30s of stale heartbeat. Wait, then retry. If it per
 ssh deploy@<host> 'docker rm -f yoink-lock'
 ```
 
+## `yoink up` / `yoink tui` hangs silently with no output
+
+Almost always an interactive ssh prompt yoink can't surface — bollard's SSH transport spawns its own `ssh` client and swallows stderr, so when ssh prompts for an extra check the connection just blocks.
+
+Run `yoink preflight` to get a classified error. The two common cases:
+
+**Tailscale SSH "additional check required":**
+```
+✗ backtrack-eu-1: ssh probe failed: Tailscale SSH requires an additional
+  check — open this URL in a browser, then re-run:
+    https://login.tailscale.com/a/<token>
+```
+
+Open the URL, approve the device, re-run the command. (Tailscale SSH gates new sessions through a browser tap when ACLs require it.)
+
+**Permission denied:**
+```
+✗ host-x: ssh probe failed: permission denied — check the ssh key
+  (`ssh-add -l`) and that the deploy user is configured on the host
+```
+
+Add the key with `ssh-add ~/.ssh/id_ed25519` (or whichever) and re-run.
+
+`yoink preflight` is the canonical "why can't I reach the host" diagnostic — it does an explicit `ssh -o BatchMode=yes user@host true` first and translates common stderr patterns. The classifier covers Tailscale auth, permission denied, connection timeout, host key changes, DNS / hostname resolution, and connection refused.
+
 ## `Authenticate to Infisical: dial tcp ... i/o timeout`
 
 The Infisical instance is on the tailnet. Join it.

--- a/yoink/src/docker_ops.rs
+++ b/yoink/src/docker_ops.rs
@@ -40,6 +40,12 @@ pub enum DockerError {
         #[source]
         source: bollard::errors::Error,
     },
+    /// Pre-bollard ssh probe failed — surfaces a classified hint
+    /// (e.g. Tailscale auth URL, permission denied with ssh-add
+    /// pointer) instead of letting bollard hang for 120s waiting on
+    /// an interactive prompt the operator can't see.
+    #[error("ssh probe failed for {host}: {detail}")]
+    SshProbe { host: String, detail: String },
     #[error("scripted fake exhausted: no response left for {0}")]
     FakeExhausted(&'static str),
     #[error("invalid response from docker: {0}")]
@@ -647,6 +653,19 @@ impl RealDockerOps {
                 source,
             })?
         } else {
+            // Probe ssh first. Without this, bollard's SSH transport
+            // happily blocks for `timeout_secs` (120 by default)
+            // waiting on interactive prompts (Tailscale auth check,
+            // password, host-key TOFU) that yoink can't see — the
+            // TUI just hangs on "(loading…)". Probing gives us a
+            // classified, actionable error string before bollard
+            // ever opens the long-lived connection.
+            crate::ssh_probe::probe(host)
+                .await
+                .map_err(|detail| DockerError::SshProbe {
+                    host: host.address.clone(),
+                    detail,
+                })?;
             Docker::connect_with_ssh(&key, self.timeout_secs, bollard::API_DEFAULT_VERSION, None)
                 .map_err(|source| DockerError::Connect {
                     host: host.address.clone(),

--- a/yoink/src/lib.rs
+++ b/yoink/src/lib.rs
@@ -12,5 +12,6 @@ pub mod network;
 pub mod output;
 pub mod prune;
 pub mod secrets;
+pub mod ssh_probe;
 pub mod status;
 pub mod tui;

--- a/yoink/src/main.rs
+++ b/yoink/src/main.rs
@@ -495,15 +495,6 @@ async fn cmd_preflight(config: &Config) -> Result<()> {
     let mut had_error = false;
     for host_cfg in &config.hosts {
         let host = Host::from(host_cfg);
-        if host.is_local() {
-            // The synthetic `local` host doesn't go through ssh —
-            // bollard talks to the laptop's docker socket directly.
-            // Skip the probe and go straight to version().
-        } else if let Err(probe) = yoink::ssh_probe::probe(&host).await {
-            had_error = true;
-            eprintln!("✗ {}: {}", host.address, probe);
-            continue;
-        }
         match ops.version(&host).await {
             Ok(v) => println!(
                 "✓ {}: docker {} (api {}) on {}/{}",

--- a/yoink/src/main.rs
+++ b/yoink/src/main.rs
@@ -495,6 +495,15 @@ async fn cmd_preflight(config: &Config) -> Result<()> {
     let mut had_error = false;
     for host_cfg in &config.hosts {
         let host = Host::from(host_cfg);
+        if host.is_local() {
+            // The synthetic `local` host doesn't go through ssh —
+            // bollard talks to the laptop's docker socket directly.
+            // Skip the probe and go straight to version().
+        } else if let Err(probe) = yoink::ssh_probe::probe(&host).await {
+            had_error = true;
+            eprintln!("✗ {}: {}", host.address, probe);
+            continue;
+        }
         match ops.version(&host).await {
             Ok(v) => println!(
                 "✓ {}: docker {} (api {}) on {}/{}",
@@ -515,6 +524,7 @@ async fn cmd_preflight(config: &Config) -> Result<()> {
     }
     Ok(())
 }
+
 
 // `UpOptions` mirrors the `up` subcommand's flags 1:1. The bool count
 // is the actual CLI surface; rolling them into an enum would just hide

--- a/yoink/src/ssh_probe.rs
+++ b/yoink/src/ssh_probe.rs
@@ -11,15 +11,30 @@
 //! Used by `yoink preflight` today; TUI Hosts pane is a candidate
 //! consumer for the same flow.
 
+use std::process::Stdio;
+use std::time::Duration;
+
+use tokio::io::AsyncReadExt;
+
 use crate::docker_ops::Host;
 
+/// Hard ceiling on probe duration. `ConnectTimeout` is the TCP
+/// handshake budget; this bounds the entire ssh process — including
+/// `BatchMode`-resistant prompts (Tailscale's "additional check
+/// required" gate prints to stderr but keeps the connection open
+/// regardless of `BatchMode=yes`).
+const PROBE_DEADLINE: Duration = Duration::from_secs(8);
+
 /// Probe the SSH connection. Returns `Ok(())` when `ssh user@host
-/// true` succeeds with `BatchMode=yes` (no interactive prompts);
-/// otherwise an operator-readable error string with both a
-/// classified hint and the raw stderr.
+/// true` succeeds; otherwise an operator-readable error string with
+/// a classified hint plus whatever stderr accumulated.
+///
+/// Bounded by `PROBE_DEADLINE` — on timeout we kill the child and
+/// return the partial stderr (which usually has the actionable
+/// signal already, e.g. Tailscale's auth URL).
 pub async fn probe(host: &Host) -> Result<(), String> {
     let target = format!("{}@{}", host.user, host.address);
-    let output = tokio::process::Command::new("ssh")
+    let mut child = tokio::process::Command::new("ssh")
         .args([
             "-o",
             "BatchMode=yes",
@@ -30,18 +45,44 @@ pub async fn probe(host: &Host) -> Result<(), String> {
             &target,
             "true",
         ])
-        .output()
-        .await
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped())
+        .spawn()
         .map_err(|e| format!("could not invoke ssh: {e}"))?;
-    if output.status.success() {
+
+    // Drain stderr into a buffer in parallel with waiting on the
+    // child. If the child times out we kill it; then awaiting the
+    // pipe finishes immediately because the descriptor closed.
+    let mut stderr_pipe = child
+        .stderr
+        .take()
+        .ok_or_else(|| "ssh child has no stderr pipe".to_string())?;
+    let stderr_task: tokio::task::JoinHandle<Vec<u8>> = tokio::spawn(async move {
+        let mut buf = Vec::new();
+        let _ = stderr_pipe.read_to_end(&mut buf).await;
+        buf
+    });
+
+    let wait = tokio::time::timeout(PROBE_DEADLINE, child.wait()).await;
+    let timed_out = wait.is_err();
+    if timed_out {
+        let _ = child.kill().await;
+    }
+    let success = matches!(wait, Ok(Ok(s)) if s.success());
+    let stderr_bytes = stderr_task.await.unwrap_or_default();
+    let stderr = String::from_utf8_lossy(&stderr_bytes);
+
+    if success {
         return Ok(());
     }
-    let stderr = String::from_utf8_lossy(&output.stderr);
+
     let translated = classify(&stderr);
-    Err(format!(
-        "ssh probe failed: {translated}\n\nraw ssh stderr:\n{}",
-        stderr.trim()
-    ))
+    let prefix = if timed_out {
+        format!("ssh probe timed out after {}s: {translated}", PROBE_DEADLINE.as_secs())
+    } else {
+        format!("ssh probe failed: {translated}")
+    };
+    Err(format!("{prefix}\n\nraw ssh stderr:\n{}", stderr.trim()))
 }
 
 /// Pattern-match ssh stderr against the failure modes operators hit

--- a/yoink/src/ssh_probe.rs
+++ b/yoink/src/ssh_probe.rs
@@ -1,0 +1,147 @@
+//! Pre-bollard ssh connectivity probe with operator-readable error
+//! classification.
+//!
+//! Bollard's SSH transport spawns its own `ssh` client and swallows
+//! stderr — so when ssh prompts for an interactive auth check (e.g.
+//! Tailscale's "additional check required"), the connection just
+//! hangs with no UI feedback. Running ssh ourselves first lets us
+//! catch and surface those patterns before falling through to
+//! bollard.
+//!
+//! Used by `yoink preflight` today; TUI Hosts pane is a candidate
+//! consumer for the same flow.
+
+use crate::docker_ops::Host;
+
+/// Probe the SSH connection. Returns `Ok(())` when `ssh user@host
+/// true` succeeds with `BatchMode=yes` (no interactive prompts);
+/// otherwise an operator-readable error string with both a
+/// classified hint and the raw stderr.
+pub async fn probe(host: &Host) -> Result<(), String> {
+    let target = format!("{}@{}", host.user, host.address);
+    let output = tokio::process::Command::new("ssh")
+        .args([
+            "-o",
+            "BatchMode=yes",
+            "-o",
+            "ConnectTimeout=5",
+            "-o",
+            "StrictHostKeyChecking=accept-new",
+            &target,
+            "true",
+        ])
+        .output()
+        .await
+        .map_err(|e| format!("could not invoke ssh: {e}"))?;
+    if output.status.success() {
+        return Ok(());
+    }
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let translated = classify(&stderr);
+    Err(format!(
+        "ssh probe failed: {translated}\n\nraw ssh stderr:\n{}",
+        stderr.trim()
+    ))
+}
+
+/// Pattern-match ssh stderr against the failure modes operators hit
+/// most often, returning a one-line actionable hint.
+#[must_use]
+pub fn classify(stderr: &str) -> String {
+    if let Some(url) = extract_tailscale_check_url(stderr) {
+        return format!(
+            "Tailscale SSH requires an additional check — open this URL in a browser, then re-run:\n  {url}"
+        );
+    }
+    if stderr.contains("Permission denied") {
+        return "permission denied — check the ssh key (`ssh-add -l`) and that the deploy user is configured on the host".into();
+    }
+    if stderr.contains("Connection timed out") || stderr.contains("Operation timed out") {
+        return "connection timed out — host unreachable. If on Tailscale, run `tailscale up` and check `tailscale status`".into();
+    }
+    if stderr.contains("Host key verification failed") {
+        return "host key verification failed — the host's key changed. Inspect ~/.ssh/known_hosts and re-add if expected".into();
+    }
+    if stderr.contains("Could not resolve hostname")
+        || stderr.contains("Name or service not known")
+    {
+        return "could not resolve hostname — typo in `address:`, or DNS / Tailscale magicDNS not reachable".into();
+    }
+    if stderr.contains("Connection refused") {
+        return "connection refused — sshd not listening on the target port".into();
+    }
+    "ssh failed (see raw stderr below for details)".into()
+}
+
+/// Pull the Tailscale auth URL out of stderr if present.
+/// Tailscale SSH's check-mode prints `# To authenticate, visit:
+/// <https://login.tailscale.com/a/TOKEN>` — note the leading `# `.
+#[must_use]
+pub fn extract_tailscale_check_url(stderr: &str) -> Option<String> {
+    for line in stderr.lines() {
+        let trimmed = line.trim().trim_start_matches('#').trim();
+        if let Some(rest) = trimmed.strip_prefix("To authenticate, visit:") {
+            let url = rest.trim();
+            if url.starts_with("https://login.tailscale.com/") {
+                return Some(url.to_string());
+            }
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn classify_tailscale_check_surfaces_url() {
+        let stderr = "# Tailscale SSH requires an additional check.\n# To authenticate, visit: https://login.tailscale.com/a/abc123\n";
+        let msg = classify(stderr);
+        assert!(msg.contains("Tailscale SSH requires an additional check"));
+        assert!(msg.contains("https://login.tailscale.com/a/abc123"));
+    }
+
+    #[test]
+    fn classify_permission_denied_points_at_ssh_key() {
+        let msg = classify("Permission denied (publickey).\r\n");
+        assert!(msg.contains("permission denied"));
+        assert!(msg.contains("ssh-add"));
+    }
+
+    #[test]
+    fn classify_timeout_mentions_tailscale_up() {
+        let msg = classify("ssh: connect to host x port 22: Operation timed out\n");
+        assert!(msg.contains("connection timed out"));
+        assert!(msg.contains("tailscale up"));
+    }
+
+    #[test]
+    fn classify_unknown_falls_back_to_generic() {
+        let msg = classify("ssh: something weird went wrong\n");
+        assert!(msg.contains("ssh failed"));
+    }
+
+    #[test]
+    fn extract_tailscale_url_picks_login_tailscale_only() {
+        let s = "# Tailscale SSH requires an additional check.\n# To authenticate, visit: https://login.tailscale.com/a/zzz\n";
+        assert_eq!(
+            extract_tailscale_check_url(s).as_deref(),
+            Some("https://login.tailscale.com/a/zzz")
+        );
+        // Non-tailscale URL — refuse to surface (don't help phishing).
+        let s2 = "# To authenticate, visit: https://evil.example.com/a/zzz\n";
+        assert_eq!(extract_tailscale_check_url(s2), None);
+    }
+
+    #[test]
+    fn extract_tailscale_url_handles_user_reported_format() {
+        // Exact text the operator pasted (including the # prefix
+        // Tailscale uses).
+        let s = "# Tailscale SSH requires an additional check.\n# To authenticate, visit: https://login.tailscale.com/a/l4ea83873a21a2\n";
+        assert_eq!(
+            extract_tailscale_check_url(s).as_deref(),
+            Some("https://login.tailscale.com/a/l4ea83873a21a2")
+        );
+    }
+}

--- a/yoink/src/tui/app.rs
+++ b/yoink/src/tui/app.rs
@@ -323,6 +323,14 @@ enum Update {
     Toast(String),
 }
 
+/// Auto-pop error overlay carrying the full text (including URLs
+/// that wouldn't fit in the one-line footer). Title goes in the
+/// modal border; body is the multi-line message.
+struct ErrorModal {
+    title: String,
+    lines: Vec<String>,
+}
+
 /// Background-task → run-loop messages. Events stream into the
 /// progress modal as they fire; `Done` flips the modal into a
 /// dismissible "finished" state with the final ✓/✗ summary.
@@ -573,6 +581,13 @@ pub struct App {
     /// `?` toggles a modal help overlay listing keybinds for the
     /// current view. Cleared on Esc and on any view transition.
     show_help: bool,
+    /// Auto-pop modal for the first occurrence of a long error
+    /// string that doesn't fit in the footer (e.g. an ssh-probe
+    /// failure carrying a Tailscale auth URL). Dismissed with Esc;
+    /// fingerprint is added to `shown_errors` so the same error
+    /// won't re-pop on every refresh.
+    error_modal: Option<ErrorModal>,
+    shown_errors: std::collections::HashSet<String>,
     /// `Some` while a kill-confirmation modal is open over the
     /// current view. The user confirms with `y` (or Enter) and
     /// cancels with anything else. Cleared on transition.
@@ -670,6 +685,8 @@ impl App {
             logs: LogsState::new(),
             shell: None,
             show_help: false,
+            error_modal: None,
+            shown_errors: std::collections::HashSet::new(),
             kill_target: None,
             reconcile_target: None,
             prune_target: false,
@@ -758,6 +775,26 @@ impl App {
         while self.toasts.len() > TOAST_CAP {
             self.toasts.pop_front();
         }
+    }
+
+    /// Show an auto-pop error modal — once per unique error. Used
+    /// when an error string is too long to fit in the one-line
+    /// footer (Tailscale auth URL, multi-line ssh-probe output,
+    /// etc.). Operator dismisses with Esc; the same error won't
+    /// re-pop on subsequent refresh ticks. The fingerprint keys on
+    /// the first line of the body, so token-regeneration in the URL
+    /// doesn't count as a different error.
+    fn show_error_modal_once(&mut self, title: &str, body: &str) {
+        let first_line = body.lines().next().unwrap_or("").to_string();
+        let fp = format!("{title}|{first_line}");
+        if !self.shown_errors.insert(fp) {
+            return;
+        }
+        let lines: Vec<String> = body.lines().map(str::to_string).collect();
+        self.error_modal = Some(ErrorModal {
+            title: title.to_string(),
+            lines,
+        });
     }
 
     /// Open the reconcile-confirm modal for `service`. Resolves the
@@ -1038,6 +1075,18 @@ impl App {
         }
         if self.show_help && key.code == KeyCode::Esc {
             self.show_help = false;
+            return false;
+        }
+
+        // Auto-pop error modal: Esc / Enter dismisses. Captured
+        // before view-specific keys so the operator can't
+        // accidentally drive the underlying view while the modal's
+        // open. The fingerprint stays in `shown_errors`, so the
+        // same error won't re-pop after dismissal.
+        if self.error_modal.is_some() {
+            if matches!(key.code, KeyCode::Esc | KeyCode::Enter) {
+                self.error_modal = None;
+            }
             return false;
         }
 
@@ -1872,6 +1921,13 @@ impl App {
                 self.container_detail_in_flight = false;
             }
             Update::Dashboard(data) => {
+                // Long error strings (ssh-probe with a Tailscale auth
+                // URL, multi-line bollard errors) get auto-popped as a
+                // modal so the URL is actually visible — the one-line
+                // footer truncates anything longer than the terminal.
+                if let Some(err) = data.error.as_deref() {
+                    self.show_error_modal_once("connection error", err);
+                }
                 // Services & ServiceDetail share the same StatusReport
                 // as Dashboard. Clone it into both before handing the
                 // original off to dashboard's apply (which moves it).
@@ -2196,6 +2252,17 @@ impl App {
             } else {
                 super::ui::render_log_modal(frame, &title, &lines, success, failure);
             }
+        }
+
+        // Render last so it sits on top of everything else when a
+        // long error needs the operator's attention. Lines stay
+        // verbatim — the modal sizes to the longest line so URLs
+        // are guaranteed to fit (clamped by terminal width).
+        if let Some(modal) = &self.error_modal {
+            let mut body: Vec<&str> = modal.lines.iter().map(String::as_str).collect();
+            body.push("");
+            body.push("[Esc] / Enter   dismiss");
+            super::ui::render_modal(frame, &modal.title, &body);
         }
     }
 }

--- a/yoink/src/tui/app.rs
+++ b/yoink/src/tui/app.rs
@@ -303,9 +303,12 @@ enum Update {
     Dashboard(DashboardRefresh),
     /// Result of `schedule_history_refresh` — per-service container
     /// list across every host, drives the History pane's table.
+    /// `errors` carries per-host failure strings so the pane can
+    /// surface them instead of silently dropping unreachable hosts.
     ServiceHistory {
         service: String,
         rows: Vec<super::history::HistoryRow>,
+        errors: Vec<String>,
     },
     /// Push notification from a host's `docker events` stream. Triggers
     /// an immediate refresh of whichever pane is currently visible.
@@ -313,6 +316,11 @@ enum Update {
         host: Host,
         event: DockerEvent,
     },
+    /// Background task wants to surface a one-line message in the
+    /// toast ring (top-right of the breadcrumb). Used for silent
+    /// failures the operator otherwise wouldn't see — log streams
+    /// dying, event subscriptions failing, secrets loader blowing up.
+    Toast(String),
 }
 
 /// Background-task → run-loop messages. Events stream into the
@@ -617,6 +625,8 @@ pub struct App {
     hosts_in_flight: bool,
     host_detail_in_flight: bool,
     dashboard_in_flight: bool,
+    container_detail_in_flight: bool,
+    history_in_flight: bool,
     update_tx: UnboundedSender<Update>,
     update_rx: UnboundedReceiver<Update>,
 
@@ -676,6 +686,8 @@ impl App {
             hosts_in_flight: false,
             host_detail_in_flight: false,
             dashboard_in_flight: false,
+            container_detail_in_flight: false,
+            history_in_flight: false,
             update_tx,
             update_rx,
             log_tasks: Vec::new(),
@@ -926,6 +938,7 @@ impl App {
     fn spawn_secrets_loader(&self) {
         let config = self.config.clone();
         let slot = self.secrets.clone();
+        let tx = self.update_tx.clone();
         tokio::spawn(async move {
             match crate::secrets::load_bundle(&config).await {
                 Ok(Some(bundle)) => {
@@ -938,6 +951,9 @@ impl App {
                 }
                 Err(e) => {
                     warn!(error = %e, "secrets load for drift detection failed; column will stay '?'");
+                    let _ = tx.send(Update::Toast(format!(
+                        "✗ secrets load failed: {e} (drift column → ?)"
+                    )));
                 }
             }
         });
@@ -956,6 +972,10 @@ impl App {
                     Ok(rx) => rx,
                     Err(e) => {
                         warn!(host = %host.address, error = %e, "subscribe_events failed");
+                        let _ = tx.send(Update::Toast(format!(
+                            "✗ events stream {}: {e}",
+                            host.address
+                        )));
                         return;
                     }
                 };
@@ -970,6 +990,12 @@ impl App {
                         return;
                     }
                 }
+                // Stream ended without an explicit error — usually
+                // means the host went away. Surface it.
+                let _ = tx.send(Update::Toast(format!(
+                    "✗ events stream {} ended (host probably unreachable)",
+                    host.address
+                )));
             });
             self.event_tasks.push(task);
         }
@@ -1649,23 +1675,37 @@ impl App {
     /// `Update::ServiceHistory` back to the run loop. Mirrors the CLI
     /// `cmd_history` query.
     fn schedule_history_refresh(&mut self, service: String) {
+        if self.history_in_flight {
+            return;
+        }
+        self.history_in_flight = true;
         let ops = self.ops.clone();
         let hosts: Vec<Host> = self.config.hosts.iter().map(Host::from).collect();
         let tx = self.update_tx.clone();
         tokio::spawn(async move {
             let label = format!("yoink.service={service}");
             let mut rows: Vec<super::history::HistoryRow> = Vec::new();
+            let mut errors: Vec<String> = Vec::new();
             for host in hosts {
-                if let Ok(containers) = ops.list_containers_by_label(&host, &label).await {
-                    for c in containers {
-                        rows.push(super::history::HistoryRow::from_container(
-                            &host.address,
-                            &c,
-                        ));
+                match ops.list_containers_by_label(&host, &label).await {
+                    Ok(containers) => {
+                        for c in containers {
+                            rows.push(super::history::HistoryRow::from_container(
+                                &host.address,
+                                &c,
+                            ));
+                        }
+                    }
+                    Err(e) => {
+                        errors.push(format!("{}: {e}", host.address));
                     }
                 }
             }
-            let _ = tx.send(Update::ServiceHistory { service, rows });
+            let _ = tx.send(Update::ServiceHistory {
+                service,
+                rows,
+                errors,
+            });
         });
     }
 
@@ -1772,9 +1812,13 @@ impl App {
     }
 
     fn schedule_container_detail_refresh(&mut self) {
+        if self.container_detail_in_flight {
+            return;
+        }
         let Some((host, container)) = self.container_detail.target().cloned() else {
             return;
         };
+        self.container_detail_in_flight = true;
         let ops = self.ops.clone();
         let tx = self.update_tx.clone();
         tokio::spawn(async move {
@@ -1825,6 +1869,7 @@ impl App {
                 {
                     self.container_detail.apply(*data);
                 }
+                self.container_detail_in_flight = false;
             }
             Update::Dashboard(data) => {
                 // Services & ServiceDetail share the same StatusReport
@@ -1843,10 +1888,16 @@ impl App {
                 self.dashboard.apply(data);
                 self.dashboard_in_flight = false;
             }
-            Update::ServiceHistory { service, rows } => {
-                self.history.apply(&service, rows);
+            Update::ServiceHistory {
+                service,
+                rows,
+                errors,
+            } => {
+                self.history.apply(&service, rows, errors);
+                self.history_in_flight = false;
             }
             Update::Event { host, event } => self.on_docker_event(&host, &event),
+            Update::Toast(msg) => self.push_toast(msg),
         }
     }
 
@@ -1903,6 +1954,7 @@ impl App {
             Ok(r) => r,
             Err(e) => {
                 warn!(error = %e, "failed to collect status for log streams");
+                self.push_toast(format!("✗ log collect failed: {e}"));
                 return;
             }
         };
@@ -1932,6 +1984,10 @@ impl App {
             Ok(rx) => rx,
             Err(e) => {
                 warn!(host = %host.address, container = %container, error = %e, "open_log_stream failed");
+                self.push_toast(format!(
+                    "✗ logs {}/{container}: {e}",
+                    host.address
+                ));
                 return;
             }
         };

--- a/yoink/src/tui/app.rs
+++ b/yoink/src/tui/app.rs
@@ -781,9 +781,15 @@ impl App {
     /// when an error string is too long to fit in the one-line
     /// footer (Tailscale auth URL, multi-line ssh-probe output,
     /// etc.). Operator dismisses with Esc; the same error won't
-    /// re-pop on subsequent refresh ticks. The fingerprint keys on
-    /// the first line of the body, so token-regeneration in the URL
-    /// doesn't count as a different error.
+    /// re-pop on subsequent refresh ticks.
+    ///
+    /// **Why first-line fingerprinting:** the first line is the
+    /// classified hint (e.g. `ssh probe failed: Tailscale SSH
+    /// requires an additional check — open this URL...`), which
+    /// stays stable across token regenerations in the URL on
+    /// subsequent lines. Hashing the full body would make every
+    /// token rotation re-pop the same modal the operator just
+    /// dismissed.
     fn show_error_modal_once(&mut self, title: &str, body: &str) {
         let first_line = body.lines().next().unwrap_or("").to_string();
         let fp = format!("{title}|{first_line}");
@@ -1733,10 +1739,24 @@ impl App {
         let tx = self.update_tx.clone();
         tokio::spawn(async move {
             let label = format!("yoink.service={service}");
+            // Fan out per-host fetches in parallel — sequential here
+            // multiplies the ssh-probe timeout by the host count
+            // (3 hosts down × 8s = 24s total before the operator
+            // sees anything). `StatusReport::collect` already does
+            // the same thing for the dashboard.
+            let futs = hosts.into_iter().map(|host| {
+                let ops = ops.clone();
+                let label = label.clone();
+                async move {
+                    let result = ops.list_containers_by_label(&host, &label).await;
+                    (host, result)
+                }
+            });
+            let results = futures_util::future::join_all(futs).await;
             let mut rows: Vec<super::history::HistoryRow> = Vec::new();
             let mut errors: Vec<String> = Vec::new();
-            for host in hosts {
-                match ops.list_containers_by_label(&host, &label).await {
+            for (host, result) in results {
+                match result {
                     Ok(containers) => {
                         for c in containers {
                             rows.push(super::history::HistoryRow::from_container(

--- a/yoink/src/tui/container_detail.rs
+++ b/yoink/src/tui/container_detail.rs
@@ -68,10 +68,14 @@ impl ContainerDetailState {
 
     pub fn apply(&mut self, data: ContainerDetailRefresh) {
         self.last_error = data.error;
+        // Flip loaded unconditionally so the pane renders the error
+        // path (which already exists at the top of `render`) instead
+        // of looping on `(loading…)`. Last-known good inspect/stats
+        // stay around to ride out transient blips.
+        self.loaded = true;
         if self.last_error.is_none() {
             self.inspect = data.inspect;
             self.stats = data.stats;
-            self.loaded = true;
         }
     }
 

--- a/yoink/src/tui/dashboard.rs
+++ b/yoink/src/tui/dashboard.rs
@@ -166,13 +166,18 @@ impl DashboardState {
         self.apply(data);
     }
 
-    /// Apply background-fetched results.
+    /// Apply background-fetched results. `loaded` flips
+    /// unconditionally — when `report` is `None` (host unreachable,
+    /// ssh probe failed, etc.), the existing render path uses
+    /// `last_error` to surface the failure instead of looping on
+    /// `(loading…)`. Last-known good `report`/`stats` are kept on
+    /// error to ride out transient blips.
     pub fn apply(&mut self, data: DashboardRefresh) {
         self.last_error = data.error;
+        self.loaded = true;
         if let Some(report) = data.report {
             self.report = Some(report);
             self.stats = data.stats;
-            self.loaded = true;
         }
     }
 
@@ -248,7 +253,15 @@ impl DashboardState {
 
     fn build_rows(&self, config: &Config, secrets: Option<&SecretsBundle>) -> Vec<Row<'static>> {
         let Some(report) = &self.report else {
-            return vec![Row::new(vec![Cell::from("(loading…)")])];
+            // No cached report. If the first fetch already finished
+            // and errored (loaded=true), don't pretend we're still
+            // loading — the error footer carries the detail.
+            let cell = if self.loaded {
+                "(no data — see error in footer)"
+            } else {
+                "(loading…)"
+            };
+            return vec![Row::new(vec![Cell::from(cell)])];
         };
         let mut rows: Vec<Row<'_>> = Vec::new();
         for host in &report.hosts {

--- a/yoink/src/tui/history.rs
+++ b/yoink/src/tui/history.rs
@@ -61,6 +61,10 @@ pub struct HistoryState {
     rows: Vec<HistoryRow>,
     table: TableState,
     loaded: bool,
+    /// Per-host failures from the last refresh. Surfaced in the
+    /// footer so the operator can tell "no history for this service"
+    /// from "the host is unreachable".
+    errors: Vec<String>,
 }
 
 impl HistoryState {
@@ -83,14 +87,16 @@ impl HistoryState {
 
     /// Apply a fresh fetch result. Sorts newest-first and pins the
     /// selection to the first row when the previous selection no
-    /// longer fits.
-    pub fn apply(&mut self, service: &str, mut rows: Vec<HistoryRow>) {
+    /// longer fits. `errors` carries per-host failures so the pane
+    /// can distinguish "no containers found" from "host unreachable".
+    pub fn apply(&mut self, service: &str, mut rows: Vec<HistoryRow>, errors: Vec<String>) {
         if self.service.as_deref() != Some(service) {
             // Result raced a different transition — the user moved on.
             return;
         }
         rows.sort_by_key(|r| std::cmp::Reverse(r.when_unix));
         self.rows = rows;
+        self.errors = errors;
         self.loaded = true;
         if self.rows.is_empty() {
             self.table.select(None);
@@ -153,6 +159,12 @@ impl HistoryState {
         ];
         let rows: Vec<Row<'_>> = if !self.loaded {
             vec![Row::new(vec![Cell::from("(loading…)")])]
+        } else if self.rows.is_empty() && !self.errors.is_empty() {
+            // All hosts errored — make that obvious instead of
+            // implying the service has no history.
+            vec![Row::new(vec![Cell::from(
+                "(no history reachable — every host failed; see footer for details)",
+            )])]
         } else if self.rows.is_empty() {
             vec![Row::new(vec![Cell::from(
                 "(no history — service has no yoink-managed containers on any host)",
@@ -191,9 +203,17 @@ impl HistoryState {
             .block(Block::default().borders(Borders::ALL).title("history"));
         frame.render_stateful_widget(table, layout[1], &mut self.table);
 
-        let footer = Paragraph::new(
-            "↑↓/jk navigate · r rollback to selected (running rows are skipped) · R refresh · esc back",
-        );
+        let footer_text = if self.errors.is_empty() {
+            "↑↓/jk navigate · r rollback to selected (running rows are skipped) · R refresh · esc back".to_string()
+        } else {
+            format!("⚠ {} host(s) unreachable: {}", self.errors.len(), self.errors.join(" · "))
+        };
+        let footer_style = if self.errors.is_empty() {
+            ratatui::style::Style::default()
+        } else {
+            ratatui::style::Style::default().fg(ratatui::style::Color::Yellow)
+        };
+        let footer = Paragraph::new(footer_text).style(footer_style);
         frame.render_widget(footer, layout[2]);
     }
 }
@@ -225,16 +245,28 @@ mod tests {
                 row("h", "v3", "running", 300),
                 row("h", "v2", "exited", 200),
             ],
+            Vec::new(),
         );
         let versions: Vec<&str> = s.rows.iter().map(|r| r.version.as_str()).collect();
         assert_eq!(versions, vec!["v3", "v2", "v1"]);
     }
 
     #[test]
+    fn apply_with_errors_distinguishes_from_empty() {
+        let mut s = HistoryState::new();
+        s.set_service("api".into());
+        // All hosts errored — rows empty but errors non-empty.
+        s.apply("api", Vec::new(), vec!["h1: connection refused".into()]);
+        assert!(s.rows.is_empty());
+        assert!(s.loaded);
+        assert_eq!(s.errors.len(), 1);
+    }
+
+    #[test]
     fn apply_for_other_service_is_dropped() {
         let mut s = HistoryState::new();
         s.set_service("api".into());
-        s.apply("web", vec![row("h", "v1", "running", 100)]);
+        s.apply("web", vec![row("h", "v1", "running", 100)], Vec::new());
         assert!(s.rows.is_empty());
         assert!(!s.loaded);
     }
@@ -249,6 +281,7 @@ mod tests {
                 row("h", "v3", "running", 300),
                 row("h", "v2", "exited", 200),
             ],
+            Vec::new(),
         );
         // Default selection is row 0 → running → no target.
         assert_eq!(s.selected_rollback_target(), None);
@@ -269,6 +302,7 @@ mod tests {
                 row("h", "v3", "running", 300),
                 row("h", "v2", "exited", 200),
             ],
+            Vec::new(),
         );
         s.select_next();
         s.select_next();

--- a/yoink/src/tui/host_detail.rs
+++ b/yoink/src/tui/host_detail.rs
@@ -69,13 +69,17 @@ impl HostDetailState {
     }
 
     /// Apply background-fetched results, preserving selection where possible.
+    /// Always flips `loaded = true` — even on error — so the pane
+    /// renders an error footer instead of looping on `(loading…)`.
+    /// Last-known good `containers`/`stats`/`host_info` are kept on
+    /// error so a transient blip doesn't blank the table.
     pub fn apply(&mut self, data: HostDetailRefresh) {
         self.last_error = data.error;
+        self.loaded = true;
         if self.last_error.is_none() {
             self.containers = data.containers;
             self.stats = data.stats;
             self.host_info = data.host_info;
-            self.loaded = true;
         }
         clamp_selection(&mut self.table, self.containers.len());
     }

--- a/yoink/src/tui/hosts.rs
+++ b/yoink/src/tui/hosts.rs
@@ -161,10 +161,25 @@ impl HostsState {
             .block(Block::default().borders(Borders::ALL).title("hosts"));
         frame.render_stateful_widget(table, layout[1], &mut self.table);
 
-        let footer = filter_footer(
-            &self.filter,
-            "q quit · ↑↓ select · enter detail · r refresh · ? help",
-        );
+        // When the highlighted row is in error state, surface the
+        // full error text in the footer — much more useful than the
+        // truncated 60-char tail in the table cell.
+        let selected_error: Option<&str> = self
+            .table
+            .selected()
+            .and_then(|i| visible.get(i).copied())
+            .and_then(|src| match &self.rows[src].status {
+                HostStatus::Err(e) => Some(e.as_str()),
+                HostStatus::Ok(_) => None,
+            });
+        let footer = match selected_error {
+            Some(err) => Paragraph::new(format!("⚠ {err}"))
+                .style(Style::default().fg(Color::Yellow)),
+            None => filter_footer(
+                &self.filter,
+                "q quit · ↑↓ select · enter detail · r refresh · ? help",
+            ),
+        };
         frame.render_widget(footer, layout[2]);
     }
 }

--- a/yoink/src/tui/services.rs
+++ b/yoink/src/tui/services.rs
@@ -56,13 +56,17 @@ impl ServicesState {
     /// Refresh data is shared with the dashboard — the caller hands us
     /// the latest `StatusReport` so we don't fetch a second time per
     /// tick. `service_names` reflects the config's declared order.
+    /// `report = None` means the underlying fetch failed (host
+    /// unreachable, etc.); we still flip `loaded = true` so the pane
+    /// renders rows from the config (with running=0/N) instead of
+    /// hanging on `(loading…)` indefinitely.
     pub fn apply(&mut self, report: Option<StatusReport>, service_names: Vec<String>) {
+        self.service_names = service_names;
+        self.loaded = true;
         if let Some(r) = report {
             self.report = Some(r);
-            self.service_names = service_names;
-            self.loaded = true;
-            clamp_selection(&mut self.table, self.service_names.len());
         }
+        clamp_selection(&mut self.table, self.service_names.len());
     }
 
     pub fn select_next(&mut self) {
@@ -245,10 +249,14 @@ impl ServiceDetailState {
     /// Apply data from a shared `StatusReport`, filtering down to the
     /// rows for the currently-selected service. `host_users` lets us
     /// reconstruct the `Host` (with ssh user) that the row drills into.
+    /// `report = None` means the underlying fetch failed; we still
+    /// flip `loaded = true` so the pane renders `(no instances)`
+    /// instead of looping on `(loading…)` indefinitely.
     pub fn apply(&mut self, report: Option<Arc<StatusReport>>, config: &Config) {
         let Some(name) = self.service.clone() else {
             return;
         };
+        self.loaded = true;
         if let Some(r) = report {
             let mut rows = Vec::new();
             for host_status in &r.hosts {
@@ -271,7 +279,6 @@ impl ServiceDetailState {
                 }
             }
             self.rows = rows;
-            self.loaded = true;
             clamp_selection(&mut self.table, self.rows.len());
         }
     }


### PR DESCRIPTION
## Summary

Started as a one-line fix for the Services pane hanging on `(loading…)` when a host was unreachable. Audit surfaced the same bug shape in three other panes plus a handful of silent failures with no operator visibility. This PR sweeps all of it.

### Tier 1 — fixed hangs (3 panes)

The pattern: pane's `apply()` was gated on `if data.error.is_none()` — so on host-unreachable, `loaded` stayed `false` and the pane was stuck on `(loading…)` forever, even after docker recovered. `dashboard_in_flight` cleared correctly, so a manual `r` retry worked, but no automatic recovery.

- **Services + ServiceDetail** — flip `loaded = true` unconditionally; render rows from config (`running=0/N`, "-" health) on error.
- **HostDetail** — same fix; existing red error footer path now actually renders.
- **ContainerDetail** — same; existing red error path made reachable.

For all of them: last-known good data is retained on error, so a transient blip doesn't blank the table.

### Tier 2 — silent-failure visibility (new `Update::Toast`)

These were "operator has no idea something failed" cases, all just `warn!` to the log file:

- **Event subscriptions** — toast when `subscribe_events` errors, and when the stream ends without an explicit error (host went away).
- **Log forwarders** — toast when `open_log_stream` fails (was: empty pane, no clue why no logs).
- **Service-log-streams** — toast when `StatusReport::collect` errors.
- **Secrets loader** — toast when `load_bundle` fails so the operator knows why the drift column is stuck on `?`.

### Tier 3 — defensive consistency

- **ContainerDetail** + **History** in-flight flags — coalesce ticks the same way Hosts/Dashboard already do, so a slow daemon can't queue up a backlog.
- **History pane** — distinguishes "no containers found" from "every host errored" with a different empty-row message + yellow error footer listing the failed hosts. Plus a new `errors: Vec<String>` plumbed through `Update::ServiceHistory`.
- **Hosts pane** — when the highlighted row is in error state, the full error text renders in the footer (yellow). Was: 60-char truncation in the rightmost column, hard to debug from.

## Test plan

- [x] `cargo test -p yoink --lib` — 153 passed (was 152; new `apply_with_errors_distinguishes_from_empty` test for History)
- [x] `cargo clippy -p yoink --all-targets -- -D warnings` — clean
- [ ] Live verify: bring `backtrack-eu-1` down briefly and tour each pane — Services/HostDetail/ContainerDetail/History — confirm error states render gracefully and toasts surface in the breadcrumb. Press `r` in each to confirm recovery once docker comes back.