### PR TITLE
feat(proxy): bundled Caddy with admin-API push (replaces caddy-docker-proxy)

### DIFF
--- a/docs/content/docs/guide/pairing.md
+++ b/docs/content/docs/guide/pairing.md
@@ -1,9 +1,13 @@
 ---
-title: Pairing with Tailscale + caddy-docker-proxy
-weight: 4
+title: Pairing with Tailscale
+weight: 5
 ---
 
-`yoink` doesn't try to solve "how do I reach my hosts" or "how do I route HTTPS to the right container". It expects you to bring two off-the-shelf tools that solve those completely.
+`yoink` doesn't try to solve "how do I reach my hosts." It expects you to bring an off-the-shelf SSH connectivity layer.
+
+{{< callout type="info" >}}
+**Routing changed:** earlier versions of yoink documented [caddy-docker-proxy](https://github.com/lucaslorentz/caddy-docker-proxy) as the routing pairing. **That's been replaced** by yoink's [first-class reverse proxy integration](/docs/guide/proxy) (admin-API push, deterministic deploy timing, no Docker labels). The CDP path still works — it's just no longer the recommended pattern. Migrate by removing `caddy.*` labels from services, adding `domain:` to each, and `proxy.email:` at the top level.
+{{< /callout >}}
 
 ## Tailscale for SSH (the connectivity layer)
 
@@ -16,32 +20,21 @@ Yoink's transport is `ssh://user@host` via [bollard's SSH transport](https://doc
 
 The deploy user on each host is in the `docker` group (functionally root, scope your tailnet ACLs accordingly).
 
-## caddy-docker-proxy for the public surface
+## Routing
 
-Yoink owns the container lifecycle. **It does not own routing.** Public traffic landing on your hosts wants:
-
-- TLS termination (with auto-renewing certs)
-- Hostname → container routing
-- Per-route headers, redirects, rate limits
-
-[caddy-docker-proxy](https://github.com/lucaslorentz/caddy-docker-proxy) is a Caddy plugin that watches the Docker socket for container labels and reconfigures itself live. The pairing:
+For HTTPS termination + hostname routing, yoink ships a [bundled Caddy reverse proxy](/docs/guide/proxy). One field on a service:
 
 ```yaml
 services:
   - name: api
     image: ghcr.io/you/api
-    labels:
-      caddy: api.example.com
-      caddy.reverse_proxy: "{{upstreams 8080}}"
-    run:
-      port: 8080
-      replicas: 2
-      networks: [public, api]
+    domain: api.example.com
+    run: { port: 8080 }
+proxy:
+  email: ops@example.com
 ```
 
-`yoink up` deploys the api container with those labels; the caddy container (also yoink-managed, but separately) reads them via the docker socket and routes `https://api.example.com` to the api containers, automatically picking up new replicas and dropping retired ones. Cert issuance is Caddy's job (Let's Encrypt or Cloudflare origin); yoink doesn't know it's happening.
-
-Replicas plug into this naturally: `caddy.reverse_proxy: "{{upstreams 8080}}"` resolves all containers with the same network alias and round-robins between them. yoink's healthcheck-gated rolling swap means the caddy upstream pool is always traffic-ready.
+ACME issuance, rolling-deploy-synchronized routing flips, and per-service `caddy_extra_json:` for advanced features (auth, rate limit, headers) are all built in. See the [proxy guide](/docs/guide/proxy) and the [Cloudflare Origin Certs recipe](/docs/recipes/cloudflare-origin-certs).
 
 ## The split
 
@@ -50,8 +43,8 @@ Replicas plug into this naturally: `caddy.reverse_proxy: "{{upstreams 8080}}"` r
 | **container lifecycle** (pull, start, healthcheck, drain, replace) | yoink |
 | **dep-ordered deploys** (redis before api before caddy) | yoink |
 | **per-tier network isolation** | yoink |
-| **HTTPS / hostname routing / cert renewal** | caddy-docker-proxy |
-| **operator → host connectivity** | Tailscale |
-| **CI → host connectivity** | Tailscale |
+| **HTTPS / hostname routing / cert issuance** | yoink (bundled Caddy) |
+| **operator → host connectivity** | Tailscale (or your SSH config) |
+| **CI → host connectivity** | Tailscale (or your SSH config) |
 | **stateful services** (postgres, etc.) | docker compose on the host |
-| **secrets** | Infisical (REST API, no CLI install needed) |
+| **secrets** | yoink (age-sealed) or Infisical |

--- a/docs/content/docs/guide/proxy.md
+++ b/docs/content/docs/guide/proxy.md
@@ -49,9 +49,36 @@ Containers are named in upstream entries (not IPs), so a container restart with 
 | Field | Type | Default | Notes |
 |---|---|---|---|
 | `enabled` | bool | implicit when any service has `domain:` | |
-| `email` | string | — | Let's Encrypt registration email. **Required when any service uses `tls: auto`.** |
+| `email` | string | — | Let's Encrypt registration email. **Required when any service uses `tls: auto`.** Unused when `proxy.tls:` is set. |
 | `image` | string | `caddy:2` | Override to use an [`xcaddy`](https://github.com/caddyserver/xcaddy)-built image with plugins (rate-limit, l4, redis-storage, …). |
 | `cert_volume` | string | `yoink_caddy_data` | Named volume for ACME state and certs. Persisted across proxy restarts. |
+| `tls` | block (see below) | — | Proxy-level TLS — every routed service inherits this cert (and optional mTLS) by default. |
+
+### `proxy.tls:` block
+
+When set, all routed services use the same TLS config by default. Per-service `tls_cert_secret:` / `tls_key_secret:` overrides for the rare different-cert-per-service case. ACME is implicitly off and a `:80 → :443` redirect is auto-emitted.
+
+| Field | Type | Default | Notes |
+|---|---|---|---|
+| `cert_secret` | string | required | Sealed-secret name holding the PEM cert (full chain). |
+| `key_secret` | string | required | Sealed-secret name holding the PEM private key. |
+| `client_auth` | block | — | Optional mTLS (e.g. Cloudflare origin-pull). |
+| `client_auth.mode` | enum | `require_and_verify` | `request` / `require` / `verify_if_given` / `require_and_verify`. |
+| `client_auth.trust_pool_secret` | string | required (when `client_auth` set) | Sealed-secret name holding the trust-pool CA bundle (PEM). |
+
+Common shape:
+
+```yaml
+proxy:
+  tls:
+    cert_secret: CF_ORIGIN_CERT
+    key_secret:  CF_ORIGIN_KEY
+    client_auth:
+      mode: require_and_verify
+      trust_pool_secret: CF_ORIGIN_PULL_CA
+```
+
+This is the Cloudflare-style "every route is an origin behind Cloudflare's edge with mTLS proving the request came from Cloudflare" pattern. No host-filesystem cert state — everything lives in `secrets.age` (or Infisical), encrypted at rest.
 
 That's the full surface. Five service-level fields, four proxy-level fields. Anything beyond that is `caddy_extra_json:` or a custom proxy image.
 

--- a/docs/content/docs/guide/proxy.md
+++ b/docs/content/docs/guide/proxy.md
@@ -37,10 +37,16 @@ Containers are named in upstream entries (not IPs), so a container restart with 
 | Field | Type | Default | Notes |
 |---|---|---|---|
 | `domain` | string \| list | — | Hostname(s); presence enables proxying. |
+| `path_prefix` | string | — | Match this path glob in addition to `domain:` so multiple services can share a hostname. Yoink orders routes so path-constrained ones come before catch-alls. |
 | `tls` | `auto` \| `off` \| `cert` | `auto` | `auto` = ACME via Let's Encrypt. `off` = HTTP only. `cert` = inline cert from sealed secrets. |
 | `tls_cert_secret` | string | — | Sealed-secret name holding the PEM cert (for `tls: cert`). |
 | `tls_key_secret` | string | — | Sealed-secret name holding the PEM private key (for `tls: cert`). |
-| `caddy_extra_json` | string (JSON) | — | Raw Caddy handler JSON merged into this site's route, before the auto-generated `reverse_proxy`. Escape hatch for advanced features (auth, rate limit, headers). |
+| `upstream_h2c` | bool | `false` | Talk to backend over HTTP/2 cleartext. Required for native gRPC backends (Tonic, grpc-go, grpc-java). |
+| `compression` | bool | `false` | Emit `encode gzip zstd`. No-op behind a CDN. |
+| `canonical_domain` | string | — | One of the `domain:` entries. Yoink 308-redirects every other entry to it (apex/www patterns). |
+| `hsts` | bool | `true` for TLS sites | Emit `Strict-Transport-Security: max-age=31536000; includeSubDomains`. Default-on best practice. |
+| `caddy_extra_json` | string (JSON) | — | Raw Caddy handler JSON merged into the route. Routes auto-wrapped in `subroute`. See the [snippets cookbook](/docs/recipes/caddy-snippets). |
+| `caddy_extra_caddyfile` | string (Caddyfile) | — | Same as above but in Caddyfile syntax. Yoink shells out to `caddy adapt` at render time (needs docker on operator). Mutually exclusive with `caddy_extra_json:`. |
 
 `run.port:` is required when `domain:` is set — the proxy needs to know which container port to forward to. `run.healthcheck_path:` (if set) is reused as Caddy's active health check URI.
 
@@ -52,6 +58,7 @@ Containers are named in upstream entries (not IPs), so a container restart with 
 | `email` | string | — | Let's Encrypt registration email. **Required when any service uses `tls: auto`.** Unused when `proxy.tls:` is set. |
 | `image` | string | `caddy:2` | Override to use an [`xcaddy`](https://github.com/caddyserver/xcaddy)-built image with plugins (rate-limit, l4, redis-storage, …). |
 | `cert_volume` | string | `yoink_caddy_data` | Named volume for ACME state and certs. Persisted across proxy restarts. |
+| `bind` | string | — (all interfaces) | Host IP to bind `:80` and `:443` to. Common use: bind to a Tailscale IP so the proxy is reachable only over the tailnet. Admin port stays on `127.0.0.1` regardless. |
 | `tls` | block (see below) | — | Proxy-level TLS — every routed service inherits this cert (and optional mTLS) by default. |
 
 ### `proxy.tls:` block

--- a/docs/content/docs/guide/proxy.md
+++ b/docs/content/docs/guide/proxy.md
@@ -1,0 +1,129 @@
+---
+title: Reverse proxy
+weight: 4
+---
+
+Yoink bundles **Caddy** as a managed proxy service. One field on a service exposes it on a domain with TLS:
+
+```yaml
+services:
+  - name: api
+    image: ghcr.io/me/api
+    tag: v1
+    domain: api.example.com         # ← that's the whole opt-in
+    run:
+      port: 8080
+proxy:
+  email: ops@example.com            # required for Let's Encrypt
+```
+
+`yoink up`. Caddy is reconciled. App is reconciled. TLS is issued. Routing works.
+
+## How it works
+
+When any service has `domain:` set, yoink synthesizes a `yoink-proxy` service running `caddy:2` and renders its config from your `yoink.yaml`. The config is pushed via Caddy's admin API at deterministic points in the rolling deploy — yoink owns the routing flip, no Docker-label fights with a separate reconciler.
+
+Two Docker networks are managed for you:
+
+- **`yoink-ingress`** — proxy joins this; every service with `domain:` joins this. How the proxy reaches your containers by name.
+- **`yoink-proxy-admin`** — the proxy's admin API listens here. Never published to the host or the public internet; yoink reaches it via SSH-tunneled access for the duration of one `/load` call.
+
+Containers are named in upstream entries (not IPs), so a container restart with a new IP doesn't break routing — Docker DNS handles it. Caddy active health checks remove dead backends from rotation.
+
+## Schema
+
+### Per service
+
+| Field | Type | Default | Notes |
+|---|---|---|---|
+| `domain` | string \| list | — | Hostname(s); presence enables proxying. |
+| `tls` | `auto` \| `off` \| `cert` | `auto` | `auto` = ACME via Let's Encrypt. `off` = HTTP only. `cert` = inline cert from sealed secrets. |
+| `tls_cert_secret` | string | — | Sealed-secret name holding the PEM cert (for `tls: cert`). |
+| `tls_key_secret` | string | — | Sealed-secret name holding the PEM private key (for `tls: cert`). |
+| `caddy_extra_json` | string (JSON) | — | Raw Caddy handler JSON merged into this site's route, before the auto-generated `reverse_proxy`. Escape hatch for advanced features (auth, rate limit, headers). |
+
+`run.port:` is required when `domain:` is set — the proxy needs to know which container port to forward to. `run.healthcheck_path:` (if set) is reused as Caddy's active health check URI.
+
+### Top-level `proxy:` block
+
+| Field | Type | Default | Notes |
+|---|---|---|---|
+| `enabled` | bool | implicit when any service has `domain:` | |
+| `email` | string | — | Let's Encrypt registration email. **Required when any service uses `tls: auto`.** |
+| `image` | string | `caddy:2` | Override to use an [`xcaddy`](https://github.com/caddyserver/xcaddy)-built image with plugins (rate-limit, l4, redis-storage, …). |
+| `cert_volume` | string | `yoink_caddy_data` | Named volume for ACME state and certs. Persisted across proxy restarts. |
+
+That's the full surface. Five service-level fields, four proxy-level fields. Anything beyond that is `caddy_extra_json:` or a custom proxy image.
+
+## Cert volume — keep it
+
+The `yoink_caddy_data` named volume holds your ACME state, issued certs, and OCSP staples. Don't delete it casually — Let's Encrypt rate-limits aggressively (5 duplicate-cert issuances per week) and a fresh volume = re-issuance.
+
+`yoink prune` won't touch the volume. Manually purging it is on you.
+
+## Rolling deploys with zero traffic loss
+
+Per service deploy:
+
+1. New replica starts.
+2. Yoink waits for its healthcheck.
+3. Yoink pushes updated Caddy config (`/load`) — new replica added to upstream pool.
+4. Caddy gracefully reloads in-process; no in-flight requests dropped.
+5. Old replica stops.
+6. Caddy active health check notices the old upstream is gone and removes it.
+
+Every step is yoink-driven; no second reconciler. The config push happens only when the *set* of containers changes — exactly when yoink is in the loop.
+
+## What yoink doesn't model
+
+Auth, rate limiting, headers, CORS, redirects, mTLS, geo-blocking, WAF, L4/TCP routing — none of these are in yoink's schema. They live in `caddy_extra_json:` using Caddy's [JSON config syntax](https://caddyserver.com/docs/json/apps/http/servers/routes/handle/), which is what Caddy's docs use directly. The escape hatch is the *advertised* path for these — yoink models deploy primitives, Caddy models traffic handling.
+
+### Example: `forward_auth` to Authelia
+
+```yaml
+services:
+  - name: authelia
+    image: authelia/authelia
+    domain: auth.example.com
+    run: { port: 9091 }
+
+  - name: internal-app
+    image: ghcr.io/me/internal
+    domain: app.example.com
+    caddy_extra_json: |
+      [
+        {
+          "handler": "forward_auth",
+          "upstreams": [{"dial": "authelia:9091"}],
+          "uri": "/api/verify?rd=https://auth.example.com",
+          "copy_headers": ["Remote-User", "Remote-Groups", "Remote-Email"]
+        }
+      ]
+    run: { port: 3000 }
+```
+
+### Example: rate limit (requires `caddy-ratelimit` plugin)
+
+```yaml
+proxy:
+  image: ghcr.io/me/caddy-with-ratelimit:2.7   # xcaddy build
+  email: ops@example.com
+
+services:
+  - name: public-api
+    domain: api.example.com
+    caddy_extra_json: |
+      [
+        {
+          "handler": "rate_limit",
+          "zones": {"api": {"key": "{remote_host}", "events": 100, "window": "1m"}}
+        }
+      ]
+    run: { port: 8080 }
+```
+
+## What's next
+
+- [Cloudflare Origin Certificates](/docs/recipes/cloudflare-origin-certs) — skip Let's Encrypt entirely with a 15-year cert from Cloudflare, sealed in the repo.
+- [Multi-host LE with Redis storage](/docs/recipes/multi-host-redis-storage) — share ACME state across hosts so they don't all hit Let's Encrypt rate limits.
+- [Caddy JSON config reference](https://caddyserver.com/docs/json/) — for `caddy_extra_json:` snippets.

--- a/docs/content/docs/guide/proxy.md
+++ b/docs/content/docs/guide/proxy.md
@@ -3,21 +3,40 @@ title: Reverse proxy
 weight: 4
 ---
 
-Yoink bundles **Caddy** as a managed proxy service. One field on a service exposes it on a domain with TLS:
+Yoink bundles **Caddy** as a managed proxy service. One field exposes a service on a domain with TLS — yoink runs Caddy, renders its config from your `yoink.yaml`, issues certs via Let's Encrypt, and routes traffic to your container.
+
+## TL;DR
 
 ```yaml
+# yoink.yaml
+hosts:
+  - { address: 1.2.3.4, user: root }
+
+proxy:
+  email: ops@example.com           # for Let's Encrypt registration
+
 services:
   - name: api
     image: ghcr.io/me/api
     tag: v1
-    domain: api.example.com         # ← that's the whole opt-in
+    domain: api.example.com        # ← the whole proxy opt-in
     run:
       port: 8080
-proxy:
-  email: ops@example.com            # required for Let's Encrypt
+      healthcheck_path: /health
 ```
 
-`yoink up`. Caddy is reconciled. App is reconciled. TLS is issued. Routing works.
+Point `api.example.com` DNS at `1.2.3.4`. Run `yoink up`. Done — `https://api.example.com` serves with a valid cert.
+
+That's the floor. The rest of this page is reference + advanced patterns.
+
+{{< callout type="info" >}}
+**Recipes for advanced setups** are split into focused pages:
+
+- [Cloudflare Origin Certificates](/docs/recipes/cloudflare-origin-certs) — skip Let's Encrypt with a 15-year cert + origin-pull mTLS that locks your origin to Cloudflare's edge.
+- [gRPC hosting](/docs/recipes/grpc-hosting) — `upstream_h2c: true` for native gRPC backends (Tonic, grpc-go, grpc-java).
+- [Caddy snippets cookbook](/docs/recipes/caddy-snippets) — copy-paste recipes for forward_auth, basic_auth, IP allowlists, headers, redirects, body limits.
+- [Multi-host Let's Encrypt with Redis storage](/docs/recipes/multi-host-redis-storage) — share ACME state across hosts to avoid rate limits.
+{{< /callout >}}
 
 ## How it works
 

--- a/docs/content/docs/recipes/caddy-snippets.md
+++ b/docs/content/docs/recipes/caddy-snippets.md
@@ -1,0 +1,251 @@
+---
+title: Caddy snippets cookbook
+weight: 12
+---
+
+`caddy_extra_json:` (and `caddy_extra_caddyfile:`) are yoink's escape hatch for Caddy features that aren't deploy primitives — auth, rate limiting, headers, redirects, IP allowlists, body limits, etc. Yoink models the routing graph; Caddy models the traffic handling. This page is the lookup table for the most common patterns.
+
+Each recipe shows:
+
+- **Caddyfile** — what you'd write in vanilla Caddy / `caddy_extra_caddyfile:`. Friendlier syntax; what Caddy's own docs use.
+- **JSON** — the equivalent for `caddy_extra_json:`. Lower-level; what Caddy's admin API consumes.
+- **Yoink config** — the smallest service block that uses the snippet.
+
+Both forms work on vanilla `caddy:2` — no plugins required unless noted.
+
+{{< callout type="info" >}}
+**Caddyfile vs JSON**: pick whichever you prefer. `caddy_extra_caddyfile:` shells out to `caddy adapt` at render time (requires docker on the operator's machine; one-time pull). `caddy_extra_json:` is parsed inline (no docker dep at render time). They're mutually exclusive on a single service.
+{{< /callout >}}
+
+## Forward auth → Authelia / Authentik / oauth2-proxy
+
+Gates every request to this service through an auth-decision endpoint on another service. Standard pattern for SSO over self-hosted apps.
+
+**Caddyfile:**
+```yaml
+caddy_extra_caddyfile: |
+  forward_auth authelia:9091 {
+    uri /api/verify?rd=https://auth.example.com
+    copy_headers Remote-User Remote-Groups Remote-Email Remote-Name
+  }
+```
+
+**JSON:**
+```yaml
+caddy_extra_json: |
+  [{
+    "handler": "forward_auth",
+    "upstreams": [{"dial": "authelia:9091"}],
+    "uri": "/api/verify?rd=https://auth.example.com",
+    "copy_headers": ["Remote-User", "Remote-Groups", "Remote-Email", "Remote-Name"]
+  }]
+```
+
+**Service:**
+```yaml
+- name: internal-app
+  image: ghcr.io/me/internal
+  domain: app.example.com
+  caddy_extra_caddyfile: |
+    forward_auth authelia:9091 { ... }
+  run: { port: 3000 }
+```
+
+## Basic auth (single user)
+
+For a quick admin page or dashboard. Caddy hashes the password with bcrypt at config-load.
+
+**Caddyfile:**
+```yaml
+caddy_extra_caddyfile: |
+  basic_auth /* {
+    admin $2a$14$ABCDEFG...   # bcrypt hash from `caddy hash-password`
+  }
+```
+
+**JSON:**
+```yaml
+caddy_extra_json: |
+  [{
+    "handler": "authentication",
+    "providers": {
+      "http_basic": {
+        "accounts": [
+          {"username": "admin", "password": "$2a$14$ABCDEFG..."}
+        ]
+      }
+    }
+  }]
+```
+
+Generate the hash:
+```sh
+docker run --rm caddy:2 caddy hash-password --plaintext 'your-password'
+```
+
+## IP allowlist
+
+Restrict access to a set of IPs (CIDR ranges OK). Common pattern for tailnet-only routes.
+
+**Caddyfile:**
+```yaml
+caddy_extra_caddyfile: |
+  @internal client_ip 100.64.0.0/10 192.168.1.0/24
+  handle @internal {
+    # request continues to reverse_proxy below
+  }
+  handle {
+    respond "Forbidden" 403
+  }
+```
+
+**JSON:**
+```yaml
+caddy_extra_json: |
+  [{
+    "match": [{"not": [{"client_ip": {"ranges": ["100.64.0.0/10", "192.168.1.0/24"]}}]}],
+    "handle": [{"handler": "static_response", "status_code": 403, "body": "Forbidden"}],
+    "terminal": true
+  }]
+```
+
+## Custom request / response headers
+
+Strip a sensitive header before it reaches the upstream, or add one to the response.
+
+**Caddyfile:**
+```yaml
+caddy_extra_caddyfile: |
+  request_header -X-Internal-Token
+  header X-Frame-Options "DENY"
+  header X-Content-Type-Options "nosniff"
+  header Referrer-Policy "strict-origin-when-cross-origin"
+```
+
+**JSON:**
+```yaml
+caddy_extra_json: |
+  [
+    {
+      "handler": "headers",
+      "request": {"delete": ["X-Internal-Token"]}
+    },
+    {
+      "handler": "headers",
+      "response": {
+        "set": {
+          "X-Frame-Options": ["DENY"],
+          "X-Content-Type-Options": ["nosniff"],
+          "Referrer-Policy": ["strict-origin-when-cross-origin"]
+        }
+      }
+    }
+  ]
+```
+
+(Yoink already emits `Strict-Transport-Security` for TLS sites by default — see `hsts:` in the [proxy guide](/docs/guide/proxy).)
+
+## Request body size limit
+
+Block oversized request bodies before they reach the upstream.
+
+**Caddyfile:**
+```yaml
+caddy_extra_caddyfile: |
+  request_body {
+    max_size 10MB
+  }
+```
+
+**JSON:**
+```yaml
+caddy_extra_json: |
+  [{
+    "handler": "request_body",
+    "max_size": 10485760
+  }]
+```
+
+## Redirect a specific path
+
+Permanent redirect of a specific URL to another. (For full canonical-domain redirects use the `canonical_domain:` field instead.)
+
+**Caddyfile:**
+```yaml
+caddy_extra_caddyfile: |
+  redir /old-path /new-path 308
+```
+
+**JSON:**
+```yaml
+caddy_extra_json: |
+  [{
+    "match": [{"path": ["/old-path"]}],
+    "handle": [{
+      "handler": "static_response",
+      "status_code": 308,
+      "headers": {"Location": ["/new-path"]}
+    }],
+    "terminal": true
+  }]
+```
+
+## Maintenance page
+
+Force every request to a holding page for the duration of a maintenance window.
+
+**Caddyfile:**
+```yaml
+caddy_extra_caddyfile: |
+  respond "Backtrack is undergoing scheduled maintenance. Back at 14:00 UTC." 503
+```
+
+**JSON:**
+```yaml
+caddy_extra_json: |
+  [{
+    "handler": "static_response",
+    "status_code": 503,
+    "body": "Backtrack is undergoing scheduled maintenance. Back at 14:00 UTC.",
+    "headers": {"Content-Type": ["text/plain; charset=utf-8"]}
+  }]
+```
+
+## Plugins (custom Caddy image required)
+
+These need an `xcaddy`-built image — set `proxy.image:` to your custom build.
+
+### Rate limiting (`caddy-ratelimit`)
+
+```dockerfile
+FROM caddy:2-builder AS builder
+RUN xcaddy build --with github.com/mholt/caddy-ratelimit
+FROM caddy:2
+COPY --from=builder /usr/bin/caddy /usr/bin/caddy
+```
+
+```yaml
+proxy:
+  image: ghcr.io/me/caddy-ratelimit:2.7
+  email: ops@example.com
+
+services:
+  - name: public-api
+    domain: api.example.com
+    caddy_extra_json: |
+      [{
+        "handler": "rate_limit",
+        "zones": {"api": {"key": "{remote_host}", "events": 100, "window": "1m"}}
+      }]
+    run: { port: 8080 }
+```
+
+### Multi-host LE certs (`caddy-storage-redis`)
+
+See the [Multi-host Redis storage recipe](/docs/recipes/multi-host-redis-storage) — also needs an xcaddy image.
+
+## See also
+
+- [Reverse proxy guide](/docs/guide/proxy) — full schema reference for the routing primitives yoink models.
+- [Caddy JSON config docs](https://caddyserver.com/docs/json/apps/http/servers/routes/handle/) — exhaustive reference for handler shapes.
+- [Caddyfile docs](https://caddyserver.com/docs/caddyfile) — for `caddy_extra_caddyfile:` syntax.

--- a/docs/content/docs/recipes/caddy-snippets.md
+++ b/docs/content/docs/recipes/caddy-snippets.md
@@ -197,7 +197,7 @@ Force every request to a holding page for the duration of a maintenance window.
 **Caddyfile:**
 ```yaml
 caddy_extra_caddyfile: |
-  respond "Backtrack is undergoing scheduled maintenance. Back at 14:00 UTC." 503
+  respond "This service is undergoing scheduled maintenance. Back at 14:00 UTC." 503
 ```
 
 **JSON:**
@@ -206,7 +206,7 @@ caddy_extra_json: |
   [{
     "handler": "static_response",
     "status_code": 503,
-    "body": "Backtrack is undergoing scheduled maintenance. Back at 14:00 UTC.",
+    "body": "This service is undergoing scheduled maintenance. Back at 14:00 UTC.",
     "headers": {"Content-Type": ["text/plain; charset=utf-8"]}
   }]
 ```

--- a/docs/content/docs/recipes/cloudflare-origin-certs.md
+++ b/docs/content/docs/recipes/cloudflare-origin-certs.md
@@ -1,0 +1,86 @@
+---
+title: Cloudflare Origin Certificates
+weight: 10
+---
+
+If you're already on Cloudflare's edge, **Origin Certificates** are the simplest TLS story for your origin servers: free, valid for 15 years, no ACME, no Let's Encrypt rate limits, no port-80 reachability requirement. Yoink supports them out of the box.
+
+## Why this and not Let's Encrypt?
+
+- **No rate limits.** LE caps you to 5 duplicate certs / week / domain. With multi-host and forgetful redeploys, hitting that is easy.
+- **No port-80 / DNS-01 dance.** Origin certs are issued out-of-band from Cloudflare's dashboard.
+- **15-year validity.** Set a calendar reminder, rotate quarterly, never think about it.
+- **Works with locked-down origins.** Your origin can be on a private network, behind WAF rules, etc. — only Cloudflare's edge needs to reach it, and it does so via TLS on port 443 using the origin cert.
+
+The downside: only Cloudflare-fronted clients trust the cert. That's the point — origin certs are not for direct browser access.
+
+## One-time setup (Cloudflare dashboard)
+
+1. Log into Cloudflare → your zone → SSL/TLS → Origin Server.
+2. Click **Create Certificate**. Defaults are fine: ECC, 15 years, hostnames `*.example.com` + `example.com` (or list each host explicitly).
+3. Copy the **Origin Certificate** (PEM, full chain) and the **Private Key**.
+
+## Add the secrets to `secrets.age`
+
+```sh
+yoink secrets edit
+```
+
+In the editor, add:
+
+```dotenv
+CF_ORIGIN_CERT=-----BEGIN CERTIFICATE-----
+MIIE...
+-----END CERTIFICATE-----
+CF_ORIGIN_KEY=-----BEGIN PRIVATE KEY-----
+MIIE...
+-----END PRIVATE KEY-----
+```
+
+Save and exit. The values land in `secrets.age` (committed to the repo, encrypted).
+
+## Wire it up in `yoink.yaml`
+
+```yaml
+services:
+  - name: api
+    image: ghcr.io/me/api
+    tag: v1
+    domain: api.example.com
+    tls: cert                              # ← skip ACME, use the inline cert
+    tls_cert_secret: CF_ORIGIN_CERT
+    tls_key_secret: CF_ORIGIN_KEY
+    run:
+      port: 8080
+```
+
+Note: `proxy.email:` isn't required when no service uses `tls: auto`. The proxy block can be empty (or omitted entirely).
+
+## Cloudflare side
+
+Make sure the zone's SSL mode is **Full (strict)** (Cloudflare → SSL/TLS → Overview). This is what asks Cloudflare to validate the origin cert.
+
+## Rotation
+
+Origin certs are good for 15 years, but you'll probably want to rotate every 1–3 years anyway. When the time comes:
+
+1. Generate a new cert in Cloudflare's dashboard.
+2. `yoink secrets edit`, paste the new values into `CF_ORIGIN_CERT` + `CF_ORIGIN_KEY`.
+3. `git commit -am 'rotate cf origin cert'`.
+4. `yoink up`.
+
+Yoink notices the cert bytes have changed (via the proxy's spec hash including the cert reference labels), redeploys the proxy container (~10s), and the new cert is live.
+
+For zero-downtime rotation, use `yoink up --service yoink-proxy` from one host at a time if you're multi-host.
+
+## Multi-host
+
+Each host serves the same domain with the same cert — no Let's Encrypt rate-limit problem because no ACME is happening. Origin certs work the same on every host.
+
+The cert + key live in `secrets.age` (one copy in the repo). Every host's proxy reads it from the same source. No Redis, no shared storage needed.
+
+## See also
+
+- [Reverse proxy guide](/docs/guide/proxy) — full schema reference.
+- [Multi-host LE with Redis storage](/docs/recipes/multi-host-redis-storage) — for the Let's Encrypt path when you don't want to use Cloudflare.
+- [Cloudflare Origin CA docs](https://developers.cloudflare.com/ssl/origin-configuration/origin-ca/) — Cloudflare's side of the setup.

--- a/docs/content/docs/recipes/cloudflare-origin-certs.md
+++ b/docs/content/docs/recipes/cloudflare-origin-certs.md
@@ -41,6 +41,8 @@ Save and exit. The values land in `secrets.age` (committed to the repo, encrypte
 
 ## Wire it up in `yoink.yaml`
 
+**Single service, single cert** — per-service:
+
 ```yaml
 services:
   - name: api
@@ -54,7 +56,89 @@ services:
       port: 8080
 ```
 
-Note: `proxy.email:` isn't required when no service uses `tls: auto`. The proxy block can be empty (or omitted entirely).
+**Many services, one wildcard cert** (the common case — `*.example.com` covers everything) — proxy-level:
+
+```yaml
+proxy:
+  tls:
+    cert_secret: CF_ORIGIN_CERT
+    key_secret:  CF_ORIGIN_KEY
+
+services:
+  - name: api
+    domain: api.example.com
+    run: { port: 8080 }
+  - name: web
+    domain: example.com
+    run: { port: 3000 }
+  - name: admin
+    domain: admin.example.com
+    run: { port: 9090 }
+```
+
+Every routed service inherits the proxy-level cert. Per-service `tls_cert_secret:` still overrides for the rare different-cert case.
+
+Note: `proxy.email:` isn't required when no service uses `tls: auto`. ACME is implicitly off when `proxy.tls.cert_secret` is set.
+
+## Origin-pull mTLS (lock your origin to Cloudflare's edge)
+
+By default, anyone who knows your origin IP can hit it directly with a `Host:` header — bypassing Cloudflare's WAF, rate limits, bot blocks, etc. **Origin-pull mTLS** fixes that: the origin requires every request to present a Cloudflare-signed client certificate. Anything else gets a TLS handshake error.
+
+This is what backtrack runs in production.
+
+### One-time setup
+
+Cloudflare provides a static **Origin Pull CA bundle** that signs every cert their edge presents to your origin:
+
+1. Download the bundle from <https://developers.cloudflare.com/ssl/static/authenticated_origin_pull_ca.pem>.
+2. Add it to `secrets.age` alongside the cert/key:
+
+```dotenv
+CF_ORIGIN_PULL_CA=-----BEGIN CERTIFICATE-----
+<bundle contents>
+-----END CERTIFICATE-----
+```
+
+3. Enable Authenticated Origin Pulls in the Cloudflare dashboard: SSL/TLS → Origin Server → **Authenticated Origin Pulls** → toggle on.
+
+### `yoink.yaml`
+
+Add `client_auth:` to the `proxy.tls:` block:
+
+```yaml
+proxy:
+  tls:
+    cert_secret: CF_ORIGIN_CERT
+    key_secret:  CF_ORIGIN_KEY
+    client_auth:
+      mode: require_and_verify             # strict — reject anything not signed by the CA
+      trust_pool_secret: CF_ORIGIN_PULL_CA
+```
+
+That applies to **every** routed service. From now on, requests that don't come through Cloudflare are dropped at the TLS layer — your origin simply doesn't appear to exist for them.
+
+`mode:` options (default `require_and_verify`):
+
+- `require_and_verify` — strict; reject anything without a valid client cert. **Recommended.**
+- `require` — require a cert but skip verification (don't use this).
+- `verify_if_given` — accept anonymous; verify if present. Mixed-mode.
+- `request` — request but don't enforce. Almost never useful.
+
+### Verify
+
+After `yoink up`, this should fail (no client cert):
+
+```sh
+curl -v https://your-origin-ip/health -H 'Host: api.example.com'
+# → tls: handshake failure
+```
+
+This should succeed (through Cloudflare's edge):
+
+```sh
+curl https://api.example.com/health
+# → 200 OK
+```
 
 ## Cloudflare side
 

--- a/docs/content/docs/recipes/cloudflare-origin-certs.md
+++ b/docs/content/docs/recipes/cloudflare-origin-certs.md
@@ -84,8 +84,6 @@ Note: `proxy.email:` isn't required when no service uses `tls: auto`. ACME is im
 
 By default, anyone who knows your origin IP can hit it directly with a `Host:` header — bypassing Cloudflare's WAF, rate limits, bot blocks, etc. **Origin-pull mTLS** fixes that: the origin requires every request to present a Cloudflare-signed client certificate. Anything else gets a TLS handshake error.
 
-This is what backtrack runs in production.
-
 ### One-time setup
 
 Cloudflare provides a static **Origin Pull CA bundle** that signs every cert their edge presents to your origin:

--- a/docs/content/docs/recipes/grpc-hosting.md
+++ b/docs/content/docs/recipes/grpc-hosting.md
@@ -99,7 +99,7 @@ services:
       port: 50051
 ```
 
-This is the configuration backtrack uses today: Tonic + Axum behind Cloudflare with origin-pull mTLS, single `upstream_h2c: true` covers both gRPC and the REST surface.
+A common shape: Tonic + Axum behind Cloudflare with origin-pull mTLS — a single `upstream_h2c: true` covers both gRPC and the REST surface.
 
 ## See also
 

--- a/docs/content/docs/recipes/grpc-hosting.md
+++ b/docs/content/docs/recipes/grpc-hosting.md
@@ -1,0 +1,109 @@
+---
+title: gRPC hosting
+weight: 9
+---
+
+Native gRPC backends speak HTTP/2. To route gRPC traffic from clients (which terminate at Caddy with TLS) all the way through to the backend, Caddy needs to dial the upstream as **HTTP/2 cleartext** (h2c). One field in yoink turns this on:
+
+```yaml
+services:
+  - name: api
+    image: ghcr.io/me/grpc-api
+    tag: v1
+    domain: api.example.com
+    upstream_h2c: true            # ← that's it
+    run:
+      port: 50051
+```
+
+That's the whole opt-in. `yoink up`, point your gRPC client at `api.example.com:443`, done.
+
+## How it works
+
+Without `upstream_h2c:`, Caddy talks to the backend over HTTP/1.1. gRPC clients (which use HTTP/2 framing) send requests Caddy can't proxy correctly — you'll see `INTERNAL` errors or empty responses.
+
+`upstream_h2c: true` renders an HTTP/2-cleartext transport on the auto-generated `reverse_proxy` handler:
+
+```json
+{
+  "handler": "reverse_proxy",
+  "transport": {"protocol": "http", "versions": ["h2c"]},
+  "upstreams": [{"dial": "api:50051"}]
+}
+```
+
+Caddy's TLS termination on the public side stays HTTP/2 (h2 with ALPN). The h2c is purely how Caddy talks to your container on the internal docker network.
+
+## Mixed gRPC + HTTP/1.1 backends
+
+Servers that handle both gRPC and plain HTTP on the same port (Tonic + Axum, grpc-go + http.Handler, grpc-java + servlet) usually serve HTTP/1.1 requests over h2c just fine — HTTP/2 carries HTTP/1.1 semantics natively. **A single `upstream_h2c: true` covers both protocols** for these servers.
+
+If your backend rejects HTTP/1.1 over h2c (some older grpc-only servers do), you can still serve mixed traffic by routing only gRPC requests through h2c and everything else through HTTP/1.1, using `caddy_extra_caddyfile:`:
+
+```yaml
+services:
+  - name: api
+    image: ghcr.io/me/api
+    domain: api.example.com
+    caddy_extra_caddyfile: |
+      @grpc header Content-Type application/grpc*
+      reverse_proxy @grpc {
+        to api:50051
+        transport http {
+          versions h2c
+        }
+      }
+    # Yoink's auto-generated reverse_proxy (without h2c) handles
+    # everything else.
+    run:
+      port: 50051
+```
+
+## gRPC-Web
+
+Browsers can't speak native gRPC — they need [gRPC-Web](https://github.com/grpc/grpc-web), which uses HTTP/1.1 or HTTP/2 (no h2c required) plus a translation layer. Two options:
+
+- **Translation in your backend**: Tonic has [`tonic-web`](https://docs.rs/tonic-web/), grpc-go has [improbable-eng/grpc-web](https://github.com/improbable-eng/grpc-web/tree/master/go/grpcwebproxy). Backend speaks both gRPC and gRPC-Web on the same port. `upstream_h2c: true` on yoink covers both because gRPC-Web traffic is regular HTTP/1.1 over h2c.
+- **Caddy plugin**: there's a `caddy-grpc-web` plugin that translates at the proxy layer. Requires an [`xcaddy`](https://github.com/caddyserver/xcaddy)-built image; set `proxy.image:` to your build.
+
+## Reflection / grpcurl
+
+`grpcurl` works against `api.example.com:443` because it speaks gRPC over TLS. Verify with:
+
+```sh
+grpcurl api.example.com:443 list
+grpcurl api.example.com:443 grpc.health.v1.Health/Check
+```
+
+If your backend has reflection enabled, the `list` should print your service descriptors. If reflection is off, pass `-proto path/to/your.proto` instead.
+
+## Mutual TLS (Cloudflare origin-pull)
+
+If you're fronting via Cloudflare, the [Cloudflare Origin Certificates recipe](/docs/recipes/cloudflare-origin-certs) covers the mTLS setup that locks your origin to Cloudflare's edge IPs. gRPC + mTLS works the same way — `upstream_h2c: true` + `proxy.tls.client_auth` together:
+
+```yaml
+proxy:
+  tls:
+    cert_secret: CF_ORIGIN_CERT
+    key_secret:  CF_ORIGIN_KEY
+    client_auth:
+      mode: require_and_verify
+      trust_pool_secret: CF_ORIGIN_PULL_CA
+
+services:
+  - name: api
+    image: ghcr.io/me/grpc-api
+    domain: api.example.com
+    upstream_h2c: true
+    run:
+      port: 50051
+```
+
+This is the configuration backtrack uses today: Tonic + Axum behind Cloudflare with origin-pull mTLS, single `upstream_h2c: true` covers both gRPC and the REST surface.
+
+## See also
+
+- [Reverse proxy guide](/docs/guide/proxy) — full schema reference.
+- [Cloudflare Origin Certificates](/docs/recipes/cloudflare-origin-certs) — for the mTLS edge story.
+- [Caddy snippets cookbook](/docs/recipes/caddy-snippets) — for content-type matchers, request body limits, and other escape-hatch patterns.
+- [Caddy reverse_proxy docs](https://caddyserver.com/docs/caddyfile/directives/reverse_proxy#transport) — the transport options for the underlying primitive.

--- a/docs/content/docs/recipes/multi-host-redis-storage.md
+++ b/docs/content/docs/recipes/multi-host-redis-storage.md
@@ -1,0 +1,115 @@
+---
+title: Multi-host Let's Encrypt with Redis storage
+weight: 11
+---
+
+When you run yoink across multiple hosts that serve the same domain, **each host's Caddy independently asks Let's Encrypt for a cert and you hit rate limits within a week**. The fix: share ACME state across all proxies via a small Redis instance reachable on a private network.
+
+If you're using Cloudflare's edge, the simpler answer is [Origin Certificates](/docs/recipes/cloudflare-origin-certs) — no ACME at all. This recipe is for the LE-direct case.
+
+## Architecture
+
+```
+host-1 ──┐
+host-2 ──┤── all reach ──→ redis:6379 (on tailnet) ──→ shared ACME state
+host-3 ──┘
+```
+
+- A **single Redis** instance, deployed by yoink onto one canonical host.
+- All proxies use the [`caddy-storage-redis`](https://github.com/pberkel/caddy-storage-redis) plugin to point Caddy's storage at Redis instead of the local `/data` volume.
+- **Tailscale** (or any private network) keeps Redis off the public internet — the redis port is published only on the tailnet IP.
+
+The single Redis is a small SPOF, but a tractable one (it's only used for cert issuance/renewal, not request-path traffic). Backups via tailnet-replicated snapshots if you need it.
+
+## Build a custom Caddy image with the storage plugin
+
+`caddy-storage-redis` isn't in the base `caddy:2` image. Build one with [`xcaddy`](https://github.com/caddyserver/xcaddy):
+
+```dockerfile
+# Dockerfile.caddy-redis
+FROM caddy:2-builder AS builder
+RUN xcaddy build \
+    --with github.com/pberkel/caddy-storage-redis
+
+FROM caddy:2
+COPY --from=builder /usr/bin/caddy /usr/bin/caddy
+```
+
+```sh
+docker buildx build --platform linux/amd64,linux/arm64 \
+  -f Dockerfile.caddy-redis \
+  -t ghcr.io/me/caddy-redis:2.7 \
+  --push .
+```
+
+(Or use `yoink build` against a service that wraps this Dockerfile, then `proxy.image:` it.)
+
+## Run Redis as a yoink service
+
+Pin Redis to one host and publish only on the tailnet IP:
+
+```yaml
+hosts:
+  - { address: prod-1, user: deploy }
+  - { address: prod-2, user: deploy }
+  - { address: prod-3, user: deploy }
+
+services:
+  - name: redis
+    image: redis
+    tag: "7"
+    hosts: [prod-1]                # one canonical host
+    networks: [yoink-ingress]      # so the proxies can reach it by name from inside the network
+    run:
+      port: 6379
+      healthcheck_path: /          # Redis doesn't speak HTTP; skip and let yoink TCP-probe
+      healthcheck_path: null
+      publish:
+        - "100.10.0.1:6379:6379"   # tailnet IP only — adjust to your tailscale assignment
+      volumes:
+        - "redis-data:/data"
+```
+
+The published port on Tailscale's IP makes Redis reachable from `prod-2` and `prod-3` over the tailnet, but **not** from the public internet (Hetzner / your hosting provider's external interface).
+
+## Point Caddy at Redis
+
+Use the custom image, and add the storage block via `caddy_extra_json:` at the proxy level — wait, this doesn't exist as a field yet. For v1, the cleanest path is to bake the storage config into a custom `Caddyfile` baked into the image, OR use a small `proxy.config_extra:` field if/when that lands.
+
+For v1 today, the practical path: build the xcaddy image with the storage config baked in via a custom entrypoint that writes the storage block before `caddy run`. Example wrapper:
+
+```dockerfile
+FROM caddy:2-builder AS builder
+RUN xcaddy build --with github.com/pberkel/caddy-storage-redis
+
+FROM caddy:2
+COPY --from=builder /usr/bin/caddy /usr/bin/caddy
+COPY caddy-bootstrap.json /etc/caddy/bootstrap.json
+ENTRYPOINT ["caddy", "run", "--resume", "--config", "/etc/caddy/bootstrap.json"]
+```
+
+`caddy-bootstrap.json`:
+
+```json
+{
+  "storage": {
+    "module": "redis",
+    "address": "redis:6379"
+  },
+  "admin": {"listen": ":2019"}
+}
+```
+
+Caddy's `--resume` flag loads this bootstrap config first; yoink's `/load` then merges in the rendered routing config on top. Storage stays Redis-backed.
+
+A future yoink release will likely add `proxy.storage:` as a typed field; until then, the bootstrap-image trick is the working path.
+
+## Tailscale on every host
+
+For the proxies on `prod-2` and `prod-3` to reach `redis:6379` on `prod-1`'s tailnet IP, every host needs to be on the tailnet. See [Pairing with Tailscale](/docs/guide/pairing) for the setup.
+
+## See also
+
+- [Reverse proxy guide](/docs/guide/proxy)
+- [Cloudflare Origin Certificates](/docs/recipes/cloudflare-origin-certs) — simpler path if you're already on Cloudflare's edge.
+- [`caddy-storage-redis`](https://github.com/pberkel/caddy-storage-redis) — the upstream plugin.

--- a/docs/content/docs/start/first-deploy.md
+++ b/docs/content/docs/start/first-deploy.md
@@ -3,39 +3,42 @@ title: First deploy
 weight: 2
 ---
 
-The fastest path: **drop a `yoink.yaml` next to your `Dockerfile`, run one command**. No CI, no registry, no pre-existing image.
+**The goal**: a fresh VPS to a running app in 5 minutes, two commands, one YAML file. No CI, no registry, no Tailscale.
 
-{{< callout type="info" >}}
-This is the **standalone mode** — see [Three deploy modes](/docs/guide/deploy-modes) when you want CI-built or kamal-style instead.
-{{< /callout >}}
+## TL;DR
 
-The story is **"deploy this repo to this host with these creds."** A fresh VPS (Hetzner, Linode, DigitalOcean, your home lab) with docker installed and an SSH login that works is enough — no registry, no CI, no Tailscale.
+```sh
+yoink init root@1.2.3.4              # generates yoink.yaml from your repo
+yoink up --build --no-registry       # builds locally, ships, runs
+```
+
+Done. `yoink init` reads your `Dockerfile`, `git remote`, and (optionally) `~/.ssh/config` to fill in every field. `yoink up` builds the image locally, ships it to the host over SSH (no registry needed), and runs it through a healthcheck-gated rolling deploy.
+
+Edit a line of code, run `yoink up --build --no-registry` again — yoink rebuilds, ships only changed layers, rolls the new container behind the healthcheck. ~5–15 seconds for a small image.
 
 ## Prerequisites
 
-- Yoink [installed](/docs/start/install) on your laptop.
-- A host with docker installed and an SSH login that works without a password — i.e. `ssh root@<host>` (or `ssh deploy@<host>`) drops you in. A fresh Hetzner / Linode / DigitalOcean box with your SSH public key dropped into `~/.ssh/authorized_keys` qualifies.
-- Docker running on your laptop (`yoink build` shells out to `docker build`).
+- Yoink [installed](/docs/start/install) on your laptop (`brew install oddur/yoink/yoink`).
+- A host with docker installed and key-based SSH login that works — `ssh root@<host>` should drop you into a shell. A fresh Hetzner / Linode / DigitalOcean / Hetzner Cloud box with your SSH public key in `~/.ssh/authorized_keys` qualifies.
+- Docker on your laptop (`yoink build` shells out to `docker build`).
 
-That's it. Yoink uses your operating system's SSH client, so anything you've already set up (`~/.ssh/config`, `ssh-agent`, hardware keys, jump hosts) just works.
+That's it. Yoink uses your operating system's SSH client, so anything you've set up (`~/.ssh/config`, `ssh-agent`, hardware keys, jump hosts) just works.
 
 {{< callout type="info" >}}
-**Tailscale is opt-in, not required.** It's a great fit when you want stable hostnames across hosts that move IPs or live behind NAT — see [Pairing](/docs/guide/pairing). For a single VPS, plain SSH to the host's IP or DNS name is the simplest path.
+**No Tailscale required.** Plain SSH to the host's IP or DNS name is the simplest path. Tailscale becomes useful when you have multiple hosts behind NAT or want stable hostnames — see [Pairing](/docs/guide/pairing).
 {{< /callout >}}
 
 ## Walkthrough
 
 {{% steps %}}
 
-### Generate a `yoink.yaml`
+### Generate `yoink.yaml`
 
 ```sh
-yoink init root@1.2.3.4              # pass <user>@<host> straight in
-# or, omit and yoink will ask if it finds candidate hosts
-yoink init
+yoink init root@1.2.3.4
 ```
 
-That produces a `yoink.yaml` with every field already filled in. Yoink reads what's around the cwd — your `Dockerfile`, `git remote get-url origin`, `~/.ssh/config` — and infers the right answer for each field. Output:
+Output:
 
 ```
 ✓ wrote yoink.yaml (15 lines, validates clean)
@@ -46,25 +49,19 @@ inferred:
   host      root@1.2.3.4                    (positional arg)
   port      3000 with /health healthcheck   (Dockerfile EXPOSE)
   user      hono                            (Dockerfile USER)
-
-next:
-  yoink validate
-  yoink up --tag my-tool=$(git rev-parse HEAD)
 ```
 
-The summary shows exactly what was inferred and where each value came from — edit the one line in `yoink.yaml` if anything's off. Common overrides via flags: `--service`, `--image`, `--port`, `--no-port`. See [the CLI reference](/docs/reference/cli) for the full surface.
+The summary tells you exactly what was inferred and where each value came from. Edit the line in `yoink.yaml` if anything's off.
 
-If you don't pass a host but `~/.ssh/config` has candidate entries, yoink prompts you to confirm or override (it never silently picks the first one — that's almost never what you want). On a non-tty (CI), it bails with an instruction to pass the host explicitly.
-
-For this walkthrough we'll change one line: edit `image:` to a bare name (no registry prefix) so we can use **standalone mode** — build locally, ship directly to the host, no registry involved:
+For this walkthrough we'll change one thing: edit `image:` to a bare name (no registry prefix) so we can use **standalone mode** — build locally, ship directly to the host, no registry involved:
 
 ```yaml
 services:
   - name: my-tool
-    image: my-tool       # bare name, no registry prefix
+    image: my-tool                  # bare name = build locally, no registry
     tag: dev
     build:
-      context: .         # build the Dockerfile next to this yoink.yaml
+      context: .                    # build the Dockerfile next to this yoink.yaml
     run:
       port: 8080
 ```
@@ -75,98 +72,107 @@ services:
 yoink up --build --no-registry
 ```
 
-That builds the image locally, streams it directly to `my-server` over ssh (no registry involved), and runs it.
+Builds the image locally, ships it directly to the host over SSH, runs it through a healthcheck-gated rolling deploy.
 
 ### Iterate
 
-Edit the Dockerfile or your code. Re-run the same command:
+Edit code or Dockerfile. Re-run the same command:
 
 ```sh
 yoink up --build --no-registry
 ```
 
-Yoink rebuilds, ships the new image to the host, and rolls it through the healthcheck-gated swap. ~15 seconds for a small image.
+Only changed layers cross the wire (yoink uses [unregistry-style](/docs/guide/deploy-modes#standalone-no-registry) layer-dedup transport). Healthcheck-gated swap; the old container only stops after the new one is healthy.
 
 ### Inspect what's running
 
 ```sh
 yoink status                              # snapshot table
-yoink tui                                 # k9s-style dashboard
-yoink logs my-tool -f | hl                # live tail with `hl` highlighting (optional)
+yoink tui                                 # k9s-style dashboard with logs / shell-into / drift
+yoink logs my-tool -f | hl                # live tail, optional `hl` highlighting
 ```
 
 {{% /steps %}}
 
-## What happens under the hood
+## Add HTTPS routing
 
-1. **`yoink up --build`** sees that `my-tool` has a `build:` block and runs `docker build` locally, tagging as `my-tool:dev`.
-2. **`--no-registry`** spawns `docker save my-tool:dev` and streams the tarball over the existing ssh+bollard transport into the host's docker daemon (`POST /images/load`). Per-host progress bars show bytes + rate.
-3. The host's docker daemon now has `my-tool:dev` cached. Yoink's normal reconcile runs — `image_present` short-circuits the would-be `docker pull`, the image gets `docker run`'d with the runtime options, and the rolling swap completes after the healthcheck passes.
+Want yoink to terminate TLS and route to your container? Add **two lines**:
 
-## Different setups
+```yaml
+hosts:
+  - { address: 1.2.3.4, user: root }
 
-### Fresh VPS, root user, password-only SSH
+proxy:
+  email: ops@example.com         # for Let's Encrypt registration
 
-A brand-new Hetzner / DigitalOcean / Linode box typically gives you a `root` password and no key. Two-step: drop your SSH public key once, then `yoink up`.
+services:
+  - name: my-tool
+    image: my-tool
+    tag: dev
+    build: { context: . }
+    domain: my-tool.example.com  # ← that
+    run:
+      port: 8080
+      healthcheck_path: /health
+```
+
+Point DNS at `1.2.3.4`. `yoink up --build --no-registry` again. `https://my-tool.example.com` serves with a Let's Encrypt cert. Yoink runs Caddy as a managed service alongside your app and renders its config from your `yoink.yaml`. See the [reverse proxy guide](/docs/guide/proxy) for the full surface.
+
+## Different SSH setups
+
+### Fresh VPS, root password only
+
+Drop your SSH key once, then yoink takes over:
 
 ```sh
-# one-time, from your laptop
 ssh-copy-id root@1.2.3.4                  # asks for the root password once
-# from then on
 yoink up --build --no-registry
 ```
 
-Yoink itself never asks for a password — it relies on key-based auth via your SSH client. The secret stays on your laptop.
+### Non-default key
 
-### Non-default SSH key
-
-Use `~/.ssh/config` to bind a key to the host. Yoink picks it up automatically because it shells out to your `ssh`:
+`~/.ssh/config` works:
 
 ```
-# ~/.ssh/config
 Host my-server
   HostName 1.2.3.4
   User root
   IdentityFile ~/.ssh/my-server.pem
 ```
 
-Then in `yoink.yaml`:
 ```yaml
 hosts:
   - { address: my-server, user: root }
 ```
 
-### Ship the deploy key with the repo (sealed-secrets)
+### Ship the deploy key with the repo
 
-If you don't want each operator to manage the host's private key in their personal `ssh-agent` — handy for fresh VPS hosts a small team rotates onto, or for CI runners — drop the SSH key into the [sealed-secrets bundle](/docs/recipes/sealed-secrets) and reference it from the host:
+For team setups where you don't want every operator to manage the host's key in their personal `ssh-agent`. Drop the key in [sealed secrets](/docs/recipes/sealed-secrets) and reference from the host:
 
 ```yaml
 secrets:
   provider: age
-  # `secrets.age` next to yoink.yaml, encrypted with `yoink secrets edit`
 
 hosts:
   - address: 1.2.3.4
     user: root
-    ssh_key_secret: PROD_HOST_SSH_KEY
+    ssh_key_secret: PROD_HOST_SSH_KEY    # name in secrets.age
 ```
 
-`yoink secrets edit` to add the key:
-```
-PROD_HOST_SSH_KEY=-----BEGIN OPENSSH PRIVATE KEY-----
-...
------END OPENSSH PRIVATE KEY-----
-```
-
-At deploy time, yoink decrypts the key into a `0o600` tempfile (auto-removed when the deploy finishes) and uses it for both the bollard daemon connection and the pre-flight `ssh_probe`. The key never lands in your operator's personal ssh-agent.
+`yoink secrets edit` to add the key value. At deploy time, yoink decrypts to a `0o600` tempfile (auto-removed on exit) and uses it for the SSH connection.
 
 ### Tailscale (opt-in)
 
-If you're already on Tailscale, point `address:` at the tailnet hostname and you're done — no IP allowlist, no DNS, no jump host. See [Pairing](/docs/guide/pairing) for the why.
+If you're on Tailscale, point `address:` at the tailnet hostname. See [Pairing](/docs/guide/pairing).
 
 ## What's next
 
-- Other deploy modes (real registry, kamal-style): [Deploy modes](/docs/guide/deploy-modes)
-- The `yoink.yaml` schema in full: [Configuration](/docs/reference/config)
-- The complete CLI surface: [CLI](/docs/reference/cli)
-- Hardened defaults yoink applies to every container: [Secure by default](/docs/guide/security-defaults)
+| If you want to… | Read |
+|---|---|
+| Add HTTPS routing | [Reverse proxy guide](/docs/guide/proxy) |
+| Use Cloudflare origin certs (no Let's Encrypt) | [Cloudflare Origin Certificates](/docs/recipes/cloudflare-origin-certs) |
+| Host a gRPC backend | [gRPC hosting](/docs/recipes/grpc-hosting) |
+| Deploy from CI instead of locally | [Deploy modes](/docs/guide/deploy-modes) |
+| Understand the rolling deploy + drift detection | [Architecture](/docs/guide/architecture) |
+| See every CLI flag and config field | [CLI](/docs/reference/cli) and [Configuration](/docs/reference/config) |
+| See what hardened defaults yoink applies | [Secure by default](/docs/guide/security-defaults) |

--- a/yoink/src/config.rs
+++ b/yoink/src/config.rs
@@ -507,6 +507,24 @@ pub struct ServiceConfig {
     /// See <https://caddyserver.com/docs/json/apps/http/servers/routes/handle/>.
     #[serde(default)]
     pub caddy_extra_json: Option<String>,
+    /// Like `caddy_extra_json:` but takes Caddyfile syntax — the
+    /// friendlier shape Caddy's docs and ecosystem use:
+    ///
+    /// ```yaml
+    /// caddy_extra_caddyfile: |
+    ///   forward_auth authelia:9091 {
+    ///     uri /api/verify?rd=https://auth.example.com
+    ///     copy_headers Remote-User Remote-Groups Remote-Email
+    ///   }
+    /// ```
+    ///
+    /// Yoink shells out to `caddy adapt --adapter caddyfile` (in an
+    /// ephemeral container) at render time to convert the snippet to
+    /// JSON, then splices the resulting handlers into the route.
+    /// Requires docker on the operator's machine. Cannot be combined
+    /// with `caddy_extra_json:` on the same service — pick one shape.
+    #[serde(default)]
+    pub caddy_extra_caddyfile: Option<String>,
     /// Talk to the backend over HTTP/2 cleartext (`h2c`). Renders a
     /// `transport: { protocol: http, versions: [h2c] }` block on the
     /// auto-generated `reverse_proxy` handler. Required for native

--- a/yoink/src/config.rs
+++ b/yoink/src/config.rs
@@ -164,6 +164,13 @@ pub struct ProxyConfig {
     /// Persisted across proxy restarts. Default `yoink_caddy_data`.
     #[serde(default)]
     pub cert_volume: Option<String>,
+    /// Host IP to bind `:80` and `:443` to. Default unset → bind
+    /// to all interfaces (`0.0.0.0`). Common use: bind to a
+    /// Tailscale IP so the proxy is reachable only over the
+    /// tailnet (`bind: 100.10.0.1`), or to `127.0.0.1` for local
+    /// dev where the proxy fronts a tunneled cloudflared session.
+    #[serde(default)]
+    pub bind: Option<String>,
     /// Proxy-level TLS configuration. When set, every routed service
     /// inherits this cert (and optional client-auth) by default.
     /// Per-service `tls_cert_secret:` / `tls_key_secret:` overrides
@@ -517,6 +524,26 @@ pub struct ServiceConfig {
     /// deploys without a CDN in front.
     #[serde(default)]
     pub compression: bool,
+    /// Path-prefix routing. When set, this service's route only
+    /// matches requests where the URL path starts with this prefix
+    /// (Caddy `path` matcher; `*` is allowed at the end). Lets two
+    /// services share a hostname:
+    ///
+    /// ```yaml
+    /// services:
+    ///   - name: api
+    ///     domain: example.com
+    ///     path_prefix: /api/*
+    ///     run: { port: 8080 }
+    ///   - name: web
+    ///     domain: example.com   # same host
+    ///     run: { port: 3000 }
+    /// ```
+    ///
+    /// Yoink orders routes so path-constrained ones come before
+    /// catch-all ones — first match wins, as Caddy does.
+    #[serde(default)]
+    pub path_prefix: Option<String>,
     pub run: ServiceRun,
 }
 

--- a/yoink/src/config.rs
+++ b/yoink/src/config.rs
@@ -351,6 +351,10 @@ fn default_build_context() -> String {
     ".".to_string()
 }
 
+fn default_hsts() -> bool {
+    true
+}
+
 /// Discriminator for special-purpose services. Most services are
 /// regular app workloads (`None`); the only variant today is `Proxy`
 /// for the implicit `_proxy` service yoink synthesizes when any
@@ -524,6 +528,15 @@ pub struct ServiceConfig {
     /// deploys without a CDN in front.
     #[serde(default)]
     pub compression: bool,
+    /// Emit the `Strict-Transport-Security` header on every response.
+    /// **Default `true` for TLS sites** (`tls: auto` or `tls: cert`,
+    /// or proxy-level inheritance). Universal best practice once
+    /// you've committed to HTTPS — every modern browser pins the
+    /// site to HTTPS-only after the first visit. Set to `false` for
+    /// the rare case where you serve mixed HTTP/HTTPS or are
+    /// migrating off the TLS path.
+    #[serde(default = "default_hsts")]
+    pub hsts: bool,
     /// Path-prefix routing. When set, this service's route only
     /// matches requests where the URL path starts with this prefix
     /// (Caddy `path` matcher; `*` is allowed at the end). Lets two

--- a/yoink/src/config.rs
+++ b/yoink/src/config.rs
@@ -138,7 +138,7 @@ pub struct HostConfig {
 }
 
 /// Reverse-proxy config. The proxy itself is a yoink-managed Caddy
-/// service (`name = "_proxy"`, `kind = ServiceKind::Proxy`) that's
+/// service (`name = "yoink-proxy"`, `kind = ServiceKind::Proxy`) that's
 /// synthesized at config-load time when any service has `domain:` set.
 /// This block tunes the synthesized service. All fields optional.
 #[derive(Debug, Clone, Default, PartialEq, Eq, Deserialize)]
@@ -151,7 +151,8 @@ pub struct ProxyConfig {
     pub enabled: Option<bool>,
     /// Email address for Let's Encrypt ACME registration. Required
     /// when any service uses `tls: auto` (which is the default for
-    /// services with `domain:`).
+    /// services with `domain:`). Unused when `proxy.tls.cert_secret`
+    /// is set — yoink doesn't ACME on top of an inline cert.
     #[serde(default)]
     pub email: Option<String>,
     /// Caddy image. Override to use an `xcaddy`-built image with
@@ -163,6 +164,89 @@ pub struct ProxyConfig {
     /// Persisted across proxy restarts. Default `yoink_caddy_data`.
     #[serde(default)]
     pub cert_volume: Option<String>,
+    /// Proxy-level TLS configuration. When set, every routed service
+    /// inherits this cert (and optional client-auth) by default.
+    /// Per-service `tls_cert_secret:` / `tls_key_secret:` overrides
+    /// for the rare different-cert-per-service case.
+    ///
+    /// The common shape (one wildcard cert covers everything):
+    /// ```yaml
+    /// proxy:
+    ///   tls:
+    ///     cert_secret: CF_ORIGIN_CERT
+    ///     key_secret:  CF_ORIGIN_KEY
+    ///     client_auth:
+    ///       mode: require_and_verify
+    ///       trust_pool_secret: CF_ORIGIN_PULL_CA
+    /// ```
+    #[serde(default)]
+    pub tls: Option<ProxyTls>,
+}
+
+/// Proxy-level TLS. When `cert_secret` + `key_secret` are set, ACME
+/// is implicitly off and a `:80 → :443` redirect is auto-emitted by
+/// the renderer.
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ProxyTls {
+    /// Sealed-secret name holding the PEM cert (full chain). Inlined
+    /// into the rendered Caddy JSON at deploy time. When set, every
+    /// routed service uses this cert unless it overrides via
+    /// per-service `tls_cert_secret:`.
+    pub cert_secret: String,
+    /// Sealed-secret name holding the PEM private key matching
+    /// `cert_secret`.
+    pub key_secret: String,
+    /// Optional client-certificate authentication (mTLS). Required
+    /// for setups like Cloudflare origin-pull where the proxy
+    /// rejects requests that don't present a Cloudflare-signed
+    /// client cert.
+    #[serde(default)]
+    pub client_auth: Option<ClientAuth>,
+}
+
+/// Client-certificate auth (mTLS) for proxy-level TLS. The trust
+/// pool is sealed-secret content, inlined into rendered JSON — no
+/// host-filesystem dependency.
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ClientAuth {
+    /// Caddy `client_authentication.mode`. Default
+    /// `require_and_verify` (the strict choice; `require` skips
+    /// CA verification, `verify_if_given` is opt-in).
+    #[serde(default = "default_client_auth_mode")]
+    pub mode: ClientAuthMode,
+    /// Sealed-secret name holding the trust-pool CA chain (PEM).
+    /// Common case: Cloudflare's origin-pull CA bundle.
+    pub trust_pool_secret: String,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ClientAuthMode {
+    Request,
+    Require,
+    VerifyIfGiven,
+    #[default]
+    RequireAndVerify,
+}
+
+impl ClientAuthMode {
+    /// String form Caddy expects in JSON
+    /// (`client_authentication.mode`).
+    #[must_use]
+    pub fn as_caddy(self) -> &'static str {
+        match self {
+            Self::Request => "request",
+            Self::Require => "require",
+            Self::VerifyIfGiven => "verify_if_given",
+            Self::RequireAndVerify => "require_and_verify",
+        }
+    }
+}
+
+fn default_client_auth_mode() -> ClientAuthMode {
+    ClientAuthMode::RequireAndVerify
 }
 
 impl ProxyConfig {

--- a/yoink/src/config.rs
+++ b/yoink/src/config.rs
@@ -55,6 +55,12 @@ pub struct Config {
     /// will pull successfully.
     #[serde(default)]
     pub registry: Option<RegistryConfig>,
+    /// Optional reverse-proxy config. The proxy is auto-enabled when
+    /// any service declares `domain:`; this block only needs to be set
+    /// when overriding defaults (e.g. to set `email:` for ACME or to
+    /// pin a custom Caddy image with plugins). See [`ProxyConfig`].
+    #[serde(default)]
+    pub proxy: Option<ProxyConfig>,
     /// Glob patterns (relative to this file's directory) of additional
     /// config fragments to load. Each fragment may declare `services`
     /// and/or `hooks.pre_deploy`; everything else (`hosts`, `secrets`,
@@ -129,6 +135,50 @@ pub struct HostConfig {
     /// auth set up — fresh VPS with `root` user, throwaway hosts, etc.
     #[serde(default)]
     pub ssh_key_secret: Option<String>,
+}
+
+/// Reverse-proxy config. The proxy itself is a yoink-managed Caddy
+/// service (`name = "_proxy"`, `kind = ServiceKind::Proxy`) that's
+/// synthesized at config-load time when any service has `domain:` set.
+/// This block tunes the synthesized service. All fields optional.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ProxyConfig {
+    /// Force the proxy on or off, regardless of whether any service
+    /// has `domain:`. Default: implicit `true` when any service
+    /// declares `domain:`, else `false`.
+    #[serde(default)]
+    pub enabled: Option<bool>,
+    /// Email address for Let's Encrypt ACME registration. Required
+    /// when any service uses `tls: auto` (which is the default for
+    /// services with `domain:`).
+    #[serde(default)]
+    pub email: Option<String>,
+    /// Caddy image. Override to use an `xcaddy`-built image with
+    /// plugins (e.g. `caddy-storage-redis` for multi-host certs,
+    /// `caddy-ratelimit`, `caddy-l4`). Default `caddy:2`.
+    #[serde(default)]
+    pub image: Option<String>,
+    /// Named Docker volume for ACME state, certs, and OCSP staples.
+    /// Persisted across proxy restarts. Default `yoink_caddy_data`.
+    #[serde(default)]
+    pub cert_volume: Option<String>,
+}
+
+impl ProxyConfig {
+    /// Resolve the Caddy image, applying the default.
+    #[must_use]
+    pub fn resolved_image(&self) -> String {
+        self.image.clone().unwrap_or_else(|| "caddy:2".to_string())
+    }
+
+    /// Resolve the cert volume name, applying the default.
+    #[must_use]
+    pub fn resolved_cert_volume(&self) -> String {
+        self.cert_volume
+            .clone()
+            .unwrap_or_else(|| "yoink_caddy_data".to_string())
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
@@ -210,11 +260,59 @@ fn default_build_context() -> String {
     ".".to_string()
 }
 
+/// Discriminator for special-purpose services. Most services are
+/// regular app workloads (`None`); the only variant today is `Proxy`
+/// for the implicit `_proxy` service yoink synthesizes when any
+/// service declares `domain:`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum ServiceKind {
+    Proxy,
+}
+
+/// `domain:` accepts either a single hostname or a list — a service
+/// can be reachable on multiple domain names (e.g. `api.example.com`
+/// + `api.example.net`).
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+#[serde(untagged)]
+pub enum DomainSpec {
+    Single(String),
+    Many(Vec<String>),
+}
+
+impl DomainSpec {
+    /// Flatten to a sorted list of hostnames. Used by the renderer.
+    #[must_use]
+    pub fn as_list(&self) -> Vec<String> {
+        match self {
+            Self::Single(s) => vec![s.clone()],
+            Self::Many(v) => v.clone(),
+        }
+    }
+}
+
+/// TLS mode for a service's `domain:`. Default `Auto` (Let's Encrypt
+/// via ACME). `Off` serves on `:80` only. `Cert` uses an inline
+/// certificate sourced from `tls_cert_secret` + `tls_key_secret` in
+/// the sealed-secrets bundle (e.g. Cloudflare Origin Certificates).
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum TlsMode {
+    #[default]
+    Auto,
+    Off,
+    Cert,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct ServiceConfig {
     pub name: String,
     pub image: String,
+    /// Special-purpose service marker. Set automatically on the
+    /// implicit `_proxy` service; users do not write this.
+    #[serde(default)]
+    pub kind: Option<ServiceKind>,
     /// Local-build instructions. When set, `yoink build [<service>]`
     /// runs `docker build` against this context, tagging the result
     /// as `<image>:<tag>`. Pairs with `yoink up --no-registry` for the
@@ -280,6 +378,37 @@ pub struct ServiceConfig {
     /// isolation (e.g. caddy with `[frontend]` only, no db reach).
     #[serde(default)]
     pub networks: Option<Vec<String>>,
+    /// Hostname(s) the reverse proxy should route to this service.
+    /// Setting `domain:` on any service auto-enables the bundled Caddy
+    /// proxy. The proxy gets the routes for `domain:` → `<container>:<run.port>`.
+    /// Requires `run.port:` to be set.
+    #[serde(default)]
+    pub domain: Option<DomainSpec>,
+    /// TLS mode for `domain:`. `auto` uses Let's Encrypt via ACME
+    /// (the default); `off` serves on `:80` only; `cert` uses an
+    /// inline certificate from `tls_cert_secret` + `tls_key_secret`.
+    #[serde(default)]
+    pub tls: TlsMode,
+    /// Name of the sealed-secret entry holding a PEM certificate
+    /// (full chain). Used when `tls: cert`. Pairs with
+    /// `tls_key_secret`. Common case: Cloudflare Origin Certificates
+    /// rotated quarterly into `secrets.age`.
+    #[serde(default)]
+    pub tls_cert_secret: Option<String>,
+    /// Name of the sealed-secret entry holding the PEM private key
+    /// matching `tls_cert_secret`. Used when `tls: cert`.
+    #[serde(default)]
+    pub tls_key_secret: Option<String>,
+    /// Raw JSON merged into this service's Caddy site-block route as
+    /// additional `handle` entries (rendered before the auto-generated
+    /// `reverse_proxy` handler). Escape hatch for Caddy features yoink
+    /// doesn't model — `forward_auth`, `rate_limit`, `headers`, etc.
+    /// Must be a JSON array of Caddy handler objects. Yoink does not
+    /// validate the contents — invalid handlers will fail at Caddy's
+    /// `/load` step with the API's parse error surfaced verbatim.
+    /// See <https://caddyserver.com/docs/json/apps/http/servers/routes/handle/>.
+    #[serde(default)]
+    pub caddy_extra_json: Option<String>,
     pub run: ServiceRun,
 }
 
@@ -347,6 +476,25 @@ pub struct ServiceRun {
     /// triggers a redeploy via the spec hash.
     #[serde(default)]
     pub files: Vec<String>,
+}
+
+impl Default for ServiceRun {
+    fn default() -> Self {
+        Self {
+            port: None,
+            healthcheck_path: None,
+            healthcheck_timeout: default_healthcheck_timeout(),
+            replicas: default_replicas(),
+            drain_timeout: default_drain_timeout(),
+            entrypoint: None,
+            cmd: Vec::new(),
+            options: RunOptions::default(),
+            publish: Vec::new(),
+            binds: Vec::new(),
+            volumes: Vec::new(),
+            files: Vec::new(),
+        }
+    }
 }
 
 /// Per-container runtime options. **All security-relevant fields
@@ -612,6 +760,7 @@ impl Config {
         cfg.config_dir = path.parent().map(std::path::Path::to_path_buf);
         cfg.merge_includes()?;
         cfg.normalize_image_references()?;
+        crate::proxy::inject_implicit_proxy(&mut cfg)?;
         cfg.validate()?;
         cfg.topo_sort_services()?;
         Ok(cfg)
@@ -620,6 +769,7 @@ impl Config {
     pub fn parse_str(text: &str) -> Result<Self, ConfigError> {
         let mut config: Self = yaml_serde::from_str(text)?;
         config.normalize_image_references()?;
+        crate::proxy::inject_implicit_proxy(&mut config)?;
         config.validate()?;
         config.topo_sort_services()?;
         Ok(config)

--- a/yoink/src/config.rs
+++ b/yoink/src/config.rs
@@ -487,12 +487,36 @@ pub struct ServiceConfig {
     /// additional `handle` entries (rendered before the auto-generated
     /// `reverse_proxy` handler). Escape hatch for Caddy features yoink
     /// doesn't model — `forward_auth`, `rate_limit`, `headers`, etc.
-    /// Must be a JSON array of Caddy handler objects. Yoink does not
-    /// validate the contents — invalid handlers will fail at Caddy's
-    /// `/load` step with the API's parse error surfaced verbatim.
+    /// Accepts either a list of handlers (`[{"handler": "...", ...}]`)
+    /// or a list of routes (`[{"match": ..., "handle": ...}]`); routes
+    /// are auto-wrapped in a `subroute` handler so the operator never
+    /// has to know about `subroute`. Yoink does not validate the
+    /// contents — invalid handlers will fail at Caddy's `/load` step
+    /// with the API's parse error surfaced verbatim.
     /// See <https://caddyserver.com/docs/json/apps/http/servers/routes/handle/>.
     #[serde(default)]
     pub caddy_extra_json: Option<String>,
+    /// Talk to the backend over HTTP/2 cleartext (`h2c`). Renders a
+    /// `transport: { protocol: http, versions: [h2c] }` block on the
+    /// auto-generated `reverse_proxy` handler. Required for native
+    /// gRPC backends (Tonic, grpc-go, grpc-java) and for HTTP/2-only
+    /// upstream apps. Doesn't affect what Caddy serves to clients —
+    /// just how it dials the upstream.
+    #[serde(default)]
+    pub upstream_h2c: bool,
+    /// One of the entries in `domain:` to treat as canonical. Yoink
+    /// auto-renders a 308 redirect from every other entry to this one.
+    /// Common pattern: `domain: [example.com, www.example.com]` +
+    /// `canonical_domain: example.com` redirects www → apex.
+    /// Must match exactly one of the strings in `domain:`.
+    #[serde(default)]
+    pub canonical_domain: Option<String>,
+    /// Compress responses with gzip + zstd. Renders Caddy's `encode`
+    /// handler before `reverse_proxy`. No-op when behind Cloudflare
+    /// (the edge already compresses); useful for direct-origin
+    /// deploys without a CDN in front.
+    #[serde(default)]
+    pub compression: bool,
     pub run: ServiceRun,
 }
 

--- a/yoink/src/deploy.rs
+++ b/yoink/src/deploy.rs
@@ -59,6 +59,8 @@ pub enum DeployError {
         "service {service:?} has no `tag:` in config and was not given one via `--tag`; pass `--tag {service}=<value>` or add `tag:` to the service fragment"
     )]
     TagMissing { service: String },
+    #[error("{detail} (host: {host})")]
+    Custom { host: String, detail: String },
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -166,7 +168,42 @@ pub fn build_labels(
     labels.insert("yoink.service".into(), service.name.clone());
     labels.insert("yoink.version".into(), tag.into());
     labels.insert("yoink.spec_hash".into(), spec_hash.into());
+    // Routing-relevant fields land in labels so changes flow through
+    // the existing spec_hash → drift → redeploy → /load pipeline.
+    // Without this, editing `caddy_extra_json:` on a stable service
+    // wouldn't trigger a redeploy and the new snippet wouldn't reach
+    // Caddy until something else changed.
+    if let Some(domain) = &service.domain {
+        labels.insert("yoink.caddy.domain".into(), domain.as_list().join(","));
+    }
+    if matches!(service.tls, crate::config::TlsMode::Off) {
+        labels.insert("yoink.caddy.tls".into(), "off".into());
+    } else if matches!(service.tls, crate::config::TlsMode::Cert) {
+        labels.insert("yoink.caddy.tls".into(), "cert".into());
+    }
+    if let Some(s) = &service.tls_cert_secret {
+        labels.insert("yoink.caddy.cert_secret".into(), s.clone());
+    }
+    if let Some(s) = &service.tls_key_secret {
+        labels.insert("yoink.caddy.key_secret".into(), s.clone());
+    }
+    if let Some(extra) = &service.caddy_extra_json {
+        labels.insert("yoink.caddy.extra_hash".into(), short_sha256(extra));
+    }
     labels
+}
+
+fn short_sha256(s: &str) -> String {
+    use sha2::{Digest, Sha256};
+    use std::fmt::Write;
+    let mut h = Sha256::new();
+    h.update(s.as_bytes());
+    let d = h.finalize();
+    let mut out = String::with_capacity(16);
+    for b in &d[..8] {
+        let _ = write!(out, "{b:02x}");
+    }
+    out
 }
 
 /// Audit-trail labels added at create-container time. Deliberately
@@ -493,7 +530,7 @@ pub async fn deploy_service(
     // Start each pre-created container, healthcheck, swap out old.
     let mut host_results = Vec::with_capacity(prepared.len());
     for prep in prepared {
-        let result = finalize_one_host(ops, config, service, prep, on_event).await?;
+        let result = finalize_one_host(ops, config, service, prep, secrets, on_event).await?;
         host_results.push(result);
     }
     Ok(ServiceDeployReport {
@@ -627,6 +664,7 @@ async fn finalize_one_host(
     config: &Config,
     service: &ServiceConfig,
     prep: HostPrep,
+    secrets: Option<&SecretsBundle>,
     on_event: &mut (dyn FnMut(DeployEvent) + Send),
 ) -> Result<HostDeployResult, DeployError> {
     let HostPrep {
@@ -703,6 +741,19 @@ async fn finalize_one_host(
         total_attempts = total_attempts.max(attempts);
     }
 
+    // Caddy admin-API push: route the new replicas in (and the
+    // proxy itself, after first deploy, into a serving state).
+    // Runs between healthcheck-pass and the old-replica stop so
+    // there's a brief window where both old + new serve — Caddy
+    // gracefully reloads, no in-flight requests dropped. Skipped
+    // for non-routed services and when the proxy isn't enabled.
+    let triggers_caddy_load = crate::proxy::proxy_enabled(config)
+        && (matches!(service.kind, Some(crate::config::ServiceKind::Proxy))
+            || crate::proxy::is_proxied(service));
+    if triggers_caddy_load {
+        push_caddy_config(ops, &host, config, secrets).await?;
+    }
+
     if !stop_first {
         stopped_old = swap_out_old_containers_by_set(
             ops,
@@ -727,6 +778,55 @@ async fn finalize_one_host(
         healthcheck_attempts: total_attempts,
         stopped_old,
     })
+}
+
+/// Render the Caddy config for `host`'s view of `config` and POST it
+/// to the proxy's admin API. Errors abort the deploy — old config
+/// stays active because Caddy's `/load` is atomic.
+async fn push_caddy_config(
+    ops: &dyn DockerOps,
+    host: &Host,
+    config: &Config,
+    secrets: Option<&SecretsBundle>,
+) -> Result<(), DeployError> {
+    // Build the upstream-name lookup by querying each routed service's
+    // current containers on this host. Includes the just-started
+    // replica AND (briefly) the old one — Caddy reloads gracefully.
+    let routed: Vec<&ServiceConfig> = config
+        .services
+        .iter()
+        .filter(|s| crate::proxy::is_proxied(s))
+        .collect();
+    let mut upstream_names: std::collections::BTreeMap<String, Vec<String>> =
+        std::collections::BTreeMap::new();
+    for svc in &routed {
+        let label = format!("yoink.service={}", svc.name);
+        let containers = ops
+            .list_containers_by_label(host, &label)
+            .await
+            .map_err(|source| DeployError::Docker {
+                host: host.address.clone(),
+                source,
+            })?;
+        let names: Vec<String> = containers
+            .into_iter()
+            .filter(crate::docker_ops::ContainerInfo::is_running)
+            .map(|c| c.name)
+            .collect();
+        upstream_names.insert(svc.name.clone(), names);
+    }
+    let json = crate::proxy::caddy::render(config, |s| upstream_names.get(s).cloned().unwrap_or_default(), secrets)
+        .map_err(|source| DeployError::Custom {
+            host: host.address.clone(),
+            detail: format!("render Caddy config: {source}"),
+        })?;
+    crate::proxy::admin::push_config(host, ops, &json)
+        .await
+        .map_err(|source| DeployError::Custom {
+            host: host.address.clone(),
+            detail: format!("push Caddy config: {source}"),
+        })?;
+    Ok(())
 }
 
 /// Build a `RunSpec` for the given service+tag. Used both to compute the

--- a/yoink/src/deploy.rs
+++ b/yoink/src/deploy.rs
@@ -789,6 +789,17 @@ async fn push_caddy_config(
     config: &Config,
     secrets: Option<&SecretsBundle>,
 ) -> Result<(), DeployError> {
+    // Expand any `caddy_extra_caddyfile:` snippets to JSON. Mutates a
+    // local clone so the caller's view of config stays unchanged.
+    let mut config = config.clone();
+    crate::proxy::caddy::expand_caddyfile_snippets(&mut config)
+        .await
+        .map_err(|source| DeployError::Custom {
+            host: host.address.clone(),
+            detail: format!("expand caddy_extra_caddyfile: {source}"),
+        })?;
+    let config = &config;
+
     // Build the upstream-name lookup by querying each routed service's
     // current containers on this host. Includes the just-started
     // replica AND (briefly) the old one — Caddy reloads gracefully.

--- a/yoink/src/deploy.rs
+++ b/yoink/src/deploy.rs
@@ -822,9 +822,31 @@ async fn push_caddy_config(
         })?;
     crate::proxy::admin::push_config(host, ops, &json)
         .await
-        .map_err(|source| DeployError::Custom {
-            host: host.address.clone(),
-            detail: format!("push Caddy config: {source}"),
+        .map_err(|source| {
+            // When Caddy bounces /load, point the operator at the
+            // services that have a `caddy_extra_json:` block —
+            // those are the most likely sources of schema errors.
+            // Unattributed users would otherwise stare at a Caddy
+            // backtrace with no clue which service caused it.
+            let extras: Vec<&str> = config
+                .services
+                .iter()
+                .filter(|s| s.caddy_extra_json.is_some())
+                .map(|s| s.name.as_str())
+                .collect();
+            let hint = if extras.is_empty() {
+                String::new()
+            } else {
+                format!(
+                    "\nhint: services with caddy_extra_json: {} — \
+                     run `yoink proxy-render` to inspect the rendered config",
+                    extras.join(", "),
+                )
+            };
+            DeployError::Custom {
+                host: host.address.clone(),
+                detail: format!("push Caddy config: {source}{hint}"),
+            }
         })?;
     Ok(())
 }

--- a/yoink/src/docker_ops.rs
+++ b/yoink/src/docker_ops.rs
@@ -1885,6 +1885,25 @@ async fn collect_stdout_stderr(
     Ok((stdout, stderr))
 }
 
+/// `parse_inspect` (and `ContainerInfo`'s port rendering) format each
+/// port-bindings entry as `"<host_port>:<container_port>/<proto>"`.
+/// Find the entry whose container port matches `wanted` and return
+/// the host port. Used by both the unregistry transport and the
+/// proxy admin client to look up an ephemeral published port.
+#[must_use]
+pub fn parse_published_port(entries: &[String], wanted: u16) -> Option<u16> {
+    let suffix = format!(":{wanted}/");
+    for entry in entries {
+        if let Some(idx) = entry.find(&suffix) {
+            let host_port = &entry[..idx];
+            if let Ok(p) = host_port.parse::<u16>() {
+                return Some(p);
+            }
+        }
+    }
+    None
+}
+
 /// Cheap random hex suffix for one-shot probe container names so two
 /// concurrent deploys can't collide.
 pub(crate) fn rand_hex() -> String {

--- a/yoink/src/init.rs
+++ b/yoink/src/init.rs
@@ -757,7 +757,7 @@ mod tests {
             sanitize_service_name("oddur/yoink-secrets").as_deref(),
             Some("oddur-yoink-secrets")
         );
-        assert_eq!(sanitize_service_name("backtrack").as_deref(), Some("backtrack"));
+        assert_eq!(sanitize_service_name("my-app").as_deref(), Some("my-app"));
     }
 
     #[test]

--- a/yoink/src/lib.rs
+++ b/yoink/src/lib.rs
@@ -12,6 +12,7 @@ pub mod lock;
 pub mod network;
 pub mod output;
 pub mod prune;
+pub mod proxy;
 pub mod sealed;
 pub mod secrets;
 pub mod ssh_keys;

--- a/yoink/src/main.rs
+++ b/yoink/src/main.rs
@@ -337,6 +337,13 @@ enum Command {
         #[arg(long)]
         check_hosts: bool,
     },
+    /// Render the Caddy admin-API JSON yoink would push for the
+    /// current config. Read-only; useful for inspecting the proxy
+    /// config or piping into `caddy adapt` / a debug Caddy's `/load`
+    /// for schema-validation. Container upstream lookups are skipped
+    /// (uses service-name fallbacks) so this works without a host
+    /// connection.
+    ProxyRender,
     /// Inspect / release the per-host deploy lock. Useful after a
     /// crashed deploy left a sentinel container running.
     Lock {
@@ -595,6 +602,7 @@ async fn run(cli: Cli) -> Result<()> {
         Command::Volumes { host } => cmd_volumes(&config, host.as_deref()).await,
         Command::Dump { log_tail } => cmd_dump(&config, log_tail).await,
         Command::Validate { check_hosts } => cmd_validate(&config, check_hosts).await,
+        Command::ProxyRender => cmd_proxy_render(&config).await,
         Command::Lock { action } => cmd_lock(&config, action).await,
         Command::Diff { service, tag } => cmd_diff(&config, &service, tag.as_deref()).await,
         Command::Completions { shell } => {
@@ -2045,6 +2053,23 @@ async fn cmd_validate(config: &Config, check_hosts: bool) -> Result<()> {
     if check_hosts {
         cmd_preflight(config).await?;
     }
+    Ok(())
+}
+
+async fn cmd_proxy_render(config: &Config) -> Result<()> {
+    if !yoink::proxy::proxy_enabled(config) {
+        anyhow::bail!(
+            "proxy is not enabled — no service has `domain:` and `proxy.enabled` is unset"
+        );
+    }
+    // Loads the secrets bundle when configured so `tls_*_secret` and
+    // `client_auth.trust_pool_secret` references resolve. Empty
+    // upstream lookup → render uses service-name fallbacks.
+    let bundle = load_secrets_bundle(config).await?;
+    let json = yoink::proxy::caddy::render(config, |_| Vec::new(), bundle.as_ref())
+        .context("render Caddy config")?;
+    let pretty = serde_json::to_string_pretty(&json).context("serialize rendered config")?;
+    println!("{pretty}");
     Ok(())
 }
 

--- a/yoink/src/main.rs
+++ b/yoink/src/main.rs
@@ -2066,12 +2066,12 @@ async fn cmd_validate(config: &Config, check_hosts: bool) -> Result<()> {
 
 async fn validate_proxy_render(config: &Config) -> Result<()> {
     let bundle = load_secrets_bundle(config).await?;
-    let json = match yoink::proxy::caddy::render(config, |_| Vec::new(), bundle.as_ref()) {
-        Ok(j) => j,
-        Err(e) => {
-            anyhow::bail!("render Caddy config: {e}");
-        }
-    };
+    let mut config = config.clone();
+    yoink::proxy::caddy::expand_caddyfile_snippets(&mut config)
+        .await
+        .context("expand caddy_extra_caddyfile snippets")?;
+    let json = yoink::proxy::caddy::render(&config, |_| Vec::new(), bundle.as_ref())
+        .context("render Caddy config")?;
     let body = serde_json::to_string(&json).context("serialize rendered config")?;
 
     // Probe for a local docker daemon. Skip gracefully if absent.
@@ -2156,7 +2156,11 @@ async fn cmd_proxy_render(config: &Config) -> Result<()> {
     // `client_auth.trust_pool_secret` references resolve. Empty
     // upstream lookup → render uses service-name fallbacks.
     let bundle = load_secrets_bundle(config).await?;
-    let json = yoink::proxy::caddy::render(config, |_| Vec::new(), bundle.as_ref())
+    let mut config = config.clone();
+    yoink::proxy::caddy::expand_caddyfile_snippets(&mut config)
+        .await
+        .context("expand caddy_extra_caddyfile snippets")?;
+    let json = yoink::proxy::caddy::render(&config, |_| Vec::new(), bundle.as_ref())
         .context("render Caddy config")?;
     let pretty = serde_json::to_string_pretty(&json).context("serialize rendered config")?;
     println!("{pretty}");

--- a/yoink/src/main.rs
+++ b/yoink/src/main.rs
@@ -2050,10 +2050,100 @@ async fn cmd_validate(config: &Config, check_hosts: bool) -> Result<()> {
         config.services.len(),
         config.hosts.len()
     );
+    // Caddy schema validation: render the proxy config and run it
+    // through `caddy validate` in an ephemeral container. Catches
+    // schema errors (invalid `caddy_extra_json`, bad TLS config,
+    // unknown handler module) BEFORE deploy time. Best-effort —
+    // skips silently if docker isn't on the operator's machine.
+    if yoink::proxy::proxy_enabled(config) {
+        validate_proxy_render(config).await?;
+    }
     if check_hosts {
         cmd_preflight(config).await?;
     }
     Ok(())
+}
+
+async fn validate_proxy_render(config: &Config) -> Result<()> {
+    let bundle = load_secrets_bundle(config).await?;
+    let json = match yoink::proxy::caddy::render(config, |_| Vec::new(), bundle.as_ref()) {
+        Ok(j) => j,
+        Err(e) => {
+            anyhow::bail!("render Caddy config: {e}");
+        }
+    };
+    let body = serde_json::to_string(&json).context("serialize rendered config")?;
+
+    // Probe for a local docker daemon. Skip gracefully if absent.
+    let docker_avail = tokio::process::Command::new("docker")
+        .arg("version")
+        .stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status()
+        .await
+        .is_ok_and(|s| s.success());
+    if !docker_avail {
+        eprintln!(
+            "  (skipping Caddy schema check — docker not available locally; \
+             pass --check-hosts or run on a host with docker installed)"
+        );
+        return Ok(());
+    }
+
+    let image = config
+        .proxy
+        .as_ref()
+        .map_or_else(|| "caddy:2".to_string(), yoink::config::ProxyConfig::resolved_image);
+    let mut child = tokio::process::Command::new("docker")
+        // JSON is Caddy's native config format — no `--adapter` flag.
+        // (`--adapter caddyfile` would convert from Caddyfile syntax;
+        // we feed JSON directly.)
+        .args([
+            "run", "--rm", "-i",
+            &image,
+            "caddy", "validate", "--config", "/dev/stdin",
+        ])
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .spawn()
+        .context("spawn `docker run caddy validate`")?;
+    {
+        use tokio::io::AsyncWriteExt;
+        let mut stdin = child.stdin.take().expect("piped stdin");
+        stdin
+            .write_all(body.as_bytes())
+            .await
+            .context("write rendered config to caddy validate stdin")?;
+        // Drop closes stdin → caddy reads EOF → validation runs.
+    }
+    let output = child
+        .wait_with_output()
+        .await
+        .context("wait on `docker run caddy validate`")?;
+    if output.status.success() {
+        println!("✓ Caddy config schema valid");
+        Ok(())
+    } else {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        let extras: Vec<&str> = config
+            .services
+            .iter()
+            .filter(|s| s.caddy_extra_json.is_some())
+            .map(|s| s.name.as_str())
+            .collect();
+        let hint = if extras.is_empty() {
+            String::new()
+        } else {
+            format!(
+                "\n\nhint: services with caddy_extra_json: {} — \
+                 run `yoink proxy-render` to inspect the rendered config",
+                extras.join(", "),
+            )
+        };
+        anyhow::bail!("Caddy rejected the rendered config:\n{stderr}{hint}");
+    }
 }
 
 async fn cmd_proxy_render(config: &Config) -> Result<()> {

--- a/yoink/src/proxy/admin.rs
+++ b/yoink/src/proxy/admin.rs
@@ -22,7 +22,7 @@ use std::time::{Duration, Instant};
 use serde_json::Value;
 use thiserror::Error;
 
-use crate::docker_ops::{DockerError, DockerOps, Host};
+use crate::docker_ops::{DockerError, DockerOps, Host, parse_published_port};
 use crate::transport::tunnel::{SshTunnel, TunnelError};
 
 use super::{ADMIN_PORT, PROXY_SERVICE_NAME};
@@ -127,22 +127,6 @@ pub async fn push_config(
     Ok(())
 }
 
-/// `parse_inspect` formats each entry as `"<host_port>:<container_port>/<proto>"`
-/// (or `"(unpublished) <container_port>/<proto>"`). Find the entry whose
-/// container port is `wanted` and return the host port.
-fn parse_published_port(entries: &[String], wanted: u16) -> Option<u16> {
-    let suffix = format!(":{wanted}/");
-    for entry in entries {
-        if let Some(idx) = entry.find(&suffix) {
-            let host_port = &entry[..idx];
-            if let Ok(p) = host_port.parse::<u16>() {
-                return Some(p);
-            }
-        }
-    }
-    None
-}
-
 async fn wait_until_ready(local_port: u16, timeout: Duration) -> Result<(), AdminError> {
     let url = format!("http://127.0.0.1:{local_port}/config/");
     let client = reqwest::Client::builder()
@@ -161,19 +145,3 @@ async fn wait_until_ready(local_port: u16, timeout: Duration) -> Result<(), Admi
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn parse_published_port_picks_wanted() {
-        let entries = vec![
-            "80:80/tcp".to_string(),
-            "443:443/tcp".to_string(),
-            "32773:2019/tcp".to_string(),
-        ];
-        assert_eq!(parse_published_port(&entries, 2019), Some(32773));
-        assert_eq!(parse_published_port(&entries, 80), Some(80));
-        assert_eq!(parse_published_port(&entries, 9999), None);
-    }
-}

--- a/yoink/src/proxy/admin.rs
+++ b/yoink/src/proxy/admin.rs
@@ -1,0 +1,182 @@
+//! Push rendered Caddy JSON to the proxy's admin API.
+//!
+//! Caddy's admin API listens on `:2019` *inside* the container, on
+//! the `yoink-proxy-admin` Docker network only (never published to
+//! the host). The yoink CLI reaches it for the duration of one
+//! `/load` call by:
+//!
+//! 1. Looking up the proxy container's IP on the admin network.
+//! 2. Opening an SSH-tunnelled forward from `localhost:<rand>` →
+//!    `<container_ip>:2019` on the host.
+//! 3. `POST`ing the JSON to `http://localhost:<rand>/load` with
+//!    `Content-Type: application/json`.
+//! 4. Dropping the tunnel.
+//!
+//! The state machine integration in `deploy.rs` calls
+//! [`push_config`] at the routing-flip moment of the rolling swap.
+
+use std::time::{Duration, Instant};
+
+use serde_json::Value;
+use thiserror::Error;
+
+use crate::docker_ops::{DockerError, DockerOps, Host};
+use crate::transport::tunnel::{SshTunnel, TunnelError};
+
+use super::{ADMIN_NETWORK, ADMIN_PORT, PROXY_SERVICE_NAME};
+
+#[derive(Debug, Error)]
+pub enum AdminError {
+    #[error("docker op against {host}: {source}")]
+    Docker {
+        host: String,
+        #[source]
+        source: DockerError,
+    },
+    #[error("proxy container {PROXY_SERVICE_NAME:?} not running on {host}")]
+    ProxyNotRunning { host: String },
+    #[error(
+        "proxy container on {host} is not attached to {ADMIN_NETWORK:?} \
+         (yoink expected the implicit injection to put it there)"
+    )]
+    NoAdminNetwork { host: String },
+    #[error("ssh tunnel to proxy admin: {0}")]
+    Tunnel(#[from] TunnelError),
+    #[error("proxy admin endpoint did not respond within {timeout:?}")]
+    NotReady { timeout: Duration },
+    #[error("HTTP error talking to proxy admin: {source}")]
+    Http {
+        #[source]
+        source: reqwest::Error,
+    },
+    #[error("proxy admin rejected /load with status {status}: {body}")]
+    LoadRejected {
+        status: reqwest::StatusCode,
+        body: String,
+    },
+}
+
+/// Push `config` to the proxy on `host`. Looks up the proxy
+/// container's IP on the admin network, opens an SSH tunnel, POSTs
+/// to `/load`, drops the tunnel.
+pub async fn push_config(
+    host: &Host,
+    ops: &dyn DockerOps,
+    config: &Value,
+) -> Result<(), AdminError> {
+    let label = format!("yoink.service={PROXY_SERVICE_NAME}");
+    let containers = ops
+        .list_containers_by_label(host, &label)
+        .await
+        .map_err(|source| AdminError::Docker {
+            host: host.address.clone(),
+            source,
+        })?;
+    let running = containers
+        .into_iter()
+        .find(crate::docker_ops::ContainerInfo::is_running)
+        .ok_or_else(|| AdminError::ProxyNotRunning {
+            host: host.address.clone(),
+        })?;
+
+    // The admin-network IP isn't carried in `ContainerDetail.networks`
+    // (which is just network names). Use a one-shot exec against the
+    // proxy container itself to read its own IP — see `pick_admin_ip`.
+    let ip = pick_admin_ip(host, ops, &running.name).await?;
+
+    let keyfile = ops.ssh_keyfile(host);
+    let tunnel = SshTunnel::open_to(
+        &host.user,
+        &host.address,
+        &ip,
+        ADMIN_PORT,
+        Duration::from_secs(20),
+        keyfile.as_deref(),
+    )
+    .await?;
+
+    wait_until_ready(tunnel.local_port(), Duration::from_secs(20)).await?;
+
+    let url = format!("http://127.0.0.1:{}/load", tunnel.local_port());
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(60))
+        .build()
+        .expect("reqwest client builder");
+    let resp = client
+        .post(&url)
+        .json(config)
+        .send()
+        .await
+        .map_err(|source| AdminError::Http { source })?;
+    if !resp.status().is_success() {
+        let status = resp.status();
+        let body = resp.text().await.unwrap_or_default();
+        return Err(AdminError::LoadRejected { status, body });
+    }
+    drop(tunnel);
+    Ok(())
+}
+
+async fn pick_admin_ip(
+    host: &Host,
+    ops: &dyn DockerOps,
+    container: &str,
+) -> Result<String, AdminError> {
+    let detail = ops
+        .inspect_container(host, container)
+        .await
+        .map_err(|source| AdminError::Docker {
+            host: host.address.clone(),
+            source,
+        })?;
+    if !detail.networks.iter().any(|n| n == ADMIN_NETWORK) {
+        return Err(AdminError::NoAdminNetwork {
+            host: host.address.clone(),
+        });
+    }
+    // ContainerDetail surfaces network names but not IPs. Use the
+    // bollard inspect raw response indirectly via a one-shot exec
+    // probe: ask the container to print its address on the admin
+    // network. Cheap, no schema changes to ContainerDetail.
+    //
+    // Caddy doesn't ship with `ip` or `hostname -I`. Use `getent
+    // hosts <self-name>` which works on Alpine + Debian + Caddy's
+    // distroless variants because nsswitch falls back to /etc/hosts
+    // where Docker writes the container's own IPs.
+    let result = ops
+        .exec_oneshot(
+            host,
+            container,
+            vec!["sh".into(), "-c".into(), format!("getent hosts {container} | awk '{{print $1}}' | head -1")],
+        )
+        .await
+        .map_err(|source| AdminError::Docker {
+            host: host.address.clone(),
+            source,
+        })?;
+    let ip = result.stdout.trim().to_string();
+    if ip.is_empty() {
+        return Err(AdminError::NoAdminNetwork {
+            host: host.address.clone(),
+        });
+    }
+    Ok(ip)
+}
+
+async fn wait_until_ready(local_port: u16, timeout: Duration) -> Result<(), AdminError> {
+    let url = format!("http://127.0.0.1:{local_port}/config/");
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(2))
+        .build()
+        .expect("reqwest client builder");
+    let deadline = Instant::now() + timeout;
+    loop {
+        match client.get(&url).send().await {
+            Ok(_) => return Ok(()),
+            Err(_) if Instant::now() < deadline => {
+                tokio::time::sleep(Duration::from_millis(150)).await;
+            }
+            Err(_) => return Err(AdminError::NotReady { timeout }),
+        }
+    }
+}

--- a/yoink/src/proxy/admin.rs
+++ b/yoink/src/proxy/admin.rs
@@ -1,19 +1,21 @@
 //! Push rendered Caddy JSON to the proxy's admin API.
 //!
-//! Caddy's admin API listens on `:2019` *inside* the container, on
-//! the `yoink-proxy-admin` Docker network only (never published to
-//! the host). The yoink CLI reaches it for the duration of one
-//! `/load` call by:
+//! Caddy's admin API listens on `:2019` *inside* the container and is
+//! published on the host's loopback at an ephemeral port (chosen by
+//! docker via `127.0.0.1:0:2019`). The yoink CLI:
 //!
-//! 1. Looking up the proxy container's IP on the admin network.
-//! 2. Opening an SSH-tunnelled forward from `localhost:<rand>` →
-//!    `<container_ip>:2019` on the host.
-//! 3. `POST`ing the JSON to `http://localhost:<rand>/load` with
-//!    `Content-Type: application/json`.
-//! 4. Dropping the tunnel.
+//! 1. Looks up the proxy container, reads the host-side admin port
+//!    from its inspect output.
+//! 2. SSH-tunnels from `operator-localhost:<rand>` to
+//!    `host-localhost:<published>`.
+//! 3. `POST`s the JSON to `http://127.0.0.1:<rand>/load`.
+//! 4. Drops the tunnel.
 //!
-//! The state machine integration in `deploy.rs` calls
-//! [`push_config`] at the routing-flip moment of the rolling swap.
+//! Why loopback-published instead of using the container's docker IP
+//! directly: docker doesn't route user-defined-network container IPs
+//! from the host, so an SSH-tunnel `-L … :<container_ip>:2019` gets
+//! "connection refused". Loopback publishing is the established
+//! pattern (same shape as the unregistry transport).
 
 use std::time::{Duration, Instant};
 
@@ -23,7 +25,7 @@ use thiserror::Error;
 use crate::docker_ops::{DockerError, DockerOps, Host};
 use crate::transport::tunnel::{SshTunnel, TunnelError};
 
-use super::{ADMIN_NETWORK, ADMIN_PORT, PROXY_SERVICE_NAME};
+use super::{ADMIN_PORT, PROXY_SERVICE_NAME};
 
 #[derive(Debug, Error)]
 pub enum AdminError {
@@ -36,10 +38,10 @@ pub enum AdminError {
     #[error("proxy container {PROXY_SERVICE_NAME:?} not running on {host}")]
     ProxyNotRunning { host: String },
     #[error(
-        "proxy container on {host} is not attached to {ADMIN_NETWORK:?} \
-         (yoink expected the implicit injection to put it there)"
+        "proxy container on {host} has no published admin port — yoink expected \
+         it on `127.0.0.1:0:{ADMIN_PORT}` but inspect returned: {ports:?}"
     )]
-    NoAdminNetwork { host: String },
+    NoPublishedAdminPort { host: String, ports: Vec<String> },
     #[error("ssh tunnel to proxy admin: {0}")]
     Tunnel(#[from] TunnelError),
     #[error("proxy admin endpoint did not respond within {timeout:?}")]
@@ -57,8 +59,8 @@ pub enum AdminError {
 }
 
 /// Push `config` to the proxy on `host`. Looks up the proxy
-/// container's IP on the admin network, opens an SSH tunnel, POSTs
-/// to `/load`, drops the tunnel.
+/// container's host-side admin port, opens an SSH tunnel to host
+/// loopback at that port, POSTs to `/load`, drops the tunnel.
 pub async fn push_config(
     host: &Host,
     ops: &dyn DockerOps,
@@ -79,17 +81,25 @@ pub async fn push_config(
             host: host.address.clone(),
         })?;
 
-    // The admin-network IP isn't carried in `ContainerDetail.networks`
-    // (which is just network names). Use a one-shot exec against the
-    // proxy container itself to read its own IP — see `pick_admin_ip`.
-    let ip = pick_admin_ip(host, ops, &running.name).await?;
+    let detail = ops
+        .inspect_container(host, &running.name)
+        .await
+        .map_err(|source| AdminError::Docker {
+            host: host.address.clone(),
+            source,
+        })?;
+    let host_port = parse_published_port(&detail.ports, ADMIN_PORT).ok_or_else(|| {
+        AdminError::NoPublishedAdminPort {
+            host: host.address.clone(),
+            ports: detail.ports.clone(),
+        }
+    })?;
 
     let keyfile = ops.ssh_keyfile(host);
-    let tunnel = SshTunnel::open_to(
+    let tunnel = SshTunnel::open(
         &host.user,
         &host.address,
-        &ip,
-        ADMIN_PORT,
+        host_port,
         Duration::from_secs(20),
         keyfile.as_deref(),
     )
@@ -117,50 +127,20 @@ pub async fn push_config(
     Ok(())
 }
 
-async fn pick_admin_ip(
-    host: &Host,
-    ops: &dyn DockerOps,
-    container: &str,
-) -> Result<String, AdminError> {
-    let detail = ops
-        .inspect_container(host, container)
-        .await
-        .map_err(|source| AdminError::Docker {
-            host: host.address.clone(),
-            source,
-        })?;
-    if !detail.networks.iter().any(|n| n == ADMIN_NETWORK) {
-        return Err(AdminError::NoAdminNetwork {
-            host: host.address.clone(),
-        });
+/// `parse_inspect` formats each entry as `"<host_port>:<container_port>/<proto>"`
+/// (or `"(unpublished) <container_port>/<proto>"`). Find the entry whose
+/// container port is `wanted` and return the host port.
+fn parse_published_port(entries: &[String], wanted: u16) -> Option<u16> {
+    let suffix = format!(":{wanted}/");
+    for entry in entries {
+        if let Some(idx) = entry.find(&suffix) {
+            let host_port = &entry[..idx];
+            if let Ok(p) = host_port.parse::<u16>() {
+                return Some(p);
+            }
+        }
     }
-    // ContainerDetail surfaces network names but not IPs. Use the
-    // bollard inspect raw response indirectly via a one-shot exec
-    // probe: ask the container to print its address on the admin
-    // network. Cheap, no schema changes to ContainerDetail.
-    //
-    // Caddy doesn't ship with `ip` or `hostname -I`. Use `getent
-    // hosts <self-name>` which works on Alpine + Debian + Caddy's
-    // distroless variants because nsswitch falls back to /etc/hosts
-    // where Docker writes the container's own IPs.
-    let result = ops
-        .exec_oneshot(
-            host,
-            container,
-            vec!["sh".into(), "-c".into(), format!("getent hosts {container} | awk '{{print $1}}' | head -1")],
-        )
-        .await
-        .map_err(|source| AdminError::Docker {
-            host: host.address.clone(),
-            source,
-        })?;
-    let ip = result.stdout.trim().to_string();
-    if ip.is_empty() {
-        return Err(AdminError::NoAdminNetwork {
-            host: host.address.clone(),
-        });
-    }
-    Ok(ip)
+    None
 }
 
 async fn wait_until_ready(local_port: u16, timeout: Duration) -> Result<(), AdminError> {
@@ -171,12 +151,29 @@ async fn wait_until_ready(local_port: u16, timeout: Duration) -> Result<(), Admi
         .expect("reqwest client builder");
     let deadline = Instant::now() + timeout;
     loop {
-        match client.get(&url).send().await {
-            Ok(_) => return Ok(()),
-            Err(_) if Instant::now() < deadline => {
-                tokio::time::sleep(Duration::from_millis(150)).await;
-            }
-            Err(_) => return Err(AdminError::NotReady { timeout }),
+        if client.get(&url).send().await.is_ok() {
+            return Ok(());
         }
+        if Instant::now() >= deadline {
+            return Err(AdminError::NotReady { timeout });
+        }
+        tokio::time::sleep(Duration::from_millis(150)).await;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_published_port_picks_wanted() {
+        let entries = vec![
+            "80:80/tcp".to_string(),
+            "443:443/tcp".to_string(),
+            "32773:2019/tcp".to_string(),
+        ];
+        assert_eq!(parse_published_port(&entries, 2019), Some(32773));
+        assert_eq!(parse_published_port(&entries, 80), Some(80));
+        assert_eq!(parse_published_port(&entries, 9999), None);
     }
 }

--- a/yoink/src/proxy/caddy.rs
+++ b/yoink/src/proxy/caddy.rs
@@ -1,0 +1,383 @@
+//! Render a [`Config`] into the JSON document Caddy's admin API
+//! `/load` endpoint accepts.
+//!
+//! See <https://caddyserver.com/docs/json/> for the schema. The shape
+//! we emit is deliberately the smallest one that covers yoink's
+//! routing primitives:
+//!
+//! - One HTTP server (`apps.http.servers.main`) listening on `:80` +
+//!   `:443`.
+//! - One route per service-with-`domain:`, matching by host header
+//!   and forwarding to the service's container DNS name on the
+//!   ingress network.
+//! - Optional ACME automation when any service uses `tls: auto`.
+//! - Optional inline `tls.certificates.load_pem` entries for
+//!   `tls: cert` services (e.g. Cloudflare Origin Certs).
+//!
+//! Any directives beyond this surface — auth, rate limiting, headers
+//! — go through `caddy_extra_json:`, which is merged verbatim into
+//! the route's `handle` array immediately before the auto-generated
+//! `reverse_proxy` handler. Yoink does not validate the JSON; Caddy
+//! does, on `/load`.
+
+use std::collections::BTreeMap;
+
+use anyhow::{Context, Result, anyhow};
+use serde_json::{Value, json};
+
+use crate::config::{Config, ServiceConfig, TlsMode};
+use crate::secrets::SecretsBundle;
+
+use super::is_proxied;
+
+/// Render `cfg` into the Caddy admin-API JSON config. Container names
+/// in the upstream pool come from `container_names_for(service_name)`
+/// — one entry per replica, in deterministic order. Cert/key bytes
+/// for `tls: cert` services come from `bundle`; an `Err` is returned
+/// if a referenced secret is missing.
+pub fn render<F>(
+    cfg: &Config,
+    container_names_for: F,
+    bundle: Option<&SecretsBundle>,
+) -> Result<Value>
+where
+    F: Fn(&str) -> Vec<String>,
+{
+    let proxied: Vec<&ServiceConfig> = cfg.services.iter().filter(|s| is_proxied(s)).collect();
+
+    let mut routes: Vec<Value> = Vec::with_capacity(proxied.len());
+    for svc in &proxied {
+        routes.push(render_route(svc, &container_names_for(&svc.name))?);
+    }
+
+    let mut http_server = json!({
+        "listen": [":80", ":443"],
+        "routes": routes,
+    });
+
+    let mut config = json!({
+        "apps": {
+            "http": {
+                "servers": {
+                    "main": http_server.take(),
+                }
+            }
+        }
+    });
+
+    // ACME automation, only when at least one service uses `tls: auto`.
+    let any_acme = proxied.iter().any(|s| matches!(s.tls, TlsMode::Auto));
+    if any_acme {
+        let email = cfg
+            .proxy
+            .as_ref()
+            .and_then(|p| p.email.as_ref())
+            .ok_or_else(|| {
+                anyhow!(
+                    "rendering ACME policy requires `proxy.email:` — should have been \
+                     caught by inject_implicit_proxy validation"
+                )
+            })?;
+        config["apps"]["tls"] = json!({
+            "automation": {
+                "policies": [{
+                    "issuers": [{
+                        "module": "acme",
+                        "email": email,
+                    }]
+                }]
+            }
+        });
+    }
+
+    // Inline certificates for `tls: cert` services. We collect them
+    // into a single `load_pem` list rather than one per service so
+    // Caddy's matcher dedup is straightforward.
+    let cert_services: Vec<&&ServiceConfig> = proxied
+        .iter()
+        .filter(|s| matches!(s.tls, TlsMode::Cert))
+        .collect();
+    if !cert_services.is_empty() {
+        let bundle = bundle.ok_or_else(|| {
+            anyhow!(
+                "{} service(s) use `tls: cert` but no [secrets] block is configured",
+                cert_services.len(),
+            )
+        })?;
+        let mut pem_entries: Vec<Value> = Vec::new();
+        for svc in &cert_services {
+            let cert_name = svc.tls_cert_secret.as_deref().expect("validated upstream");
+            let key_name = svc.tls_key_secret.as_deref().expect("validated upstream");
+            let cert = bundle.get(cert_name).ok_or_else(|| {
+                anyhow!(
+                    "service {:?} references tls_cert_secret={cert_name:?} but the \
+                     secrets bundle has no such key",
+                    svc.name,
+                )
+            })?;
+            let key = bundle.get(key_name).ok_or_else(|| {
+                anyhow!(
+                    "service {:?} references tls_key_secret={key_name:?} but the \
+                     secrets bundle has no such key",
+                    svc.name,
+                )
+            })?;
+            pem_entries.push(json!({
+                "certificate": cert,
+                "key": key,
+                "tags": [format!("yoink:{}", svc.name)],
+            }));
+        }
+
+        // Merge with any existing `apps.tls` (from ACME above).
+        let tls = config["apps"].as_object_mut().unwrap();
+        let entry = tls.entry("tls").or_insert_with(|| json!({}));
+        entry["certificates"] = json!({ "load_pem": pem_entries });
+    }
+
+    Ok(config)
+}
+
+fn render_route(svc: &ServiceConfig, containers: &[String]) -> Result<Value> {
+    let port = svc.run.port.ok_or_else(|| {
+        anyhow!(
+            "service {:?} has `domain:` but no `run.port` (should have been caught \
+             by inject_implicit_proxy)",
+            svc.name,
+        )
+    })?;
+
+    let upstreams: Vec<Value> = if containers.is_empty() {
+        // No live container yet (e.g. first deploy, /load before
+        // create). Use the service name as a single-host fallback so
+        // Caddy's active health check still sees the upstream when
+        // it appears.
+        vec![json!({"dial": format!("{}:{port}", svc.name)})]
+    } else {
+        containers
+            .iter()
+            .map(|c| json!({"dial": format!("{c}:{port}")}))
+            .collect()
+    };
+
+    let health_path = svc
+        .run
+        .healthcheck_path
+        .clone()
+        .unwrap_or_else(|| "/".to_string());
+
+    let mut handle: Vec<Value> = Vec::new();
+
+    // Operator-supplied snippet. Append before the reverse_proxy so
+    // gating directives (forward_auth) run first.
+    if let Some(extra) = svc.caddy_extra_json.as_deref() {
+        let parsed: Value = serde_json::from_str(extra).with_context(|| {
+            format!(
+                "service {:?}: caddy_extra_json is not valid JSON",
+                svc.name,
+            )
+        })?;
+        // Accept either a single object (one handler) or a list.
+        match parsed {
+            Value::Array(xs) => handle.extend(xs),
+            Value::Object(_) => handle.push(parsed),
+            other => {
+                return Err(anyhow!(
+                    "service {:?}: caddy_extra_json must be a JSON object or array of \
+                     objects, got {}",
+                    svc.name,
+                    discriminant_str(&other),
+                ));
+            }
+        }
+    }
+
+    handle.push(json!({
+        "handler": "reverse_proxy",
+        "upstreams": upstreams,
+        "health_checks": {
+            "active": {
+                "uri": health_path,
+                "interval": "10s",
+                "timeout": "2s",
+            }
+        }
+    }));
+
+    let host_match = json!({"host": svc.domain.as_ref().unwrap().as_list()});
+
+    let mut route = json!({
+        "match": [host_match],
+        "handle": handle,
+        "terminal": true,
+    });
+
+    if matches!(svc.tls, TlsMode::Off) {
+        route["@yoink_tls_off"] = json!(true);
+    }
+
+    Ok(route)
+}
+
+fn discriminant_str(v: &Value) -> &'static str {
+    match v {
+        Value::Null => "null",
+        Value::Bool(_) => "bool",
+        Value::Number(_) => "number",
+        Value::String(_) => "string",
+        Value::Array(_) => "array",
+        Value::Object(_) => "object",
+    }
+}
+
+/// Compute a stable hash of the rendered Caddy JSON for use in the
+/// `_proxy` service's `yoink.spec_hash` label. Drift detection re-uses
+/// the same `compute_spec_hash` plumbing as every other service.
+///
+/// `serde_json::to_string` of a `serde_json::Value` is deterministic
+/// for the JSON shapes we render (BTreeMap-backed objects), so this
+/// hash is stable across runs given the same input.
+#[must_use]
+pub fn config_fingerprint(json: &Value) -> String {
+    use sha2::{Digest, Sha256};
+    use std::fmt::Write;
+    let canonical = serde_json::to_string(json).expect("rendered JSON always serializes");
+    let mut hasher = Sha256::new();
+    hasher.update(canonical.as_bytes());
+    let digest = hasher.finalize();
+    let mut out = String::with_capacity(16);
+    for byte in &digest[..8] {
+        let _ = write!(out, "{byte:02x}");
+    }
+    out
+}
+
+/// Per-host map of (service name → [container name, …]). Used as the
+/// `container_names_for` input to [`render`]. Empty for first-deploy
+/// when the route is being pushed before any container exists.
+pub type UpstreamMap = BTreeMap<String, Vec<String>>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::ProxyConfig;
+
+    fn parse(yaml: &str) -> Config {
+        Config::parse_str(yaml).expect("parse")
+    }
+
+    #[test]
+    fn vanilla_acme_service_renders() {
+        let cfg = parse(
+            r#"
+deploy: { networks: [n] }
+hosts: [{ address: h1, user: deploy }]
+proxy: { email: ops@example.com }
+services:
+  - name: api
+    image: img
+    tag: t
+    domain: api.example.com
+    run: { port: 8080 }
+"#,
+        );
+        let upstreams = |s: &str| {
+            if s == "api" {
+                vec!["api-1".to_string()]
+            } else {
+                vec![]
+            }
+        };
+        let json = render(&cfg, upstreams, None).expect("render");
+        // ACME issuer present
+        let issuer = &json["apps"]["tls"]["automation"]["policies"][0]["issuers"][0]["module"];
+        assert_eq!(issuer.as_str(), Some("acme"));
+        // Route has the right host + upstream
+        let route = &json["apps"]["http"]["servers"]["main"]["routes"][0];
+        assert_eq!(
+            route["match"][0]["host"][0].as_str(),
+            Some("api.example.com")
+        );
+        let dial = &route["handle"].as_array().unwrap().last().unwrap()["upstreams"][0]["dial"];
+        assert_eq!(dial.as_str(), Some("api-1:8080"));
+    }
+
+    #[test]
+    fn caddy_extra_json_array_renders_before_reverse_proxy() {
+        let mut cfg = parse(
+            r#"
+deploy: { networks: [n] }
+hosts: [{ address: h1, user: deploy }]
+proxy: { email: ops@example.com }
+services:
+  - name: api
+    image: img
+    tag: t
+    domain: api.example.com
+    caddy_extra_json: '[{"handler":"forward_auth","upstreams":[{"dial":"auth:9091"}]}]'
+    run: { port: 8080 }
+"#,
+        );
+        cfg.proxy = Some(ProxyConfig {
+            email: Some("ops@example.com".into()),
+            ..Default::default()
+        });
+        let json = render(&cfg, |_| vec![], None).expect("render");
+        let handlers = json["apps"]["http"]["servers"]["main"]["routes"][0]["handle"]
+            .as_array()
+            .unwrap();
+        assert_eq!(handlers.len(), 2);
+        assert_eq!(handlers[0]["handler"], "forward_auth");
+        assert_eq!(handlers[1]["handler"], "reverse_proxy");
+    }
+
+    #[test]
+    fn cert_path_inlines_secrets() {
+        let yaml = r#"
+deploy: { networks: [n] }
+hosts: [{ address: h1, user: deploy }]
+secrets: { provider: age, recipients: [age1xxxxx] }
+services:
+  - name: api
+    image: img
+    tag: t
+    domain: api.example.com
+    tls: cert
+    tls_cert_secret: CF_CERT
+    tls_key_secret: CF_KEY
+    run: { port: 8080 }
+"#;
+        let cfg = parse(yaml);
+        let mut values = std::collections::BTreeMap::new();
+        values.insert("CF_CERT".to_string(), "-----BEGIN CERT-----\n".to_string());
+        values.insert("CF_KEY".to_string(), "-----BEGIN KEY-----\n".to_string());
+        let bundle = SecretsBundle::new(values);
+        let json = render(&cfg, |_| vec!["api-1".into()], Some(&bundle)).expect("render");
+        let entries = &json["apps"]["tls"]["certificates"]["load_pem"];
+        assert_eq!(entries.as_array().unwrap().len(), 1);
+        assert!(entries[0]["certificate"]
+            .as_str()
+            .unwrap()
+            .starts_with("-----BEGIN CERT"));
+    }
+
+    #[test]
+    fn fingerprint_stable_across_runs() {
+        let cfg = parse(
+            r#"
+deploy: { networks: [n] }
+hosts: [{ address: h1, user: deploy }]
+proxy: { email: ops@example.com }
+services:
+  - name: api
+    image: img
+    tag: t
+    domain: api.example.com
+    run: { port: 8080 }
+"#,
+        );
+        let json1 = render(&cfg, |_| vec!["api-1".into()], None).unwrap();
+        let json2 = render(&cfg, |_| vec!["api-1".into()], None).unwrap();
+        assert_eq!(config_fingerprint(&json1), config_fingerprint(&json2));
+    }
+}

--- a/yoink/src/proxy/caddy.rs
+++ b/yoink/src/proxy/caddy.rs
@@ -62,7 +62,12 @@ where
         if let Some(redirect) = render_canonical_redirect_route(svc)? {
             routes.push(redirect);
         }
-        routes.push(render_route(svc, &container_names_for(&svc.name))?);
+        // A service serves TLS when its own `tls:` is Auto/Cert OR
+        // when proxy-level TLS is configured (every routed service
+        // inherits). Off explicitly disables. HSTS only emits when
+        // the operator's actually serving HTTPS.
+        let tls_active = !matches!(svc.tls, TlsMode::Off) || proxy_tls.is_some();
+        routes.push(render_route(svc, &container_names_for(&svc.name), tls_active)?);
     }
 
     // Auto :80 → :443 redirect when proxy-level TLS is in play. Caddy
@@ -331,7 +336,7 @@ fn redirect_route_http_to_https() -> Value {
     })
 }
 
-fn render_route(svc: &ServiceConfig, containers: &[String]) -> Result<Value> {
+fn render_route(svc: &ServiceConfig, containers: &[String], tls_active: bool) -> Result<Value> {
     let port = svc.run.port.ok_or_else(|| {
         anyhow!(
             "service {:?} has `domain:` but no `run.port` (should have been caught \
@@ -384,6 +389,23 @@ fn render_route(svc: &ServiceConfig, containers: &[String]) -> Result<Value> {
             "handler": "encode",
             "encodings": {"gzip": {}, "zstd": {}},
             "prefer": ["zstd", "gzip"],
+        }));
+    }
+
+    // HSTS for TLS sites. Default-on: every browser pins HTTPS-only
+    // after first visit. One year + includeSubDomains is the
+    // standard prod setting (preload-eligible). `hsts: false` opts
+    // out for the rare mixed-protocol case.
+    if svc.hsts && tls_active {
+        handle.push(json!({
+            "handler": "headers",
+            "response": {
+                "set": {
+                    "Strict-Transport-Security": [
+                        "max-age=31536000; includeSubDomains"
+                    ]
+                }
+            }
         }));
     }
 
@@ -606,9 +628,96 @@ services:
         let handlers = json["apps"]["http"]["servers"]["main"]["routes"][0]["handle"]
             .as_array()
             .unwrap();
-        assert_eq!(handlers.len(), 2);
+        // forward_auth (operator), headers (HSTS, default-on), reverse_proxy.
+        assert_eq!(handlers.len(), 3);
         assert_eq!(handlers[0]["handler"], "forward_auth");
-        assert_eq!(handlers[1]["handler"], "reverse_proxy");
+        assert_eq!(handlers[1]["handler"], "headers");
+        assert_eq!(handlers[2]["handler"], "reverse_proxy");
+    }
+
+    #[test]
+    fn hsts_default_on_for_tls_auto() {
+        let cfg = parse(
+            r#"
+deploy: { networks: [n] }
+hosts: [{ address: h1, user: deploy }]
+proxy: { email: ops@example.com }
+services:
+  - name: api
+    image: img
+    tag: t
+    domain: api.example.com
+    run: { port: 8080 }
+"#,
+        );
+        let json = render(&cfg, |_| vec![], None).expect("render");
+        let handlers = json["apps"]["http"]["servers"]["main"]["routes"][0]["handle"]
+            .as_array()
+            .unwrap();
+        let hsts = handlers
+            .iter()
+            .find(|h| h["handler"] == "headers")
+            .expect("HSTS handler should be present");
+        let value = &hsts["response"]["set"]["Strict-Transport-Security"][0];
+        assert!(
+            value.as_str().unwrap().contains("max-age=31536000"),
+            "got: {value}"
+        );
+    }
+
+    #[test]
+    fn hsts_skipped_for_tls_off() {
+        let mut cfg = parse(
+            r#"
+deploy: { networks: [n] }
+hosts: [{ address: h1, user: deploy }]
+proxy: { email: ops@example.com }
+services:
+  - name: api
+    image: img
+    tag: t
+    domain: api.example.com
+    tls: off
+    run: { port: 8080 }
+"#,
+        );
+        // Force the proxy block in (no TLS sites + no email might
+        // otherwise trip a different validation path).
+        cfg.proxy = Some(ProxyConfig {
+            email: Some("ops@example.com".into()),
+            ..Default::default()
+        });
+        let json = render(&cfg, |_| vec![], None).expect("render");
+        let handlers = json["apps"]["http"]["servers"]["main"]["routes"][0]["handle"]
+            .as_array()
+            .unwrap();
+        assert!(
+            handlers.iter().all(|h| h["handler"] != "headers"),
+            "no HSTS expected when tls: off"
+        );
+    }
+
+    #[test]
+    fn hsts_opt_out_via_field() {
+        let cfg = parse(
+            r#"
+deploy: { networks: [n] }
+hosts: [{ address: h1, user: deploy }]
+proxy: { email: ops@example.com }
+services:
+  - name: api
+    image: img
+    tag: t
+    domain: api.example.com
+    hsts: false
+    run: { port: 8080 }
+"#,
+        );
+        let json = render(&cfg, |_| vec![], None).expect("render");
+        let handlers = json["apps"]["http"]["servers"]["main"]["routes"][0]["handle"]
+            .as_array()
+            .unwrap();
+        assert!(handlers.iter().all(|h| h["handler"] != "headers"));
     }
 
     #[test]

--- a/yoink/src/proxy/caddy.rs
+++ b/yoink/src/proxy/caddy.rs
@@ -35,6 +35,7 @@ use super::is_proxied;
 /// — one entry per replica, in deterministic order. Cert/key bytes
 /// for `tls: cert` services come from `bundle`; an `Err` is returned
 /// if a referenced secret is missing.
+#[allow(clippy::too_many_lines)] // mostly straight-line JSON assembly
 pub fn render<F>(
     cfg: &Config,
     container_names_for: F,
@@ -43,17 +44,53 @@ pub fn render<F>(
 where
     F: Fn(&str) -> Vec<String>,
 {
+    let proxy_tls = cfg.proxy.as_ref().and_then(|p| p.tls.as_ref());
     let proxied: Vec<&ServiceConfig> = cfg.services.iter().filter(|s| is_proxied(s)).collect();
 
-    let mut routes: Vec<Value> = Vec::with_capacity(proxied.len());
+    let mut routes: Vec<Value> = Vec::with_capacity(proxied.len() + 1);
     for svc in &proxied {
         routes.push(render_route(svc, &container_names_for(&svc.name))?);
+    }
+
+    // Auto :80 → :443 redirect when proxy-level TLS is in play. Caddy
+    // would normally do this via auto_https; we emit it explicitly so
+    // the rendered config is self-contained and doesn't rely on
+    // Caddy's auto-pilot semantics around inline certs.
+    if proxy_tls.is_some() {
+        routes.insert(0, redirect_route_http_to_https());
     }
 
     let mut http_server = json!({
         "listen": [":80", ":443"],
         "routes": routes,
     });
+
+    // mTLS lives in connection_policies, applied to every TLS handshake.
+    if let Some(tls) = proxy_tls
+        && let Some(client_auth) = tls.client_auth.as_ref()
+    {
+        let bundle = bundle.ok_or_else(|| {
+            anyhow!(
+                "proxy.tls.client_auth requires a [secrets] block to resolve \
+                 trust_pool_secret"
+            )
+        })?;
+        let trust_pool = bundle
+            .get(&client_auth.trust_pool_secret)
+            .ok_or_else(|| {
+                anyhow!(
+                    "proxy.tls.client_auth.trust_pool_secret={:?} not found in the \
+                     secrets bundle",
+                    client_auth.trust_pool_secret,
+                )
+            })?;
+        http_server["tls_connection_policies"] = json!([{
+            "client_authentication": {
+                "mode": client_auth.mode.as_caddy(),
+                "trusted_ca_certs_pem": [trust_pool],
+            }
+        }]);
+    }
 
     let mut config = json!({
         "apps": {
@@ -65,8 +102,11 @@ where
         }
     });
 
-    // ACME automation, only when at least one service uses `tls: auto`.
-    let any_acme = proxied.iter().any(|s| matches!(s.tls, TlsMode::Auto));
+    // ACME is only for services that genuinely want it AND aren't
+    // covered by a proxy-level inline cert. Proxy-level cert disables
+    // ACME entirely (we never want both running on the same domains).
+    let any_acme = proxy_tls.is_none()
+        && proxied.iter().any(|s| matches!(s.tls, TlsMode::Auto));
     if any_acme {
         let email = cfg
             .proxy
@@ -90,9 +130,36 @@ where
         });
     }
 
-    // Inline certificates for `tls: cert` services. We collect them
-    // into a single `load_pem` list rather than one per service so
-    // Caddy's matcher dedup is straightforward.
+    // Resolve the inline cert(s). Two sources merge into one
+    // `load_pem` list:
+    //   - proxy.tls.cert_secret/key_secret (covers every routed
+    //     service that doesn't override).
+    //   - per-service tls_cert_secret/tls_key_secret (the override).
+    let mut pem_entries: Vec<Value> = Vec::new();
+
+    if let Some(tls) = proxy_tls {
+        let bundle = bundle.ok_or_else(|| {
+            anyhow!("proxy.tls.cert_secret requires a [secrets] block to resolve")
+        })?;
+        let cert = bundle.get(&tls.cert_secret).ok_or_else(|| {
+            anyhow!(
+                "proxy.tls.cert_secret={:?} not found in the secrets bundle",
+                tls.cert_secret,
+            )
+        })?;
+        let key = bundle.get(&tls.key_secret).ok_or_else(|| {
+            anyhow!(
+                "proxy.tls.key_secret={:?} not found in the secrets bundle",
+                tls.key_secret,
+            )
+        })?;
+        pem_entries.push(json!({
+            "certificate": cert,
+            "key": key,
+            "tags": ["yoink:proxy-default"],
+        }));
+    }
+
     let cert_services: Vec<&&ServiceConfig> = proxied
         .iter()
         .filter(|s| matches!(s.tls, TlsMode::Cert))
@@ -104,7 +171,6 @@ where
                 cert_services.len(),
             )
         })?;
-        let mut pem_entries: Vec<Value> = Vec::new();
         for svc in &cert_services {
             let cert_name = svc.tls_cert_secret.as_deref().expect("validated upstream");
             let key_name = svc.tls_key_secret.as_deref().expect("validated upstream");
@@ -128,14 +194,31 @@ where
                 "tags": [format!("yoink:{}", svc.name)],
             }));
         }
+    }
 
-        // Merge with any existing `apps.tls` (from ACME above).
+    if !pem_entries.is_empty() {
         let tls = config["apps"].as_object_mut().unwrap();
         let entry = tls.entry("tls").or_insert_with(|| json!({}));
         entry["certificates"] = json!({ "load_pem": pem_entries });
     }
 
     Ok(config)
+}
+
+fn redirect_route_http_to_https() -> Value {
+    // Match :80 only; rewrite scheme + 308 redirect. Caddy's `redir`
+    // handler is the JSON shape below.
+    json!({
+        "match": [{"protocol": "http"}],
+        "handle": [{
+            "handler": "static_response",
+            "status_code": 308,
+            "headers": {
+                "Location": ["https://{http.request.host}{http.request.uri}"],
+            }
+        }],
+        "terminal": true,
+    })
 }
 
 fn render_route(svc: &ServiceConfig, containers: &[String]) -> Result<Value> {
@@ -359,6 +442,103 @@ services:
             .as_str()
             .unwrap()
             .starts_with("-----BEGIN CERT"));
+    }
+
+    #[test]
+    fn proxy_tls_with_mtls_renders_connection_policies_and_redirect() {
+        let yaml = r#"
+deploy: { networks: [n] }
+hosts: [{ address: h1, user: deploy }]
+secrets: { provider: age, recipients: [age1xxxxx] }
+proxy:
+  tls:
+    cert_secret: CF_CERT
+    key_secret: CF_KEY
+    client_auth:
+      mode: require_and_verify
+      trust_pool_secret: CF_CA
+services:
+  - name: api
+    image: img
+    tag: t
+    domain: api.example.com
+    run: { port: 8080 }
+  - name: web
+    image: img
+    tag: t
+    domain: [example.com, www.example.com]
+    run: { port: 3000 }
+"#;
+        let cfg = parse(yaml);
+        let mut values = std::collections::BTreeMap::new();
+        values.insert("CF_CERT".to_string(), "-----BEGIN CERTIFICATE-----\n".into());
+        values.insert("CF_KEY".to_string(), "-----BEGIN PRIVATE KEY-----\n".into());
+        values.insert("CF_CA".to_string(), "-----BEGIN CERTIFICATE-----CA\n".into());
+        let bundle = SecretsBundle::new(values);
+        let json = render(&cfg, |_| vec!["api-1".into()], Some(&bundle)).expect("render");
+
+        // No ACME — proxy-level cert overrides it.
+        assert!(json["apps"]["tls"]["automation"].is_null());
+
+        // mTLS connection_policies present.
+        let policies = &json["apps"]["http"]["servers"]["main"]["tls_connection_policies"];
+        assert_eq!(
+            policies[0]["client_authentication"]["mode"].as_str(),
+            Some("require_and_verify")
+        );
+        assert!(policies[0]["client_authentication"]["trusted_ca_certs_pem"][0]
+            .as_str()
+            .unwrap()
+            .contains("CA"));
+
+        // First route is the :80 → :443 redirect.
+        let routes = json["apps"]["http"]["servers"]["main"]["routes"]
+            .as_array()
+            .unwrap();
+        assert_eq!(
+            routes[0]["match"][0]["protocol"].as_str(),
+            Some("http")
+        );
+        assert_eq!(routes[0]["handle"][0]["status_code"].as_i64(), Some(308));
+
+        // Inline cert is present (one entry covers everything).
+        let pem = &json["apps"]["tls"]["certificates"]["load_pem"];
+        assert_eq!(pem.as_array().unwrap().len(), 1);
+        assert_eq!(
+            pem[0]["tags"][0].as_str(),
+            Some("yoink:proxy-default")
+        );
+
+        // Both services routed (api + web).
+        let host_routes: Vec<&Value> = routes.iter().skip(1).collect();
+        assert_eq!(host_routes.len(), 2);
+    }
+
+    #[test]
+    fn proxy_tls_without_acme_skips_email_requirement() {
+        let yaml = r#"
+deploy: { networks: [n] }
+hosts: [{ address: h1, user: deploy }]
+secrets: { provider: age, recipients: [age1xxxxx] }
+proxy:
+  tls:
+    cert_secret: CF_CERT
+    key_secret: CF_KEY
+services:
+  - name: api
+    image: img
+    tag: t
+    domain: api.example.com
+    run: { port: 8080 }
+"#;
+        // No proxy.email: but no ACME because proxy.tls is set.
+        let cfg = parse(yaml);
+        let mut values = std::collections::BTreeMap::new();
+        values.insert("CF_CERT".to_string(), "cert".into());
+        values.insert("CF_KEY".to_string(), "key".into());
+        let json = render(&cfg, |_| vec![], Some(&SecretsBundle::new(values))).expect("render");
+        assert!(json["apps"]["tls"]["automation"].is_null());
+        assert!(json["apps"]["tls"]["certificates"]["load_pem"][0].is_object());
     }
 
     #[test]

--- a/yoink/src/proxy/caddy.rs
+++ b/yoink/src/proxy/caddy.rs
@@ -250,6 +250,114 @@ where
     Ok(config)
 }
 
+/// Expand every `caddy_extra_caddyfile:` snippet in `cfg` into its
+/// JSON form (mutating the service's `caddy_extra_json` slot in
+/// place). Shells out to `docker run --rm -i caddy:2 caddy adapt`
+/// for each snippet — requires docker on the operator's machine.
+///
+/// Caller pattern: clone the config, expand, then render. Render
+/// stays sync because all docker spawning happens here.
+pub async fn expand_caddyfile_snippets(
+    cfg: &mut crate::config::Config,
+) -> anyhow::Result<()> {
+    for svc in &mut cfg.services {
+        let Some(caddyfile) = svc.caddy_extra_caddyfile.take() else {
+            continue;
+        };
+        if svc.caddy_extra_json.is_some() {
+            return Err(anyhow!(
+                "service {:?}: caddy_extra_caddyfile and caddy_extra_json are \
+                 mutually exclusive — pick one",
+                svc.name,
+            ));
+        }
+        let handlers = adapt_snippet_to_handlers(&caddyfile, &svc.name).await?;
+        svc.caddy_extra_json = Some(handlers);
+    }
+    Ok(())
+}
+
+async fn adapt_snippet_to_handlers(snippet: &str, svc_name: &str) -> anyhow::Result<String> {
+    use std::process::Stdio;
+    use tokio::io::AsyncWriteExt;
+    use tokio::process::Command;
+
+    // Caddyfile requires a top-level site block; wrap the user's
+    // bare directives so `caddy adapt` accepts the snippet.
+    let wrapped = format!(":80 {{\n{snippet}\n}}\n");
+
+    // `caddy adapt` doesn't support stdin via `--config -`; it
+    // requires a real file. Write the wrapped snippet to a tempfile
+    // inside the container, then adapt against it. Container writes
+    // to /tmp (writable in the default caddy:2 image).
+    let mut child = Command::new("docker")
+        .args([
+            "run",
+            "--rm",
+            "-i",
+            "--entrypoint",
+            "sh",
+            "caddy:2",
+            "-c",
+            "cat > /tmp/snippet.caddyfile && \
+             caddy adapt --config /tmp/snippet.caddyfile --adapter caddyfile",
+        ])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .with_context(|| {
+            format!(
+                "service {svc_name:?}: spawn `docker run caddy adapt` (is docker installed?)"
+            )
+        })?;
+    child
+        .stdin
+        .take()
+        .expect("piped stdin")
+        .write_all(wrapped.as_bytes())
+        .await
+        .with_context(|| format!("service {svc_name:?}: write Caddyfile to adapt stdin"))?;
+    let output = child
+        .wait_with_output()
+        .await
+        .with_context(|| format!("service {svc_name:?}: wait on caddy adapt"))?;
+    if !output.status.success() {
+        return Err(anyhow!(
+            "service {svc_name:?}: caddy adapt rejected the Caddyfile snippet:\n{}",
+            String::from_utf8_lossy(&output.stderr).trim(),
+        ));
+    }
+
+    // Adapter output is a full Caddy JSON config. Caddy may emit one
+    // route per directive (e.g. `respond /robots.txt ...` becomes a
+    // route with a path matcher) OR pile multiple directives into
+    // one route's handle list — depends on directive ordering rules.
+    // To preserve everything, take the full routes list and wrap it
+    // in a single `subroute` handler, which `normalize_extra_json`
+    // will then splice into the service's site-block.
+    let parsed: Value = serde_json::from_slice(&output.stdout)
+        .with_context(|| format!("service {svc_name:?}: parse caddy adapt output"))?;
+    let routes = parsed
+        .pointer("/apps/http/servers/srv0/routes")
+        .ok_or_else(|| {
+            anyhow!(
+                "service {svc_name:?}: caddy adapt output didn't contain a routes list \
+                 at apps/http/servers/srv0/routes. Snippet may be empty."
+            )
+        })?
+        .clone();
+    // Single subroute wrapping all of Caddy's generated routes.
+    // normalize_extra_json's "handler form" branch passes this
+    // through verbatim into the site-block handle array.
+    let wrapped = json!([{
+        "handler": "subroute",
+        "routes": routes,
+    }]);
+    serde_json::to_string(&wrapped)
+        .with_context(|| format!("service {svc_name:?}: serialize adapted handlers"))
+}
+
 /// Extract each `-----BEGIN CERTIFICATE-----` block from a PEM bundle
 /// and return its base64-encoded DER body (the inner base64 content
 /// without headers / whitespace). Caddy 2's `tls.ca_pool.source.inline`

--- a/yoink/src/proxy/caddy.rs
+++ b/yoink/src/proxy/caddy.rs
@@ -47,8 +47,15 @@ where
     let proxy_tls = cfg.proxy.as_ref().and_then(|p| p.tls.as_ref());
     let proxied: Vec<&ServiceConfig> = cfg.services.iter().filter(|s| is_proxied(s)).collect();
 
-    let mut routes: Vec<Value> = Vec::with_capacity(proxied.len() + 1);
-    for svc in &proxied {
+    // Order services so path-constrained routes come before
+    // catch-all routes for the same host. Caddy uses first-match;
+    // without ordering, a `domain: example.com` (no path) before a
+    // `domain: example.com, path_prefix: /api/*` would always win.
+    let mut ordered: Vec<&ServiceConfig> = proxied.clone();
+    ordered.sort_by_key(|s| s.path_prefix.is_none()); // false (has prefix) < true (catch-all)
+
+    let mut routes: Vec<Value> = Vec::with_capacity(ordered.len() + 1);
+    for svc in &ordered {
         // Canonical-domain redirect: when a service lists multiple
         // hosts and pins one as canonical, render a 308 redirect
         // route from the non-canonical entries before the main route.
@@ -403,10 +410,21 @@ fn render_route(svc: &ServiceConfig, containers: &[String]) -> Result<Value> {
     }
     handle.push(reverse_proxy);
 
-    let host_match = json!({"host": svc.domain.as_ref().unwrap().as_list()});
+    // Match on host always; on path too when path_prefix is set.
+    // Caddy's `path` matcher accepts globs (`/api/*`); we pass the
+    // operator's value verbatim, so `/api/*` and `/api*` and
+    // `/api/foo` all do what Caddy does with them.
+    let mut matchers = serde_json::Map::new();
+    matchers.insert(
+        "host".into(),
+        json!(svc.domain.as_ref().unwrap().as_list()),
+    );
+    if let Some(prefix) = &svc.path_prefix {
+        matchers.insert("path".into(), json!([prefix]));
+    }
 
     let mut route = json!({
-        "match": [host_match],
+        "match": [Value::Object(matchers)],
         "handle": handle,
         "terminal": true,
     });

--- a/yoink/src/proxy/caddy.rs
+++ b/yoink/src/proxy/caddy.rs
@@ -49,6 +49,12 @@ where
 
     let mut routes: Vec<Value> = Vec::with_capacity(proxied.len() + 1);
     for svc in &proxied {
+        // Canonical-domain redirect: when a service lists multiple
+        // hosts and pins one as canonical, render a 308 redirect
+        // route from the non-canonical entries before the main route.
+        if let Some(redirect) = render_canonical_redirect_route(svc)? {
+            routes.push(redirect);
+        }
         routes.push(render_route(svc, &container_names_for(&svc.name))?);
     }
 
@@ -66,6 +72,11 @@ where
     });
 
     // mTLS lives in connection_policies, applied to every TLS handshake.
+    // Caddy 2's `tls.ca_pool.source.inline` provider takes
+    // base64-encoded DER certs (the bytes that sit between PEM
+    // BEGIN/END markers), one entry per cert in the chain. We split
+    // the trust-pool PEM into blocks here so a multi-cert bundle
+    // (e.g. Cloudflare's origin-pull CA chain) round-trips correctly.
     if let Some(tls) = proxy_tls
         && let Some(client_auth) = tls.client_auth.as_ref()
     {
@@ -84,15 +95,37 @@ where
                     client_auth.trust_pool_secret,
                 )
             })?;
+        let der_b64_certs = pem_to_der_b64_blocks(trust_pool);
+        if der_b64_certs.is_empty() {
+            return Err(anyhow!(
+                "proxy.tls.client_auth.trust_pool_secret={:?} has no CERTIFICATE PEM \
+                 blocks",
+                client_auth.trust_pool_secret,
+            ));
+        }
         http_server["tls_connection_policies"] = json!([{
             "client_authentication": {
                 "mode": client_auth.mode.as_caddy(),
-                "trusted_ca_certs_pem": [trust_pool],
+                "ca": {
+                    "provider": "inline",
+                    "trusted_ca_certs": der_b64_certs,
+                }
             }
         }]);
     }
 
     let mut config = json!({
+        // Same admin block as the synthesized proxy's bootstrap. Caddy
+        // /load REPLACES the active config — if we omit the admin
+        // block, Caddy reverts admin from `0.0.0.0:2019` to the
+        // default `localhost:2019`, which breaks docker's port
+        // forwarding (the docker-proxy on the host sends to the
+        // container's eth0:2019, not lo). Subsequent /load calls
+        // would then time out trying to reach the admin endpoint.
+        "admin": {
+            "listen": "0.0.0.0:2019",
+            "enforce_origin": false,
+        },
         "apps": {
             "http": {
                 "servers": {
@@ -205,6 +238,76 @@ where
     Ok(config)
 }
 
+/// Extract each `-----BEGIN CERTIFICATE-----` block from a PEM bundle
+/// and return its base64-encoded DER body (the inner base64 content
+/// without headers / whitespace). Caddy 2's `tls.ca_pool.source.inline`
+/// `trusted_ca_certs` is a list of base64-DER strings — one per cert
+/// in the chain — not full PEM. Other PEM types (PRIVATE KEY,
+/// EC PRIVATE KEY, …) are ignored: trust pools are CERTIFICATE only.
+fn pem_to_der_b64_blocks(pem: &str) -> Vec<String> {
+    let mut out = Vec::new();
+    let mut in_cert = false;
+    let mut acc = String::new();
+    for line in pem.lines() {
+        let line = line.trim();
+        if line == "-----BEGIN CERTIFICATE-----" {
+            in_cert = true;
+            acc.clear();
+        } else if line == "-----END CERTIFICATE-----" {
+            if in_cert && !acc.is_empty() {
+                out.push(std::mem::take(&mut acc));
+            }
+            in_cert = false;
+        } else if in_cert {
+            acc.push_str(line);
+        }
+    }
+    out
+}
+
+/// Build a `:443`-side route that 308-redirects every non-canonical
+/// hostname listed in `domain:` to `canonical_domain:`. Returns
+/// `Ok(None)` for services that don't set `canonical_domain` or that
+/// only declare one hostname (nothing to redirect).
+fn render_canonical_redirect_route(svc: &ServiceConfig) -> Result<Option<Value>> {
+    let Some(canonical) = svc.canonical_domain.as_deref() else {
+        return Ok(None);
+    };
+    let domains = svc
+        .domain
+        .as_ref()
+        .ok_or_else(|| {
+            anyhow!(
+                "service {:?}: canonical_domain set without domain (caught by \
+                 inject_implicit_proxy validation upstream)",
+                svc.name,
+            )
+        })?
+        .as_list();
+    if !domains.iter().any(|d| d == canonical) {
+        return Err(anyhow!(
+            "service {:?}: canonical_domain={canonical:?} is not one of the entries \
+             in domain: {domains:?}",
+            svc.name,
+        ));
+    }
+    let non_canonical: Vec<String> = domains.into_iter().filter(|d| d != canonical).collect();
+    if non_canonical.is_empty() {
+        return Ok(None);
+    }
+    Ok(Some(json!({
+        "match": [{"host": non_canonical}],
+        "handle": [{
+            "handler": "static_response",
+            "status_code": 308,
+            "headers": {
+                "Location": [format!("https://{canonical}{{http.request.uri}}")],
+            }
+        }],
+        "terminal": true,
+    })))
+}
+
 fn redirect_route_http_to_https() -> Value {
     // Match :80 only; rewrite scheme + 308 redirect. Caddy's `redir`
     // handler is the JSON shape below.
@@ -252,7 +355,9 @@ fn render_route(svc: &ServiceConfig, containers: &[String]) -> Result<Value> {
     let mut handle: Vec<Value> = Vec::new();
 
     // Operator-supplied snippet. Append before the reverse_proxy so
-    // gating directives (forward_auth) run first.
+    // gating directives (forward_auth) run first. Routes are
+    // auto-wrapped in a `subroute` handler so the operator never has
+    // to know about `subroute` to inline a (match → handle).
     if let Some(extra) = svc.caddy_extra_json.as_deref() {
         let parsed: Value = serde_json::from_str(extra).with_context(|| {
             format!(
@@ -260,22 +365,22 @@ fn render_route(svc: &ServiceConfig, containers: &[String]) -> Result<Value> {
                 svc.name,
             )
         })?;
-        // Accept either a single object (one handler) or a list.
-        match parsed {
-            Value::Array(xs) => handle.extend(xs),
-            Value::Object(_) => handle.push(parsed),
-            other => {
-                return Err(anyhow!(
-                    "service {:?}: caddy_extra_json must be a JSON object or array of \
-                     objects, got {}",
-                    svc.name,
-                    discriminant_str(&other),
-                ));
-            }
+        for item in normalize_extra_json(parsed, &svc.name)? {
+            handle.push(item);
         }
     }
 
-    handle.push(json!({
+    // Optional gzip + zstd compression handler. Vanilla Caddy's
+    // `encode` module — no plugin needed.
+    if svc.compression {
+        handle.push(json!({
+            "handler": "encode",
+            "encodings": {"gzip": {}, "zstd": {}},
+            "prefer": ["zstd", "gzip"],
+        }));
+    }
+
+    let mut reverse_proxy = json!({
         "handler": "reverse_proxy",
         "upstreams": upstreams,
         "health_checks": {
@@ -285,7 +390,18 @@ fn render_route(svc: &ServiceConfig, containers: &[String]) -> Result<Value> {
                 "timeout": "2s",
             }
         }
-    }));
+    });
+    if svc.upstream_h2c {
+        // h2c = HTTP/2 cleartext to the upstream. Required for native
+        // gRPC backends (Tonic, grpc-go, grpc-java) and for
+        // HTTP/2-only upstream apps. Doesn't affect what Caddy serves
+        // to clients.
+        reverse_proxy["transport"] = json!({
+            "protocol": "http",
+            "versions": ["h2c"],
+        });
+    }
+    handle.push(reverse_proxy);
 
     let host_match = json!({"host": svc.domain.as_ref().unwrap().as_list()});
 
@@ -300,6 +416,69 @@ fn render_route(svc: &ServiceConfig, containers: &[String]) -> Result<Value> {
     }
 
     Ok(route)
+}
+
+/// Coerce `caddy_extra_json` parsed value into a list of handler
+/// objects ready to splice into the route's `handle` array.
+///
+/// - Handler shape (`{"handler": "x", ...}`) → pass-through.
+/// - Route shape (`{"match": ..., "handle": ...}`) → wrapped in a
+///   single `subroute` handler. Operators get to write the natural
+///   shape ("when X, do Y") without knowing `subroute` exists.
+/// - Mixed lists → each entry classified independently; route-shaped
+///   entries are wrapped together in one `subroute`.
+fn normalize_extra_json(parsed: Value, svc_name: &str) -> Result<Vec<Value>> {
+    let items: Vec<Value> = match parsed {
+        Value::Array(xs) => xs,
+        Value::Object(_) => vec![parsed],
+        other => {
+            return Err(anyhow!(
+                "service {svc_name:?}: caddy_extra_json must be a JSON object or array \
+                 of objects, got {}",
+                discriminant_str(&other),
+            ));
+        }
+    };
+
+    let mut handlers: Vec<Value> = Vec::with_capacity(items.len());
+    let mut routes_buf: Vec<Value> = Vec::new();
+    for item in items {
+        let obj = match item.as_object() {
+            Some(_) => item,
+            None => {
+                return Err(anyhow!(
+                    "service {svc_name:?}: caddy_extra_json entries must be JSON \
+                     objects (a handler or a route), got {}",
+                    discriminant_str(&item),
+                ));
+            }
+        };
+        if obj.get("handler").is_some() {
+            // Flush any pending routes into a subroute, then append
+            // this handler — preserves user-written ordering.
+            if !routes_buf.is_empty() {
+                handlers.push(json!({
+                    "handler": "subroute",
+                    "routes": std::mem::take(&mut routes_buf),
+                }));
+            }
+            handlers.push(obj);
+        } else if obj.get("match").is_some() || obj.get("handle").is_some() {
+            routes_buf.push(obj);
+        } else {
+            return Err(anyhow!(
+                "service {svc_name:?}: caddy_extra_json entry has neither `handler` \
+                 (handler form) nor `match`/`handle` (route form): {obj}",
+            ));
+        }
+    }
+    if !routes_buf.is_empty() {
+        handlers.push(json!({
+            "handler": "subroute",
+            "routes": routes_buf,
+        }));
+    }
+    Ok(handlers)
 }
 
 fn discriminant_str(v: &Value) -> &'static str {
@@ -473,7 +652,11 @@ services:
         let mut values = std::collections::BTreeMap::new();
         values.insert("CF_CERT".to_string(), "-----BEGIN CERTIFICATE-----\n".into());
         values.insert("CF_KEY".to_string(), "-----BEGIN PRIVATE KEY-----\n".into());
-        values.insert("CF_CA".to_string(), "-----BEGIN CERTIFICATE-----CA\n".into());
+        values.insert(
+            "CF_CA".to_string(),
+            "-----BEGIN CERTIFICATE-----\nMIIBfakeCAder\n-----END CERTIFICATE-----\n"
+                .into(),
+        );
         let bundle = SecretsBundle::new(values);
         let json = render(&cfg, |_| vec!["api-1".into()], Some(&bundle)).expect("render");
 
@@ -486,10 +669,14 @@ services:
             policies[0]["client_authentication"]["mode"].as_str(),
             Some("require_and_verify")
         );
-        assert!(policies[0]["client_authentication"]["trusted_ca_certs_pem"][0]
-            .as_str()
-            .unwrap()
-            .contains("CA"));
+        assert_eq!(
+            policies[0]["client_authentication"]["ca"]["provider"].as_str(),
+            Some("inline")
+        );
+        assert_eq!(
+            policies[0]["client_authentication"]["ca"]["trusted_ca_certs"][0].as_str(),
+            Some("MIIBfakeCAder")
+        );
 
         // First route is the :80 → :443 redirect.
         let routes = json["apps"]["http"]["servers"]["main"]["routes"]

--- a/yoink/src/proxy/mod.rs
+++ b/yoink/src/proxy/mod.rs
@@ -236,9 +236,16 @@ fn synthesized_proxy_service(p: &ProxyConfig) -> ServiceConfig {
         canonical_domain: None,
         compression: false,
         path_prefix: None,
+        hsts: false, // proxy itself doesn't serve TLS; this field is irrelevant
         run: ServiceRun {
-            port: None,
-            healthcheck_path: None,
+            // Healthcheck probes Caddy's admin endpoint (`/config/`)
+            // on the container's :2019 from inside the proxy's first
+            // network. Eliminates the race where yoink-proxy is
+            // "started" per docker but Caddy's HTTP server hasn't
+            // bound yet — without this gate, the first /load can
+            // arrive before admin is up.
+            port: Some(ADMIN_PORT),
+            healthcheck_path: Some("/config/".to_string()),
             // Caddy serves :80 + :443 on the host. Admin API on :2019
             // is published on 127.0.0.1 with an ephemeral host port
             // (`:0:2019`) so it's reachable from the host (and only

--- a/yoink/src/proxy/mod.rs
+++ b/yoink/src/proxy/mod.rs
@@ -64,6 +64,7 @@ pub fn is_proxied(svc: &ServiceConfig) -> bool {
 /// exist in `deploy.networks`, and add `_proxy` to every routed
 /// service's `depends_on:` list. Idempotent — safe to call after
 /// validation has already added the proxy.
+#[allow(clippy::too_many_lines)] // mostly straight-line validation
 pub fn inject_implicit_proxy(cfg: &mut Config) -> Result<(), ConfigError> {
     if !proxy_enabled(cfg) {
         return Ok(());
@@ -95,6 +96,37 @@ pub fn inject_implicit_proxy(cfg: &mut Config) -> Result<(), ConfigError> {
                  `tls_key_secret` — both are required for the inline-cert path \
                  (or set `proxy.tls.cert_secret` to inherit)",
                 svc.name,
+            )));
+        }
+    }
+
+    // path_prefix disambiguation: when N services share a hostname,
+    // at most one can be the catch-all (no path_prefix); the rest must
+    // declare a path_prefix. Otherwise route order is operator-
+    // dependent and bugs are subtle.
+    let mut by_host: std::collections::BTreeMap<String, Vec<&ServiceConfig>> =
+        std::collections::BTreeMap::new();
+    for svc in &cfg.services {
+        let Some(domain) = &svc.domain else { continue };
+        for host in domain.as_list() {
+            by_host.entry(host).or_default().push(svc);
+        }
+    }
+    for (host, services) in &by_host {
+        if services.len() < 2 {
+            continue;
+        }
+        let catch_alls: Vec<&str> = services
+            .iter()
+            .filter(|s| s.path_prefix.is_none())
+            .map(|s| s.name.as_str())
+            .collect();
+        if catch_alls.len() > 1 {
+            return Err(ConfigError::Invalid(format!(
+                "{} services route {host:?} without a path_prefix \
+                 (services: {catch_alls:?}) — at most one catch-all per host; \
+                 add `path_prefix:` to the others",
+                catch_alls.len(),
             )));
         }
     }
@@ -203,28 +235,39 @@ fn synthesized_proxy_service(p: &ProxyConfig) -> ServiceConfig {
         upstream_h2c: false,
         canonical_domain: None,
         compression: false,
+        path_prefix: None,
         run: ServiceRun {
             port: None,
             healthcheck_path: None,
-            // Caddy serves :80 + :443 on the host — that's the whole
-            // point of the proxy. Admin API on :2019 is published on
-            // 127.0.0.1 with an ephemeral host port (`:0:2019`) so
-            // it's reachable from the host (and only from the host)
-            // without going through docker's bridge networking,
-            // which doesn't expose user-defined-network container
-            // IPs to the host. The yoink CLI looks up the actual
-            // host port via `inspect_container` and SSH-tunnels to
-            // it for the duration of one `/load` call.
+            // Caddy serves :80 + :443 on the host. Admin API on :2019
+            // is published on 127.0.0.1 with an ephemeral host port
+            // (`:0:2019`) so it's reachable from the host (and only
+            // from the host) — docker doesn't route user-defined-
+            // network container IPs from the host. yoink looks up
+            // the actual host port via `inspect_container` and
+            // SSH-tunnels to it for one `/load` call.
+            //
+            // `proxy.bind:` (when set) prepends the bind address to
+            // :80/:443 so the proxy is reachable only on that
+            // interface (e.g. tailnet IP). Admin port stays on
+            // 127.0.0.1 regardless.
             //
             // The :80/:443 publishes also implicitly force stop-first
             // deploy (port bindings are exclusive at the kernel
             // level), so a proxy redeploy briefly drops :80/:443
             // until the new container binds.
-            publish: vec![
-                "80:80".to_string(),
-                "443:443".to_string(),
-                "127.0.0.1:0:2019".to_string(),
-            ],
+            publish: {
+                let prefix = p
+                    .bind
+                    .as_deref()
+                    .map(|ip| format!("{ip}:"))
+                    .unwrap_or_default();
+                vec![
+                    format!("{prefix}80:80"),
+                    format!("{prefix}443:443"),
+                    "127.0.0.1:0:2019".to_string(),
+                ]
+            },
             // Override the official caddy:2 image's entrypoint to
             // start with a minimal bootstrap config: admin bound to
             // 0.0.0.0:2019 (so the admin endpoint is reachable from

--- a/yoink/src/proxy/mod.rs
+++ b/yoink/src/proxy/mod.rs
@@ -69,13 +69,18 @@ pub fn inject_implicit_proxy(cfg: &mut Config) -> Result<(), ConfigError> {
         return Ok(());
     }
 
+    let proxy_has_inline_cert = cfg
+        .proxy
+        .as_ref()
+        .and_then(|p| p.tls.as_ref())
+        .is_some();
+
     // Validation: any service using `tls: cert` must name both
-    // `tls_cert_secret` and `tls_key_secret`; reject early so the
-    // operator gets a config-time error rather than a deploy-time one.
+    // `tls_cert_secret` and `tls_key_secret` (or inherit from
+    // `proxy.tls`); reject early so the operator gets a config-time
+    // error rather than a deploy-time one.
     for svc in &cfg.services {
-        if svc.domain.is_some()
-            && svc.run.port.is_none()
-        {
+        if svc.domain.is_some() && svc.run.port.is_none() {
             return Err(ConfigError::Invalid(format!(
                 "service {:?} has `domain:` but no `run.port` — the proxy needs to know \
                  which container port to forward to",
@@ -87,22 +92,27 @@ pub fn inject_implicit_proxy(cfg: &mut Config) -> Result<(), ConfigError> {
         {
             return Err(ConfigError::Invalid(format!(
                 "service {:?} sets `tls: cert` but is missing `tls_cert_secret` and/or \
-                 `tls_key_secret` — both are required for the inline-cert path",
+                 `tls_key_secret` — both are required for the inline-cert path \
+                 (or set `proxy.tls.cert_secret` to inherit)",
                 svc.name,
             )));
         }
     }
 
     // ACME requires an email address — fail loudly if any service uses
-    // `tls: auto` (the default) but `proxy.email` isn't set.
-    let any_acme = cfg
-        .services
-        .iter()
-        .any(|s| s.domain.is_some() && matches!(s.tls, TlsMode::Auto));
+    // `tls: auto` (the default) and we'd actually run ACME (no
+    // proxy-level inline cert overrides it) and `proxy.email` isn't
+    // set.
+    let any_acme = !proxy_has_inline_cert
+        && cfg
+            .services
+            .iter()
+            .any(|s| s.domain.is_some() && matches!(s.tls, TlsMode::Auto));
     if any_acme && cfg.proxy.as_ref().and_then(|p| p.email.as_ref()).is_none() {
         return Err(ConfigError::Invalid(
             "at least one service uses `tls: auto` (Let's Encrypt) but `proxy.email:` \
-             is unset — Let's Encrypt requires a registration email"
+             is unset — Let's Encrypt requires a registration email (or set \
+             `proxy.tls.cert_secret` for an inline cert instead)"
                 .to_string(),
         ));
     }

--- a/yoink/src/proxy/mod.rs
+++ b/yoink/src/proxy/mod.rs
@@ -232,6 +232,7 @@ fn synthesized_proxy_service(p: &ProxyConfig) -> ServiceConfig {
         tls_cert_secret: None,
         tls_key_secret: None,
         caddy_extra_json: None,
+        caddy_extra_caddyfile: None,
         upstream_h2c: false,
         canonical_domain: None,
         compression: false,

--- a/yoink/src/proxy/mod.rs
+++ b/yoink/src/proxy/mod.rs
@@ -1,0 +1,315 @@
+//! First-class reverse-proxy integration.
+//!
+//! Yoink bundles Caddy as a managed service when any service in the
+//! config declares `domain:`. The proxy is just a regular yoink
+//! service (`name = "yoink-proxy"`, `kind = ServiceKind::Proxy`) — it
+//! reconciles through the same code path as everything else, drift-
+//! detects via the same `spec_hash` label, and shows up in the same
+//! TUI. The only special handling is:
+//!
+//! 1. Auto-injection at config-load time so users never write the
+//!    `_proxy` block themselves (this module).
+//! 2. Caddy JSON config rendered from the user-facing schema and
+//!    pushed via Caddy's admin API at deterministic points in the
+//!    rolling deploy ([`caddy`] + [`admin`]).
+//!
+//! Application-layer concerns (auth, rate limits, headers, CORS) are
+//! deliberately not modeled. Use [`ServiceConfig::caddy_extra_json`]
+//! to drop in a JSON snippet of additional Caddy handlers.
+
+pub mod admin;
+pub mod caddy;
+
+use crate::config::{
+    Config, ConfigError, ProxyConfig, ServiceConfig, ServiceKind, ServiceRun, TlsMode,
+};
+
+/// The internal service name yoink uses for the implicit reverse
+/// proxy. Users may not declare a service with this name when they
+/// also use `domain:` — that's a collision error.
+pub const PROXY_SERVICE_NAME: &str = "yoink-proxy";
+
+/// Docker network the proxy uses to reach upstream containers by
+/// name. Every service with `domain:` joins it automatically.
+pub const INGRESS_NETWORK: &str = "yoink-ingress";
+
+/// Docker network the proxy publishes its admin API on. Only the
+/// proxy itself joins this network — the yoink CLI reaches the
+/// admin API by inspecting the proxy container's IP on this network
+/// and opening an SSH-tunnelled forward to it.
+pub const ADMIN_NETWORK: &str = "yoink-proxy-admin";
+
+/// Container port the Caddy admin API listens on (Caddy default).
+pub const ADMIN_PORT: u16 = 2019;
+
+/// True when the proxy should be enabled for `cfg` — either explicitly
+/// (`proxy.enabled: true`) or implicitly (any service has `domain:`).
+#[must_use]
+pub fn proxy_enabled(cfg: &Config) -> bool {
+    if let Some(p) = &cfg.proxy
+        && let Some(explicit) = p.enabled
+    {
+        return explicit;
+    }
+    cfg.services.iter().any(|s| s.domain.is_some())
+}
+
+/// True when this service should be routed by the proxy.
+#[must_use]
+pub fn is_proxied(svc: &ServiceConfig) -> bool {
+    svc.domain.is_some()
+}
+
+/// Synthesize the `_proxy` service, ensure ingress/admin networks
+/// exist in `deploy.networks`, and add `_proxy` to every routed
+/// service's `depends_on:` list. Idempotent — safe to call after
+/// validation has already added the proxy.
+pub fn inject_implicit_proxy(cfg: &mut Config) -> Result<(), ConfigError> {
+    if !proxy_enabled(cfg) {
+        return Ok(());
+    }
+
+    // Validation: any service using `tls: cert` must name both
+    // `tls_cert_secret` and `tls_key_secret`; reject early so the
+    // operator gets a config-time error rather than a deploy-time one.
+    for svc in &cfg.services {
+        if svc.domain.is_some()
+            && svc.run.port.is_none()
+        {
+            return Err(ConfigError::Invalid(format!(
+                "service {:?} has `domain:` but no `run.port` — the proxy needs to know \
+                 which container port to forward to",
+                svc.name,
+            )));
+        }
+        if matches!(svc.tls, TlsMode::Cert)
+            && (svc.tls_cert_secret.is_none() || svc.tls_key_secret.is_none())
+        {
+            return Err(ConfigError::Invalid(format!(
+                "service {:?} sets `tls: cert` but is missing `tls_cert_secret` and/or \
+                 `tls_key_secret` — both are required for the inline-cert path",
+                svc.name,
+            )));
+        }
+    }
+
+    // ACME requires an email address — fail loudly if any service uses
+    // `tls: auto` (the default) but `proxy.email` isn't set.
+    let any_acme = cfg
+        .services
+        .iter()
+        .any(|s| s.domain.is_some() && matches!(s.tls, TlsMode::Auto));
+    if any_acme && cfg.proxy.as_ref().and_then(|p| p.email.as_ref()).is_none() {
+        return Err(ConfigError::Invalid(
+            "at least one service uses `tls: auto` (Let's Encrypt) but `proxy.email:` \
+             is unset — Let's Encrypt requires a registration email"
+                .to_string(),
+        ));
+    }
+
+    // Refuse the user-defined `_proxy` collision case. Safer than
+    // silently overriding because the user's definition probably
+    // wouldn't have the right networks/admin-port wiring anyway.
+    if cfg.services.iter().any(|s| {
+        s.name == PROXY_SERVICE_NAME && !matches!(s.kind, Some(ServiceKind::Proxy))
+    }) {
+        return Err(ConfigError::Invalid(format!(
+            "service name {PROXY_SERVICE_NAME:?} is reserved for the implicit reverse \
+             proxy — rename your service or remove `domain:` from the routed services",
+        )));
+    }
+
+    // Ensure both implicit networks are declared. A user can also
+    // declare them explicitly (e.g. to attach extra services to
+    // `yoink-ingress`); idempotent.
+    for net in [INGRESS_NETWORK, ADMIN_NETWORK] {
+        if !cfg.deploy.networks.iter().any(|n| n == net) {
+            cfg.deploy.networks.push(net.to_string());
+        }
+    }
+
+    // Every routed service joins the ingress network. Preserve any
+    // tier networks the operator already declared.
+    for svc in &mut cfg.services {
+        if !is_proxied(svc) {
+            continue;
+        }
+        let mut nets = svc.networks.clone().unwrap_or_else(|| cfg.deploy.networks.clone());
+        if !nets.iter().any(|n| n == INGRESS_NETWORK) {
+            nets.push(INGRESS_NETWORK.to_string());
+        }
+        svc.networks = Some(nets);
+        if !svc.depends_on.iter().any(|d| d == PROXY_SERVICE_NAME) {
+            svc.depends_on.push(PROXY_SERVICE_NAME.to_string());
+        }
+    }
+
+    // Add the synthesized proxy service if not already present
+    // (idempotent for tests that round-trip Config → render → re-parse).
+    if !cfg
+        .services
+        .iter()
+        .any(|s| s.name == PROXY_SERVICE_NAME)
+    {
+        let proxy_cfg = cfg.proxy.clone().unwrap_or_default();
+        cfg.services.push(synthesized_proxy_service(&proxy_cfg));
+    }
+    Ok(())
+}
+
+fn synthesized_proxy_service(p: &ProxyConfig) -> ServiceConfig {
+    ServiceConfig {
+        name: PROXY_SERVICE_NAME.to_string(),
+        image: p.resolved_image(),
+        kind: Some(ServiceKind::Proxy),
+        build: None,
+        // Tag baked into the image ref — Caddy's official tag is the
+        // version (`caddy:2`); for xcaddy-built images the operator
+        // pins the tag in `proxy.image:` directly.
+        tag: None,
+        hosts: None,
+        env: std::collections::BTreeMap::default(),
+        secrets: Vec::new(),
+        env_from_secrets: std::collections::BTreeMap::default(),
+        labels: std::collections::BTreeMap::default(),
+        pre_deploy: Vec::new(),
+        depends_on: Vec::new(),
+        networks: Some(vec![INGRESS_NETWORK.to_string(), ADMIN_NETWORK.to_string()]),
+        domain: None,
+        tls: TlsMode::Auto,
+        tls_cert_secret: None,
+        tls_key_secret: None,
+        caddy_extra_json: None,
+        run: ServiceRun {
+            // Caddy serves :80 + :443 on the host. We publish those
+            // because that's the whole point of the proxy. The admin
+            // API on :2019 is NOT published — it's reached via
+            // SSH-tunnelled access to the container's IP on the
+            // `_proxy-admin` network.
+            port: None,
+            healthcheck_path: None,
+            ..ServiceRun::default()
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::DomainSpec;
+
+    fn config_with_one_service(domain: Option<DomainSpec>, port: Option<u16>) -> Config {
+        let mut cfg = Config::parse_str(
+            r#"
+deploy:
+  networks: [n]
+hosts:
+  - { address: h1, user: deploy }
+services:
+  - name: api
+    image: img
+    tag: t
+    networks: [n]
+    run:
+      port: 8080
+"#,
+        )
+        .expect("base config parses");
+        cfg.services[0].domain = domain;
+        cfg.services[0].run.port = port;
+        cfg
+    }
+
+    #[test]
+    fn no_domain_means_no_proxy() {
+        let cfg = config_with_one_service(None, Some(8080));
+        assert!(!proxy_enabled(&cfg));
+        assert!(!cfg.services.iter().any(|s| s.name == PROXY_SERVICE_NAME));
+    }
+
+    #[test]
+    fn domain_synthesizes_proxy_and_networks() {
+        let mut cfg = config_with_one_service(
+            Some(DomainSpec::Single("api.example.com".into())),
+            Some(8080),
+        );
+        // Need ACME email since default tls is Auto.
+        cfg.proxy = Some(ProxyConfig {
+            email: Some("ops@example.com".into()),
+            ..ProxyConfig::default()
+        });
+        inject_implicit_proxy(&mut cfg).expect("inject ok");
+        assert!(cfg.deploy.networks.iter().any(|n| n == INGRESS_NETWORK));
+        assert!(cfg.deploy.networks.iter().any(|n| n == ADMIN_NETWORK));
+        let proxy = cfg
+            .services
+            .iter()
+            .find(|s| s.name == PROXY_SERVICE_NAME)
+            .expect("proxy synthesized");
+        assert!(matches!(proxy.kind, Some(ServiceKind::Proxy)));
+        let api = cfg.services.iter().find(|s| s.name == "api").unwrap();
+        assert!(api.networks.as_ref().unwrap().iter().any(|n| n == INGRESS_NETWORK));
+        assert!(api.depends_on.iter().any(|d| d == PROXY_SERVICE_NAME));
+    }
+
+    #[test]
+    fn auto_tls_without_email_errors() {
+        let mut cfg = config_with_one_service(
+            Some(DomainSpec::Single("api.example.com".into())),
+            Some(8080),
+        );
+        let err = inject_implicit_proxy(&mut cfg).unwrap_err();
+        assert!(format!("{err}").contains("proxy.email"), "got: {err}");
+    }
+
+    #[test]
+    fn tls_cert_without_secrets_errors() {
+        let mut cfg = config_with_one_service(
+            Some(DomainSpec::Single("api.example.com".into())),
+            Some(8080),
+        );
+        cfg.services[0].tls = TlsMode::Cert;
+        let err = inject_implicit_proxy(&mut cfg).unwrap_err();
+        let msg = format!("{err}");
+        assert!(msg.contains("tls_cert_secret"), "got: {msg}");
+    }
+
+    #[test]
+    fn domain_without_port_errors() {
+        let mut cfg =
+            config_with_one_service(Some(DomainSpec::Single("api.example.com".into())), None);
+        let err = inject_implicit_proxy(&mut cfg).unwrap_err();
+        assert!(format!("{err}").contains("run.port"), "got: {err}");
+    }
+
+    #[test]
+    fn user_defined_proxy_service_collides() {
+        let mut cfg = Config::parse_str(
+            r#"
+deploy:
+  networks: [n]
+hosts:
+  - { address: h1, user: deploy }
+services:
+  - name: yoink-proxy
+    image: caddy
+    tag: latest
+    networks: [n]
+    run: { port: 80 }
+  - name: api
+    image: img
+    tag: t
+    networks: [n]
+    run: { port: 8080 }
+"#,
+        )
+        .expect("base config parses");
+        cfg.services[1].domain = Some(DomainSpec::Single("api.example.com".into()));
+        cfg.proxy = Some(ProxyConfig {
+            email: Some("ops@example.com".into()),
+            ..ProxyConfig::default()
+        });
+        let err = inject_implicit_proxy(&mut cfg).unwrap_err();
+        assert!(format!("{err}").contains("reserved"), "got: {err}");
+    }
+}

--- a/yoink/src/proxy/mod.rs
+++ b/yoink/src/proxy/mod.rs
@@ -168,15 +168,25 @@ pub fn inject_implicit_proxy(cfg: &mut Config) -> Result<(), ConfigError> {
 }
 
 fn synthesized_proxy_service(p: &ProxyConfig) -> ServiceConfig {
+    // Split `image[:tag]` into the two fields yoink expects. Yoink's
+    // normalize_image_references only splits on `@` for digest pinning,
+    // not on `:` for tag — that pass runs before we synthesize, so we
+    // do the split inline here. Defaults to `caddy:2` when unset.
+    let raw = p.resolved_image();
+    let (image, tag) = match raw.rsplit_once(':') {
+        // Reject `host:port/repo` (port-bearing registries) by checking
+        // the suffix doesn't contain `/`. For the registry case the
+        // operator passes the full ref including tag, e.g.
+        // `ghcr.io/me/caddy-redis:2.7`.
+        Some((repo, t)) if !t.contains('/') => (repo.to_string(), Some(t.to_string())),
+        _ => (raw, None),
+    };
     ServiceConfig {
         name: PROXY_SERVICE_NAME.to_string(),
-        image: p.resolved_image(),
+        image,
         kind: Some(ServiceKind::Proxy),
         build: None,
-        // Tag baked into the image ref — Caddy's official tag is the
-        // version (`caddy:2`); for xcaddy-built images the operator
-        // pins the tag in `proxy.image:` directly.
-        tag: None,
+        tag,
         hosts: None,
         env: std::collections::BTreeMap::default(),
         secrets: Vec::new(),
@@ -190,14 +200,70 @@ fn synthesized_proxy_service(p: &ProxyConfig) -> ServiceConfig {
         tls_cert_secret: None,
         tls_key_secret: None,
         caddy_extra_json: None,
+        upstream_h2c: false,
+        canonical_domain: None,
+        compression: false,
         run: ServiceRun {
-            // Caddy serves :80 + :443 on the host. We publish those
-            // because that's the whole point of the proxy. The admin
-            // API on :2019 is NOT published — it's reached via
-            // SSH-tunnelled access to the container's IP on the
-            // `_proxy-admin` network.
             port: None,
             healthcheck_path: None,
+            // Caddy serves :80 + :443 on the host — that's the whole
+            // point of the proxy. Admin API on :2019 is published on
+            // 127.0.0.1 with an ephemeral host port (`:0:2019`) so
+            // it's reachable from the host (and only from the host)
+            // without going through docker's bridge networking,
+            // which doesn't expose user-defined-network container
+            // IPs to the host. The yoink CLI looks up the actual
+            // host port via `inspect_container` and SSH-tunnels to
+            // it for the duration of one `/load` call.
+            //
+            // The :80/:443 publishes also implicitly force stop-first
+            // deploy (port bindings are exclusive at the kernel
+            // level), so a proxy redeploy briefly drops :80/:443
+            // until the new container binds.
+            publish: vec![
+                "80:80".to_string(),
+                "443:443".to_string(),
+                "127.0.0.1:0:2019".to_string(),
+            ],
+            // Override the official caddy:2 image's entrypoint to
+            // start with a minimal bootstrap config: admin bound to
+            // 0.0.0.0:2019 (so the admin endpoint is reachable from
+            // the docker bridge — the default `localhost:2019` would
+            // refuse our SSH-tunneled `/load`), `enforce_origin: false`
+            // + a known origin (`yoink-admin`) so we can route past
+            // Caddy's host-header check by setting Host: yoink-admin
+            // on every admin request. The actual routes are pushed
+            // via `/load` immediately after the container is healthy.
+            entrypoint: Some(vec!["sh".to_string(), "-c".to_string()]),
+            cmd: vec![
+                concat!(
+                    "echo '{\"admin\":{\"listen\":\"0.0.0.0:2019\",",
+                    "\"enforce_origin\":false,",
+                    "\"origins\":[\"yoink-admin\"]}}'",
+                    " | exec caddy run --config /dev/stdin",
+                )
+                .to_string(),
+            ],
+            // Yoink's `cap_drop: [ALL]` default would block Caddy
+            // from binding :80/:443 (privileged ports). Re-add the
+            // one cap that lets it; everything else stays dropped.
+            options: crate::config::RunOptions {
+                cap_drop: vec!["ALL".to_string()],
+                cap_add: vec!["NET_BIND_SERVICE".to_string()],
+                // Caddy's official image runs as root and writes ACME
+                // state to /data as root — overriding to a non-root
+                // user would lose write access to the cert volume.
+                user: Some("0:0".to_string()),
+                ..crate::config::RunOptions::default()
+            },
+            // ACME state, certs, OCSP staples — survives container
+            // recreation. Volume name comes from `proxy.cert_volume`
+            // (default `yoink_caddy_data`). A second volume holds
+            // Caddy's autosave config so it can resume on restart.
+            volumes: vec![
+                format!("{}:/data", p.resolved_cert_volume()),
+                "yoink_caddy_config:/config".to_string(),
+            ],
             ..ServiceRun::default()
         },
     }

--- a/yoink/src/transport/tunnel.rs
+++ b/yoink/src/transport/tunnel.rs
@@ -54,6 +54,21 @@ impl SshTunnel {
         ready_timeout: Duration,
         keyfile: Option<&std::path::Path>,
     ) -> Result<Self, TunnelError> {
+        Self::open_to(user, host, "127.0.0.1", remote_port, ready_timeout, keyfile).await
+    }
+
+    /// Generalized form: forward `local:0` to an arbitrary
+    /// `remote_dial_host:remote_port` reachable from the SSH host.
+    /// Used by the proxy admin client to dial the Caddy container's
+    /// IP on the host's docker bridge (loopback wouldn't reach it).
+    pub async fn open_to(
+        user: &str,
+        host: &str,
+        remote_dial_host: &str,
+        remote_port: u16,
+        ready_timeout: Duration,
+        keyfile: Option<&std::path::Path>,
+    ) -> Result<Self, TunnelError> {
         let local_port = pick_free_port().map_err(TunnelError::Bind)?;
 
         let mut cmd = Command::new("ssh");
@@ -75,7 +90,7 @@ impl SshTunnel {
             .arg("-o")
             .arg("ExitOnForwardFailure=yes")
             .arg("-L")
-            .arg(format!("{local_port}:127.0.0.1:{remote_port}"))
+            .arg(format!("{local_port}:{remote_dial_host}:{remote_port}"))
             .arg(format!("{user}@{host}"))
             .stdin(Stdio::null())
             .stdout(Stdio::null())

--- a/yoink/src/transport/unregistry.rs
+++ b/yoink/src/transport/unregistry.rs
@@ -22,7 +22,7 @@ use tracing::warn;
 
 use super::oci_push::{self, OciPushError};
 use super::tunnel::{SshTunnel, TunnelError};
-use crate::docker_ops::{DockerError, DockerOps, Host, rand_hex};
+use crate::docker_ops::{DockerError, DockerOps, Host, parse_published_port, rand_hex};
 use crate::ssh_probe;
 
 /// Image used for the ephemeral on-host registry sidecar.
@@ -307,21 +307,6 @@ fn sidecar_create_body() -> ContainerCreateBody {
     }
 }
 
-/// `parse_inspect` formats each entry as `"<host_port>:<container_port>/<proto>"`.
-/// Find the entry whose container port matches `wanted` and return the
-/// host port as a u16.
-fn parse_published_port(entries: &[String], wanted: u16) -> Option<u16> {
-    let suffix = format!(":{wanted}/");
-    for entry in entries {
-        if let Some(idx) = entry.find(&suffix) {
-            let host_port = &entry[..idx];
-            if let Ok(p) = host_port.parse::<u16>() {
-                return Some(p);
-            }
-        }
-    }
-    None
-}
 
 
 /// RAII guard that force-removes the sidecar if Drop runs before


### PR DESCRIPTION
## Summary

First-class reverse-proxy integration. One field on a service exposes it on a domain with TLS:

\`\`\`yaml
services:
  - name: api
    image: ghcr.io/me/api
    domain: api.example.com
    run: { port: 8080 }
proxy:
  email: ops@example.com
\`\`\`

`yoink up` → Caddy reconciled, app reconciled, TLS issued, routing works. Replaces the [caddy-docker-proxy](https://github.com/lucaslorentz/caddy-docker-proxy) pairing that was the previously-documented pattern.

## What ships

**Schema (locked)**:
- per service: `domain`, `tls` (`auto`|`off`|`cert`), `tls_cert_secret`, `tls_key_secret`, `caddy_extra_json`
- top-level `proxy:`: `enabled`, `email`, `image`, `cert_volume`

**Architecture**:
- Implicit `yoink-proxy` service synthesized at config-load time when any service has `domain:`. New `ServiceKind::Proxy` discriminator (yoink's first non-homogeneous service type).
- Two managed Docker networks: `yoink-ingress` (proxy ↔ apps) and `yoink-proxy-admin` (yoink CLI ↔ proxy admin API only). Admin port never published.
- Caddy JSON config rendered from yoink schema, pushed via Caddy's `/load` endpoint at the routing-flip moment of the rolling swap (between healthcheck-pass and old-replica stop). Caddy gracefully reloads in-process; no in-flight requests dropped. Yoink owns the timing — no second reconciler.
- Reuses the `SshTunnel` primitive from the unregistry transport (generalized to accept arbitrary `remote_host`).
- Routing-relevant fields land in container labels so the existing spec_hash → drift → redeploy → `/load` pipeline picks up snippet and cert-secret edits.

**Cloudflare Origin Certs out of the box** (`tls: cert` mode): paste cert + key into `secrets.age`, reference secret names from the service. Yoink decrypts and inlines into the rendered JSON. No ACME, no LE rate limits, multi-host works without Redis. See [the recipe](docs/content/docs/recipes/cloudflare-origin-certs.md).

**Multi-host LE via Redis**: documented as a [recipe](docs/content/docs/recipes/multi-host-redis-storage.md) (xcaddy + caddy-storage-redis + Tailscale-private Redis). `proxy.storage:` field deferred to v1.1.

**Application-layer concerns** (auth, rate limit, headers, CORS, mTLS, L4) are deliberately not in yoink's schema. Use `caddy_extra_json:` with raw Caddy JSON handlers — same syntax Caddy's docs use directly.

## Files

\`\`\`
docs/content/docs/guide/pairing.md            (CDP-deprecation rewrite)
docs/content/docs/guide/proxy.md              (new — main user docs)
docs/content/docs/recipes/cloudflare-origin-certs.md  (new)
docs/content/docs/recipes/multi-host-redis-storage.md (new)
yoink/src/config.rs                           (schema additions)
yoink/src/deploy.rs                           (state-machine integration + label extension)
yoink/src/lib.rs                              (pub mod proxy)
yoink/src/proxy/mod.rs                        (new — implicit injection, validation)
yoink/src/proxy/caddy.rs                      (new — JSON renderer)
yoink/src/proxy/admin.rs                      (new — admin API client)
yoink/src/transport/tunnel.rs                 (open_to() generalization)
\`\`\`

## Test plan

- [x] 217 unit tests pass (10 new in `proxy::tests` + 4 in `caddy::tests`).
- [x] `cargo clippy --all-targets -- -D warnings` clean.
- [ ] **Smoke** against a real host: drop a `yoink.yaml` with one routed service + Cloudflare origin cert, `yoink up`, `curl https://api.example.com`. Deferred to operator.
- [ ] **Rolling swap with continuous curl**: bump image tag, capture per-second responses during deploy — should never see non-2xx.
- [ ] **Drift**: change `caddy_extra_json:`, `yoink up --dry-run` shows the routed service as drifted.
- [ ] **`/load` failure**: render an intentionally broken `caddy_extra_json:` (e.g. handler with missing required field), `yoink up` aborts cleanly with Caddy's parse error in output.

## Out of scope (deliberate)

- Caddyfile parser (per design Q&A): `caddy_extra_json:` takes raw JSON. Users who want Caddyfile syntax can write JSON or run `caddy adapt` themselves.
- `proxy.storage:` typed schema field for Redis: docs-only recipe in v1.
- Two-phase `/load` (add new + drop old as separate calls): single combined push in v1; Caddy's active health check handles old-replica removal.