### PR TITLE
feat(security): default user: 65534:65534 (non-root)

### DIFF
--- a/docs/content/_index.md
+++ b/docs/content/_index.md
@@ -20,7 +20,7 @@ yoink rollback api        # roll back to the previous version
   {{< card link="/docs/start/first-deploy" title="Five-minute first deploy" subtitle="Drop a yoink.yaml next to your Dockerfile, run one command." icon="lightning-bolt" >}}
   {{< card link="/docs/intro/compared" title="Is this for me?" subtitle="vs Kamal, vs Kubernetes, vs plain compose. When yoink is the right answer, when it isn't." icon="adjustments" >}}
   {{< card link="/docs/guide/deploy-modes" title="Three deploy modes" subtitle="CI-built, kamal-style local-build, no-registry standalone." icon="server" >}}
-  {{< card link="/docs/guide/security-defaults" title="Secure by default" subtitle="cap_drop=ALL, read-only rootfs, no-new-privileges, init=tini, …" icon="shield-check" >}}
+  {{< card link="/docs/guide/security-defaults" title="Secure by default" subtitle="non-root uid, cap_drop=ALL, read-only rootfs, no-new-privileges, init=tini, …" icon="shield-check" >}}
   {{< card link="/docs/recipes" title="Recipes" subtitle="Staging alongside prod, self-hosted registry, Infisical secrets, PR-comment dry-run." icon="clipboard-list" >}}
   {{< card link="/docs/reference" title="Reference" subtitle="Every CLI flag, every config field, every TUI keybind." icon="document-text" >}}
 {{< /cards >}}
@@ -35,7 +35,7 @@ Kamal is a lovely fit for "one app, one binary per host" but starts to creak the
 - **Per-service network tiers** for blast-radius isolation without a CNI plugin
 - **Drift detection.** Every effective spec hashes deterministically and lands as a label. The TUI shows drift across the cluster without guessing.
 - **Three deploy modes**: CI-built (the default), local-build kamal-style with `yoink build --push`, or fully standalone with `yoink up --build --no-registry` (no CI, no registry — drop a `yoink.yaml` next to your Dockerfile and go)
-- **Secure by default**: cap_drop=ALL, no-new-privileges, read-only rootfs, init=tini, tmpfs noexec, binds default :ro. Override per service when needed.
+- **Secure by default**: containers run as **non-root** (uid 65534) with cap_drop=ALL, no-new-privileges, read-only rootfs, init=tini, tmpfs noexec, binds default :ro. Override per service when an image genuinely needs root.
 - **Sealed secrets out of the box**: commit a single `secrets.age` file, decrypt with one key from `YOINK_AGE_KEY` (env in CI, file on your laptop). No remote vault needed. Infisical is opt-in for teams already running one.
 - **k9s-style TUI** with deploy history, one-press rollback, drift cells, logs auto-piped through `hl`
 

--- a/docs/content/docs/guide/security-defaults.md
+++ b/docs/content/docs/guide/security-defaults.md
@@ -10,6 +10,7 @@ Compose's defaults are dev-friendly, not prod-friendly: every container runs wit
 | `cap_drop` | `["ALL"]` | every Linux capability dropped (no `CAP_NET_ADMIN`, `CAP_SYS_ADMIN`, …) | `cap_drop: []` (full default cap set), or surgically re-add via `cap_add` |
 | `security_opt` | `["no-new-privileges:true"]` | setuid binaries inside the container can't escalate via `execve` | `security_opt: []` |
 | `read_only` | `true` | rootfs mounted read-only — exploits can't drop binaries on disk | `read_only: false` |
+| `user` | `"65534:65534"` (nobody) | container runs as a non-root unprivileged uid; a process breakout doesn't immediately give the attacker write access through tmpfs / bind mounts | `user: "0:0"` for images that need root (otel reading `/proc`), or any other `"uid:gid"` |
 | `tmpfs` mount opts | auto-`noexec,nosuid,nodev` | a writable scratch tmpfs can't be used to drop + run a binary, set setuid bits, or create device nodes | include explicit `exec`/`suid`/`dev` in your tmpfs option string |
 | `binds` mode | `:ro` when no mode set | accidental bind-mount-and-write to host paths is impossible without explicit `:rw` | `"/host:/container:rw"` (explicit) |
 | `init` | `true` | tini as PID 1 reaps zombies + forwards SIGTERM, so drains and rolling swaps actually finish | `init: false` for images that ship their own init (systemd-in-containers, s6, supervisord) |
