### PR TITLE
docs(compared): add Komodo and Uncloud as neighbors

### DIFF
--- a/docs/content/docs/intro/compared.md
+++ b/docs/content/docs/intro/compared.md
@@ -9,7 +9,8 @@ Yoink lives in a populated neighborhood. Pick the tool that fits your scale and 
 **Quick decision tree.**
 1 host, 1 app → **plain `docker compose`** is fine.
 1-3 hosts, Rails/Django/Phoenix-shaped app → **[Kamal](https://kamal-deploy.org)**.
-1-10 hosts, multi-service, want drift detection / per-tier networks / k9s-style TUI → **yoink**.
+1-10 hosts, multi-service, want a web UI + agents on each host → **[Komodo](https://komo.do)**.
+1-10 hosts, multi-service, want a single binary with no control plane → **yoink**.
 Many hosts, autoscaling, multi-tenant, "real" infrastructure team → **Kubernetes**.
 {{< /callout >}}
 
@@ -40,6 +41,31 @@ Kamal is the closest neighbor — both are "ship a Rust/Ruby binary, ssh into ho
 **Pick Kamal when**: you have a Rails/Phoenix/Hanami app, you want one tool that builds + deploys + routes, and you don't need replicas or per-tier network isolation.
 
 **Pick yoink when**: you've got several services with different shapes (Rust API + Node web + Caddy + Postgres), you want drift detection and a k9s-style TUI for inspect/rollback, and you're willing to bring your own reverse proxy. Or when you want the no-registry, no-CI standalone loop for a hobby project.
+
+## vs. [Komodo](https://komo.do)
+
+Komodo is a fellow Rust-built deploy/management tool for self-hosted containers, with a sizable feature overlap with yoink. The biggest split is **ceremony**: Komodo is a long-running web service with a control plane and per-host agents; yoink is a single binary you run from your laptop or CI.
+
+| | **yoink** | **Komodo** |
+|---|---|---|
+| Architecture | Single Rust binary, runs on demand | `Komodo Core` (web service + UI) + `Komodo Periphery` (agent on every managed host) |
+| Always-on services to operate | None | Two: Core (with a database — MongoDB or FerretDB) + Periphery on each host |
+| Operator interface | CLI + TUI (k9s-style, keyboard-only) | Web UI (primary) + CLI/API |
+| State of truth | The git repo's `yoink.yaml` | Komodo's database (UI-edited, with optional GitOps "Resource Sync" file imports) |
+| Deploy trigger | `yoink up` from operator's laptop or CI | Click in the UI, webhook, scheduled, or sync-from-git |
+| Multi-user / RBAC | None — operator-as-user | First-class users, groups, permissions |
+| Auth | Whatever ssh + git + your secret store gives you | OAuth (GitHub / Google) + local accounts, baked in |
+| Bring-your-own-host | yoink connects to any host you can ssh into | Each host needs `Periphery` installed + reachable from Core |
+| Container shape | Yoink-managed containers via per-service spec | Stacks (compose files) / Deployments / Builds / Repos |
+| Drift detection | ✓ (`yoink.spec_hash` label) | ✓ (UI shows diff between desired and live) |
+| Reverse proxy | None — pairs with caddy / Traefik | None — same |
+| Healthcheck-gated rolling swap | ✓ | ✓ (compose-style) |
+| Audit log of who deployed what | git history of `yoink.yaml` + per-container deploy labels | First-class audit log in the database |
+| Best fit team size | 1–3 operators sharing a repo | 3+ operators, a team that benefits from a UI + RBAC |
+
+**Pick Komodo when**: you want a UI for non-CLI users, you're managing more hosts than fit in one operator's head, RBAC matters, and the overhead of running a database + a web service + per-host agents is worth it for the control-plane affordances.
+
+**Pick yoink when**: a single binary on your laptop is the entire control surface, the git repo is the source of truth, and you'd rather not operate yet another service-with-database to deploy your services. The CLI/TUI shape works best for 1–3 operators who are already comfortable in a terminal.
 
 ## vs. plain `docker compose`
 

--- a/docs/content/docs/intro/compared.md
+++ b/docs/content/docs/intro/compared.md
@@ -10,7 +10,8 @@ Yoink lives in a populated neighborhood. Pick the tool that fits your scale and 
 1 host, 1 app → **plain `docker compose`** is fine.
 1-3 hosts, Rails/Django/Phoenix-shaped app → **[Kamal](https://kamal-deploy.org)**.
 1-10 hosts, multi-service, want a web UI + agents on each host → **[Komodo](https://komo.do)**.
-1-10 hosts, multi-service, want a single binary with no control plane → **yoink**.
+1-10 hosts, multi-service, want a built-in WireGuard mesh + per-host daemon → **[Uncloud](https://uncloud.run)**.
+1-10 hosts, multi-service, want a single binary with no control plane and no agents → **yoink**.
 Many hosts, autoscaling, multi-tenant, "real" infrastructure team → **Kubernetes**.
 {{< /callout >}}
 
@@ -66,6 +67,27 @@ Komodo is a fellow Rust-built deploy/management tool for self-hosted containers,
 **Pick Komodo when**: you want a UI for non-CLI users, you're managing more hosts than fit in one operator's head, RBAC matters, and the overhead of running a database + a web service + per-host agents is worth it for the control-plane affordances.
 
 **Pick yoink when**: a single binary on your laptop is the entire control surface, the git repo is the source of truth, and you'd rather not operate yet another service-with-database to deploy your services. The CLI/TUI shape works best for 1–3 operators who are already comfortable in a terminal.
+
+## vs. [Uncloud](https://uncloud.run)
+
+Uncloud is in the same neighborhood as yoink — small fleet, multi-service, deliberate-not-Kubernetes. The biggest split is again **ceremony**: Uncloud installs a per-host daemon (`uncloudd`) on every managed machine and stitches them into a WireGuard mesh; yoink is a one-binary client that talks to docker over plain ssh.
+
+| | **yoink** | **Uncloud** |
+|---|---|---|
+| Architecture | Single client binary; talks to docker on each host over ssh | Per-host daemon (`uncloudd`) on every managed machine, peer-to-peer (no master) |
+| Always-on services to operate | None | One daemon per host (auto-installed by `uncloud machine init`) |
+| Cross-host networking | None — yoink relies on docker's per-host networks; cross-host is your routing problem (Tailscale, public DNS, …) | First-class — Uncloud builds a WireGuard mesh between machines, services dial each other by name across hosts |
+| Reverse proxy / public ingress | None — pairs with caddy / Traefik / your own | First-class — built-in Caddy-based ingress with auto-TLS |
+| State of truth | The git repo's `yoink.yaml` | Cluster state lives in the daemon mesh; YAML config is also supported |
+| Drift detection | ✓ (`yoink.spec_hash` label) | ✓ (compares running state to declared spec) |
+| Multi-host service replicas | ✓ (per-host counts, `services[].hosts:` whitelist) | ✓ (cluster-aware scheduling) |
+| Onboarding a new host | Already works if you can ssh into it | `uncloud machine init` to install + join the mesh |
+| What yoink leaves to other tools that Uncloud bundles | cross-host networking, ingress / TLS | — |
+| Best fit | "I have ssh access to my hosts and want a deploy tool that respects that" | "I want a self-hosted lightweight cluster with mesh + ingress baked in" |
+
+**Pick Uncloud when**: cross-host service-to-service networking matters (your api on one box talking to your worker on another), you'd rather have ingress + auto-TLS bundled than wire it up yourself, and you're OK with running a daemon per host as the price of those affordances.
+
+**Pick yoink when**: you already have a routing answer (Tailscale, a single edge box running caddy, public-DNS-everywhere), you don't want any always-on yoink-specific service running on the host, and the per-host docker daemon over ssh is enough surface area to manage from. The two tools converge on "small fleet of containers, opinionated defaults" — diverge on whether the deploy tool also owns the network fabric.
 
 ## vs. plain `docker compose`
 


### PR DESCRIPTION
Adds two close peers to the comparison page:

- **[Komodo](https://komo.do)** — Rust-built, web UI + database + Periphery agents. Closest peer feature-wise; biggest split is ceremony (long-running services + DB vs. single binary).
- **[Uncloud](https://uncloud.run)** — small-fleet container orchestrator with a per-host daemon and WireGuard mesh. Same audience as yoink; biggest split is whether the deploy tool also owns the network fabric (Uncloud yes, yoink no).

Each gets a side-by-side table covering the dimensions an operator would actually weigh: architecture, always-on services, source of truth, what is bundled vs. left to other tools, best-fit team size. Closes with the symmetric `Pick X when / Pick yoink when` framing the rest of the page uses.

Quick decision tree at the top of the page gains a line for each.

## Test plan

- [x] Local hugo build clean
- [ ] Live preview after merge