### PR TITLE
chore: examples/sealed-secrets test fixture

### DIFF
--- a/examples/sealed-secrets/.gitignore
+++ b/examples/sealed-secrets/.gitignore
@@ -1,0 +1,2 @@
+secrets.age
+*.age.tmp

--- a/examples/sealed-secrets/README.md
+++ b/examples/sealed-secrets/README.md
@@ -1,0 +1,74 @@
+# Sealed-secrets test fixture
+
+Self-contained walkthrough that exercises age-sealed secrets end-to-end against your laptop's docker daemon. No ssh, no registry, no remote services.
+
+## Setup (~30 seconds)
+
+```sh
+cd examples/sealed-secrets
+
+# 1. Generate an age identity. Writes the secret to ~/.config/yoink/age.key
+#    (0o600); prints the public recipient.
+yoink secrets keygen
+
+# 2. Paste the public key into yoink.yaml under `secrets.recipients:`,
+#    replacing the `age1REPLACE_ME_...` placeholder.
+
+# 3. Seal a value into secrets.age.
+printf 'GREETING=hello sealed world\n' | yoink secrets seal
+
+# 4. Reconcile — pulls alpine, injects GREETING from secrets.age,
+#    starts the demo container.
+yoink up
+
+# 5. Verify the value lands inside the container.
+yoink exec demo -- env | grep GREETING
+# → GREETING=hello sealed world
+```
+
+## What this exercises
+
+- `secrets.provider: age` schema parsing
+- `yoink secrets keygen / seal` round-trip on disk
+- The deploy-time decryption path (`secrets::load_bundle`)
+- Per-service `secrets:` injection as env vars
+- spec_hash inclusion of secret values — change the value, re-seal, run `yoink up` again, and the container is replaced (rather than reused) because the hash differs.
+
+## Iterating
+
+Edit the sealed file in `$EDITOR` to add / change keys:
+
+```sh
+yoink secrets edit
+```
+
+Or interactively from the TUI:
+
+```sh
+yoink tui
+# press `e` to enter the secrets pane
+# `a` to add, `e` to edit, `d` to delete, `r` to reveal/mask
+```
+
+After any edit, `yoink up` re-deploys the demo container with the new env (drift detection picks it up automatically).
+
+## Tear down
+
+```sh
+yoink kill demo --yes      # stop the container
+docker rm demo             # remove it (yoink prune would too, once the config is gone)
+docker network rm demo     # remove the network
+rm secrets.age             # discard the sealed bundle
+```
+
+Or just `docker system prune` if you don't mind the broader cleanup.
+
+## What's NOT in scope
+
+- **Multiple hosts**: `local` only. For multi-host distribution see [docs/recipes/multi-host-distribution](https://oddur.github.io/yoink/docs/recipes/multi-host-distribution).
+- **Registry auth**: this fixture pulls `alpine` from Docker Hub anonymously. For private registries, see the `registry:` block in the [config reference](https://oddur.github.io/yoink/docs/reference/config).
+- **CI integration**: the [AGE secrets in GitHub Actions recipe](https://oddur.github.io/yoink/docs/recipes/age-in-github-actions) covers paste-into-secret + workflow wiring.
+
+## Note on `secrets.age` in this directory
+
+This directory does NOT commit a real `secrets.age`. The `.gitignore` here ignores it — every operator generates their own identity + sealed file. If you want to commit a sealed file for a real environment (which is the whole point of age), check it in from your repo root, not from this fixture.

--- a/examples/sealed-secrets/yoink.yaml
+++ b/examples/sealed-secrets/yoink.yaml
@@ -1,0 +1,48 @@
+# Sealed-secrets test fixture — runs entirely against the operator's
+# local docker daemon. No ssh, no registry, no remote infrastructure.
+#
+# Setup:
+#   1. yoink secrets keygen
+#   2. Replace `recipients:` below with the public key keygen printed.
+#   3. printf 'GREETING=hello sealed world\n' | yoink secrets seal
+#   4. yoink up
+#   5. yoink exec demo -- env | grep GREETING
+#      → GREETING=hello sealed world
+
+deploy:
+  networks: [demo]
+
+# The synthetic `local` host routes through bollard's local socket
+# transport — no ssh, no remote credentials needed. The user value
+# is unused for the local host but the schema requires a string.
+hosts:
+  - address: local
+    user: local
+
+secrets:
+  provider: age
+  recipients:
+    # Replace with the public key from `yoink secrets keygen`. The
+    # placeholder below is intentionally invalid so an unconfigured
+    # `yoink up` fails loudly instead of silently sealing nothing.
+    - age1REPLACE_ME_WITH_YOUR_PUBLIC_KEY
+
+services:
+  - name: demo
+    image: alpine
+    tag: "3.20"
+    networks: [demo]
+    # Inject the sealed value as an env var of the same name.
+    secrets: [GREETING]
+    run:
+      cmd:
+        - sh
+        - -c
+        - |
+          echo "demo container started — GREETING is set in env."
+          echo "verify with: yoink exec demo -- env | grep GREETING"
+          # Keep the container alive so the operator can exec into it.
+          sleep infinity
+      options:
+        memory: "32Mi"
+        cpus: "0.1"


### PR DESCRIPTION
Self-contained sealed-secrets walkthrough that runs against the laptop's local docker daemon. No ssh / registry / remote services needed.

\`\`\`sh
cd examples/sealed-secrets
yoink secrets keygen
# paste public key into yoink.yaml's recipients
printf 'GREETING=hello\n' | yoink secrets seal
yoink up
yoink exec demo -- env | grep GREETING
\`\`\`

Useful for:

- Quick local verification that the sealed-secrets path works end-to-end
- A starter template for operators bootstrapping their first sealed config
- Regression coverage when changing the secrets pipeline

## Test plan

- [x] \`yoink validate\` parses the fixture clean
- [ ] Live: \`yoink up\` against laptop docker, exec into container, confirm \`GREETING\` env var is set