### PR TITLE
docs: fix broken card links on landing/section pages

### DIFF
--- a/docs/layouts/_partials/shortcodes/card.html
+++ b/docs/layouts/_partials/shortcodes/card.html
@@ -1,0 +1,78 @@
+{{- $link := .link -}}
+{{- $title := .title -}}
+{{- $icon := .icon -}}
+{{- $subtitle := .subtitle -}}
+{{- $image := .image -}}
+{{- $alt := .alt | default $title -}}
+{{- $width := .width -}}
+{{- $height := .height -}}
+{{- $imageStyle := .imageStyle -}}
+{{- $tag := .tag -}}
+{{- $tagColor := .tagColor | default .tagType | default "" -}}{{- /* Compatibility with previous parameter. */ -}}
+{{- $tagBorder := not (eq .tagBorder false) | default true }}
+{{- $tagIcon := .tagIcon -}}
+
+{{ $linkClass := "hx:hover:border-gray-300 hx:bg-transparent hx:shadow-xs hx:dark:border-neutral-800 hx:hover:bg-slate-50 hx:hover:shadow-md hx:dark:hover:border-neutral-700 hx:dark:hover:bg-neutral-900" }}
+{{- with $image -}}
+  {{ $linkClass = "hx:hover:border-gray-300 hx:bg-gray-100 hx:shadow-sm hx:dark:border-neutral-700 hx:dark:bg-neutral-800 hx:dark:text-gray-50 hx:hover:shadow-lg hx:dark:hover:border-neutral-500 hx:dark:hover:bg-neutral-700" }}
+{{- end -}}
+
+{{- $external := strings.HasPrefix $link "http" -}}
+{{/*
+  Override of Hextra's upstream `card.html`: use `absURL` instead of
+  `relURL` for absolute-path inputs. Hugo's `relURL "/docs/foo"`
+  strips the leading slash but does NOT prepend the baseURL's path
+  component — on a project page at `https://oddur.github.io/yoink/`
+  that yields `/docs/foo` (404) instead of `/yoink/docs/foo`.
+  `absURL` prepends the full baseURL (path component included).
+*/}}
+{{- $href := cond (strings.HasPrefix $link "/") ($link | absURL) $link -}}
+
+
+<a
+  class="hextra-card hx:group hx:flex hx:flex-col hx:justify-start hx:overflow-hidden hx:rounded-lg hx:border hx:border-gray-200 hx:text-current hx:no-underline hx:dark:shadow-none hx:hover:shadow-gray-100 hx:dark:hover:shadow-none hx:shadow-gray-100 hx:active:shadow-sm hx:active:shadow-gray-200 hx:transition-all hx:duration-200 {{ $linkClass }}"
+  {{- if $link -}}
+    href="{{ $href }}"
+    {{ with $external }}target="_blank" rel="noreferrer"{{ end -}}
+  {{- end -}}
+>
+  {{- with $image -}}
+    <img
+      alt="{{ $alt }}"
+      class="hextra-card-image"
+      loading="lazy"
+      decoding="async"
+      src="{{ $image | safeURL }}"
+      {{ with $width }}width="{{ . }}"{{ end }}
+      {{ with $height }}height="{{ . }}"{{ end }}
+      {{ with $imageStyle }}style="{{ . | safeCSS }}"{{ end }}
+    />
+  {{- end -}}
+
+  {{- $padding := "hx:p-4" -}}
+  {{- with $subtitle -}}
+    {{- $padding = "hx:pt-4 hx:px-4" -}}
+  {{- end -}}
+
+  <div class="hx:mt-auto">
+    <span class="hextra-card-icon hx:flex hx:font-semibold hx:items-start hx:gap-2 {{ $padding }} hx:text-gray-700 hx:hover:text-gray-900 hx:dark:text-neutral-200 hx:dark:hover:text-neutral-50">
+      {{- with $icon }}{{ partial "utils/icon.html" (dict "name" $icon) -}}{{- end -}}
+      {{- $title -}}
+    </span>
+    {{- with $subtitle -}}
+      <div class="hextra-card-subtitle hx:line-clamp-3 hx:text-sm hx:font-normal hx:text-gray-500 hx:dark:text-gray-400 hx:px-4 hx:mb-4 hx:mt-2">{{- $subtitle | markdownify -}}</div>
+    {{- end -}}
+  </div>
+
+  {{- if $tag }}
+    {{- partial "shortcodes/badge.html" (dict
+      "content" $tag
+      "color" $tagColor
+      "class" "hextra-card-tag"
+      "border" $tagBorder
+      "icon" $tagIcon
+      )
+    -}}
+  {{- end -}}
+</a>
+{{- /* Strip trailing newline. */ -}}


### PR DESCRIPTION
## Summary

Lychee scan of the live site flagged 6 broken links on the landing page (and similar on each section index). Root cause: Hugo's \`relURL\` is a footgun on project pages — \`relURL \"/docs/foo\"\` strips the leading slash but does **not** prepend the baseURL's path component. With \`baseURL: https://oddur.github.io/yoink/\` that produced \`/docs/foo\` (404) instead of \`/yoink/docs/foo\`.

Hextra's upstream \`card.html\` partial uses \`relURL\` for absolute-path links, which is why every \`{{< card link=\"/docs/...\" >}}\` rendered broken.

## Fix

Copied Hextra's \`_partials/shortcodes/card.html\` into \`docs/layouts/\` (Hugo precedence: project layouts override module layouts) and swapped \`relURL\` → \`absURL\`. \`absURL\` prepends the full baseURL including its path component, so cards render as \`https://oddur.github.io/yoink/docs/foo\`.

## Test plan

- [x] Local build with the production baseURL: \`hugo --baseURL "https://oddur.github.io/yoink/"\`
- [x] \`lychee\` against the local build's landing page: 0 broken links (was 6)
- [x] All 6 cards now render with hrefs starting \`/yoink/docs/\` (verified via grep)
- [ ] Live verify after merge: \`lychee https://oddur.github.io/yoink/\` should be clean