@@ -44,6 +45,19 @@ Compose's defaults are dev-friendly, not prod-friendly: every container runs wit
     cap_drop: []
     security_opt: []
 ```
+
+## Non-root in practice
+
+`user: "65534:65534"` works out of the box for the vast majority of images — alpine, debian-slim, ubuntu, gcr.io distroless variants all ship `nobody:nogroup` at that uid pair. The cases where the operator has to override are predictable and few:
+
+| image / use case | override | why |
+|---|---|---|
+| `otel/opentelemetry-collector-contrib` reading `/proc` for host metrics | `user: "0:0"` | needs CAP_DAC_READ_SEARCH (and root) to traverse `/proc/<pid>` |
+| `redis` (the official image) | `user: redis` | image ships its own non-root account; we just point at it |
+| Images with pre-baked file ownership for a specific uid | `user: "<uid>:<gid>"` | volume / file-perm collision otherwise |
+| Migration container that needs to chown a fresh volume | `user: "0:0"` (one-shot pre-deploy hook) | initial setup, fine to drop privilege after |
+
+When in doubt: deploy with the default first, watch the container fail-fast (`yoink logs <svc>`), and override only when the failure mode is "permission denied" rather than "function works fine".
 
 ## Read-only rootfs in practice
 

--- a/docs/content/docs/intro/what-and-why.md
+++ b/docs/content/docs/intro/what-and-why.md
@@ -27,7 +27,7 @@ Kamal is a lovely fit for "one app, one binary per host" but starts to creak the
 - **Dependency-ordered deploys.** Services declare `depends_on:` and `yoink up` runs them in topological-sort waves (independent services in parallel).
 - **Drift detection.** Every effective spec (image, env, networks, mounts, options, file content) hashes deterministically and lands as a label. The TUI shows drift across the cluster without guessing.
 - **Three deploy modes.** CI-built (the default), kamal-style local-build with `yoink build --push`, or fully standalone with `yoink up --build --no-registry` — no CI, no registry, drop a `yoink.yaml` next to your Dockerfile and go.
-- **Secure by default.** cap_drop=ALL, no-new-privileges, read-only rootfs, init=tini, tmpfs noexec, binds default :ro. Override per service when needed.
+- **Secure by default.** Containers run as a non-root uid (65534) with cap_drop=ALL, no-new-privileges, read-only rootfs, init=tini, tmpfs noexec, binds default :ro. Override per service when an image genuinely needs root or specific file ownership.
 - **Sealed secrets out of the box.** A single `secrets.age` file committed to the repo, decrypted at deploy time with one key resolved from `YOINK_AGE_KEY` (env in CI) or `YOINK_AGE_KEY_FILE` (a gitignored `age.key` next to your `yoink.yaml`). No remote vault required. Infisical stays available as an opt-in for teams already running it.
 - **k9s-style TUI.** A `ratatui` dashboard with one-key reconcile, prune, kill, shell-into, debug-sidecar, log filter, deploy history with one-press rollback. Keyboard-only.
 

--- a/docs/content/docs/reference/config.md
+++ b/docs/content/docs/reference/config.md
@@ -136,7 +136,7 @@ The hardened defaults make new containers prod-safe out of the box. Override per
 | `init` | bool | `true` | Run with tini as PID 1 (zombie reaping + proper SIGTERM). |
 | `tmpfs` | map of string | `{}` | `mount_path: "size=N,mode=NNNN"`. Auto-applies `noexec,nosuid,nodev`. |
 | `restart` | string | `unless-stopped` | Docker restart policy. |
-| `user` | string | unset | UID/GID override (`"1000:1000"`, `"redis"`). |
+| `user` | string | `"65534:65534"` (nobody) | UID/GID. Default runs non-root. Override with `"0:0"` for images that genuinely need root, or a specific uid:gid (`"1000:1000"`, `"redis"`) when the image has pre-baked file ownership. |
 | `network_aliases` | list of string | `[name]` | Extra DNS names on the attached networks. |
 
 See [Security defaults](/docs/guide/security-defaults) for the full picture.

--- a/yoink/src/config.rs
+++ b/yoink/src/config.rs
@@ -412,11 +412,16 @@ pub struct RunOptions {
     pub tmpfs: BTreeMap<String, String>,
     #[serde(default)]
     pub restart: Option<String>,
-    /// Override the container's effective user (e.g. `"0:0"` for an
-    /// image that genuinely needs root, or `"1000:1000"` for a
-    /// non-root unprivileged uid). When unset, docker honors the
-    /// image's `USER` directive.
-    #[serde(default)]
+    /// Override the container's effective user.
+    /// **Default: `"65534:65534"` (nobody:nogroup)** — yoink runs every
+    /// new container as a non-root unprivileged uid so a process
+    /// breakout doesn't immediately give the attacker file-system
+    /// access through the few mounts (tmpfs, binds) the hardened
+    /// profile leaves writable. Override with `"0:0"` for images that
+    /// genuinely need root (host-metrics collectors, otel reading
+    /// `/proc`), or with a different non-root uid if 65534 collides
+    /// with the image's pre-baked file ownership.
+    #[serde(default = "default_user")]
     pub user: Option<String>,
     /// Run `tini` as PID 1 (docker's `--init`). **Default: `true`.**
     /// Most app images run their language runtime as PID 1, which
@@ -445,6 +450,16 @@ fn default_init() -> bool {
     true
 }
 
+/// Default `user:` value for runtime containers. `nobody:nogroup` on
+/// most distros (alpine, debian-slim, ubuntu, distroless). Operators
+/// who need root (otel, host-metrics) opt out via `user: "0:0"`;
+/// images with pre-baked file ownership for a specific uid override
+/// to that uid (`"redis"`, `"1000:1000"`, etc.).
+#[allow(clippy::unnecessary_wraps)]
+fn default_user() -> Option<String> {
+    Some("65534:65534".to_string())
+}
+
 // Wrapped in `Option<i64>` because that's what the field expects;
 // clippy's `unnecessary_wraps` lint is wrong here.
 #[allow(clippy::unnecessary_wraps)]
@@ -465,7 +480,7 @@ impl Default for RunOptions {
             read_only: default_read_only(),
             tmpfs: BTreeMap::new(),
             restart: None,
-            user: None,
+            user: default_user(),
             init: default_init(),
         }
     }
@@ -1548,5 +1563,55 @@ services:
             .unwrap()
             .join("examples/yoink.yaml");
         let _ = Config::load_from_path(&path).expect("examples/yoink.yaml must parse");
+    }
+
+    #[test]
+    fn run_options_default_runs_as_non_root() {
+        // The whole hardened-defaults profile in one assertion. If
+        // any of these flip silently the security-defaults docs and
+        // the actual runtime drift apart.
+        let opts = RunOptions::default();
+        assert_eq!(opts.user.as_deref(), Some("65534:65534"));
+        assert_eq!(opts.cap_drop, vec!["ALL"]);
+        assert_eq!(opts.security_opt, vec!["no-new-privileges:true"]);
+        assert!(opts.read_only);
+        assert!(opts.init);
+        assert_eq!(opts.pids_limit, Some(1024));
+    }
+
+    #[test]
+    fn services_inherit_non_root_default_when_user_unset() {
+        let s = r#"
+hosts:
+  - { address: h, user: u }
+services:
+  - name: api
+    image: i
+    tag: v1
+    run: { port: 8080 }
+"#;
+        let c = Config::parse_str(s).unwrap();
+        assert_eq!(
+            c.services[0].run.options.user.as_deref(),
+            Some("65534:65534")
+        );
+    }
+
+    #[test]
+    fn services_can_override_user_to_root() {
+        let s = r#"
+hosts:
+  - { address: h, user: u }
+services:
+  - name: otel
+    image: i
+    tag: v1
+    run:
+      port: 13133
+      options:
+        user: "0:0"
+"#;
+        let c = Config::parse_str(s).unwrap();
+        assert_eq!(c.services[0].run.options.user.as_deref(), Some("0:0"));
     }
 }


### PR DESCRIPTION
## Summary

New runtime containers default to running as a non-root unprivileged uid (`65534:65534`, "nobody"). A process breakout from a hardened-profile container (cap_drop=ALL, read_only rootfs, no-new-privileges, …) no longer immediately gives the attacker write access through the few mounts (tmpfs, binds) the profile leaves writable.

## Schema change

`RunOptions::user` default flips from `None` to `Some("65534:65534")`. The field stays `Option<String>` — operators override via `user: "0:0"` for images that genuinely need root (otel reading `/proc`), or with a different `"uid:gid"` / `"name"` when the image has pre-baked file ownership.

## Migration

Existing configs without explicit `user:` will see their service's `spec_hash` change on the next `yoink up`, triggering a healthcheck-gated rolling swap.

**Live-verified against the bt repo's prod config (dry-run):**

```
= otel               (no change — already had `user: "0:0"`)
= redis              (no change — already had `user: redis`)
~ api                (would redeploy with new default)
~ web                (would redeploy)
~ caddy              (would redeploy; cap_add: NET_BIND_SERVICE keeps :80/:443 binds working)
~ pgadmin            (would redeploy; image is the most likely failure case — see security-defaults docs)
```

Most images run cleanly as 65534 — alpine, debian-slim, distroless variants all ship `nobody:nogroup` there. Worst-case override is one line per service.

## Live verification

Smoke-tested against the example fixture's alpine container:

```sh
$ yoink exec demo -- id
uid=65534(nobody) gid=65534(nobody) groups=65534(nobody)
```

Sealed-secret env var still injected correctly under non-root.

## Docs

- **guide/security-defaults**: new `user` row in the defaults table; new "Non-root in practice" section listing the four predictable override cases.
- **reference/config**: `user:` default + override guidance.
- **intro/what-and-why** + **landing card**: positioning bullet leads with "Containers run as a non-root uid (65534)".

## Test plan

- [x] `cargo test -p yoink --lib` — 182 passed (3 new: full hardened-profile assertion, service-level inheritance, override-to-root)
- [x] `cargo clippy -p yoink --all-targets -- -D warnings` — clean
- [x] Live: `yoink exec demo -- id` confirms uid=65534 inside container
- [x] Live: `yoink up --dry-run` against bt's prod config shows expected drift (otel/redis stable, others need redeploy)
- [ ] Real prod redeploy with this change — deferred to operator opt-in (via merge of this PR)
