### PR TITLE
docs: v2 pass — comparison matrix, agent-friendly framing, surface gaps

### DIFF
--- a/docs/content/_index.md
+++ b/docs/content/_index.md
@@ -4,7 +4,7 @@ layout: docs
 toc: false
 ---
 
-A small, opinionated container deploy CLI + TUI for people who run a handful of services on a handful of bare-metal hosts. **Low ceremony**: drop a `yoink.yaml` next to your code describing where the app should go, and `yoink up`. **Batteries and best practices included** — `age`-sealed secrets, hardened container defaults, healthcheck-gated rolling swaps, drift detection, dependency-ordered waves, all on by default with no plugins to install. Sits between [Kamal](https://kamal-deploy.org) and Kubernetes — opinionated about the same things Kamal is, borrowing the few Kubernetes ideas that actually pay off at this scale.
+A small, opinionated container deploy CLI + TUI for people who run a handful of services on a handful of bare-metal hosts. **Low ceremony**: drop a `yoink.yaml` next to your code describing where the app should go, and `yoink up`. **Batteries and best practices included** — `age`-sealed secrets, hardened container defaults, healthcheck-gated rolling swaps, drift detection, dependency-ordered waves, a bundled Caddy reverse proxy with Let's Encrypt or Cloudflare origin certs, all on by default with no plugins to install. **CLI + YAML, no GUI** — perfect for AI agents (Claude Code, Cursor) and CI runners as much as for humans at a terminal.
 
 ```
 yoink up                  # reconcile every service in dep order
@@ -18,8 +18,8 @@ yoink rollback api        # roll back to the previous version
 
 {{< cards >}}
   {{< card link="/docs/start/first-deploy" title="Five-minute first deploy" subtitle="Drop a yoink.yaml next to your Dockerfile, run one command." icon="lightning-bolt" >}}
-  {{< card link="/docs/intro/compared" title="Is this for me?" subtitle="vs Kamal, vs Kubernetes, vs plain compose. When yoink is the right answer, when it isn't." icon="adjustments" >}}
-  {{< card link="/docs/guide/deploy-modes" title="Three deploy modes" subtitle="CI-built, kamal-style local-build, no-registry standalone." icon="server" >}}
+  {{< card link="/docs/intro/compared" title="Is this for me?" subtitle="Side-by-side matrix vs Kamal, Coolify, Dokku, Komodo, Kubernetes, plain compose. When yoink is the right answer, when it isn't." icon="adjustments" >}}
+  {{< card link="/docs/guide/deploy-modes" title="Three deploy modes" subtitle="CI-built, local-build push-then-deploy, no-registry standalone." icon="server" >}}
   {{< card link="/docs/guide/security-defaults" title="Secure by default" subtitle="non-root uid, cap_drop=ALL, read-only rootfs, no-new-privileges, init=tini, …" icon="shield-check" >}}
   {{< card link="/docs/recipes" title="Recipes" subtitle="Staging alongside prod, self-hosted registry, Infisical secrets, PR-comment dry-run." icon="clipboard-list" >}}
   {{< card link="/docs/reference" title="Reference" subtitle="Every CLI flag, every config field, every TUI keybind." icon="document-text" >}}
@@ -27,16 +27,18 @@ yoink rollback api        # roll back to the previous version
 
 ## Why it exists
 
-Kamal is a lovely fit for "one app, one binary per host" but starts to creak the moment you want a second app on the same box, replicas of the same service, or any kind of network isolation between containers. Kubernetes solves all that — and a hundred other problems you don't have, in exchange for a control plane to operate, a YAML schema with a learning curve, and a vocabulary you have to teach every new operator.
+Single-host PaaS tools (Kamal, Dokku) are wonderful for "one app, one host" but creak when you want multiple services on the same box, replicas behind a proxy, or network isolation between tiers. Kubernetes solves all that — and a hundred other problems you don't have, in exchange for a control plane to operate, a YAML schema with a learning curve, and a vocabulary you have to teach every new operator.
 
-`yoink` is the thinnest tool that gives you the Kubernetes ideas that actually matter at small scale, while keeping Kamal's "one binary, ssh into the host, drive Docker directly" simplicity:
+`yoink` is the thinnest tool that gives you the few Kubernetes ideas that actually matter at small scale, while keeping the "one binary, ssh into the host, drive Docker directly" simplicity of the single-host PaaS world:
 
 - **Multiple services per host** with replicas + dependency-ordered deploys (`depends_on:` topo-sort)
 - **Per-service network tiers** for blast-radius isolation without a CNI plugin
+- **Bundled Caddy reverse proxy** — one `domain:` field exposes a service over HTTPS with automatic Let's Encrypt or sealed Cloudflare origin certs. mTLS, h2c (gRPC), HSTS, all defaults
 - **Drift detection.** Every effective spec hashes deterministically and lands as a label. The TUI shows drift across the cluster without guessing.
-- **Three deploy modes**: CI-built (the default), local-build kamal-style with `yoink build --push`, or fully standalone with `yoink up --build --no-registry` (no CI, no registry — drop a `yoink.yaml` next to your Dockerfile and go)
+- **Three deploy modes**: CI-built (the default), local-build with `yoink build --push`, or fully standalone with `yoink up --build --no-registry` (no CI, no registry — drop a `yoink.yaml` next to your Dockerfile and go)
 - **Secure by default**: containers run as **non-root** (uid 65534) with cap_drop=ALL, no-new-privileges, read-only rootfs, init=tini, tmpfs noexec, binds default :ro. Override per service when an image genuinely needs root.
 - **Sealed secrets out of the box**: commit a single `secrets.age` file, decrypt with one key from `YOINK_AGE_KEY` (env in CI, file on your laptop). No remote vault needed. Infisical is opt-in for teams already running one.
+- **CLI + YAML, no GUI**. Everything is a `yoink` subcommand or a `yoink.yaml` field — no web dashboard, no clicking. Identical experience on your laptop, in CI, and inside an AI coding agent like Claude Code or Cursor.
 - **k9s-style TUI** with deploy history, one-press rollback, drift cells, logs auto-piped through `hl`
 
 Read more in the [intro](/docs/intro), or skip ahead to [first deploy](/docs/start/first-deploy).

--- a/docs/content/_index.md
+++ b/docs/content/_index.md
@@ -21,7 +21,8 @@ yoink rollback api        # roll back to the previous version
   {{< card link="/docs/intro/compared" title="Is this for me?" subtitle="Side-by-side matrix vs Kamal, Coolify, Dokku, Komodo, Kubernetes, plain compose. When yoink is the right answer, when it isn't." icon="adjustments" >}}
   {{< card link="/docs/guide/deploy-modes" title="Three deploy modes" subtitle="CI-built, local-build push-then-deploy, no-registry standalone." icon="server" >}}
   {{< card link="/docs/guide/security-defaults" title="Secure by default" subtitle="non-root uid, cap_drop=ALL, read-only rootfs, no-new-privileges, init=tini, …" icon="shield-check" >}}
-  {{< card link="/docs/recipes" title="Recipes" subtitle="Staging alongside prod, self-hosted registry, Infisical secrets, PR-comment dry-run." icon="clipboard-list" >}}
+  {{< card link="/docs/recipes/ai-agents" title="Driving yoink from an AI agent" subtitle="CLI + YAML, no GUI. Patterns for Claude Code, Cursor, GitHub Actions." icon="terminal" >}}
+  {{< card link="/docs/recipes" title="Recipes" subtitle="Staging alongside prod, sealed secrets, Cloudflare origin certs, Caddy snippets." icon="clipboard-list" >}}
   {{< card link="/docs/reference" title="Reference" subtitle="Every CLI flag, every config field, every TUI keybind." icon="document-text" >}}
 {{< /cards >}}
 

--- a/docs/content/docs/examples/production.md
+++ b/docs/content/docs/examples/production.md
@@ -13,7 +13,6 @@ yoink.staging.yaml          # staging entry; includes services/staging/*.yaml
 services/prod/api.yaml
 services/prod/web.yaml
 services/prod/redis.yaml
-services/prod/caddy.yaml
 services/prod/otel.yaml
 services/staging/api.yaml   # name: api-staging, networks: [api-staging, …]
 services/staging/web.yaml   # name: web-staging
@@ -23,7 +22,9 @@ services/staging/web.yaml   # name: web-staging
 
 ```yaml
 deploy:
-  networks: [public, api, web, redis, otel]
+  # `yoink-ingress` and `yoink-proxy-admin` are auto-injected by the
+  # bundled-proxy code path — no need to list them here.
+  networks: [api, web, redis, otel]
 
 hosts:
   - { address: prod-eu-1, user: deploy }
@@ -49,7 +50,22 @@ registry:
 
 include:
   - services/prod/*.yaml
+
+# Bundled reverse proxy (yoink-proxy). Renders Caddy from each
+# service's `domain:` field; ACME is implicitly off because
+# `proxy.tls.cert_secret` is set, and a :80 → :443 redirect is
+# auto-emitted. Origin-pull mTLS locks the origin to Cloudflare's
+# edge — direct hits to the host IP fail at TLS handshake.
+proxy:
+  tls:
+    cert_secret: CF_ORIGIN_CERT
+    key_secret:  CF_ORIGIN_KEY
+    client_auth:
+      mode: require_and_verify
+      trust_pool_secret: CF_ORIGIN_PULL_CA
 ```
+
+For ACME (Let's Encrypt) instead of sealed Cloudflare origin certs, drop `proxy.tls` and set `proxy.email: ops@example.com` — every service with `domain:` then auto-issues. See the [proxy guide](/docs/guide/proxy) and the [Cloudflare Origin Certs recipe](/docs/recipes/cloudflare-origin-certs).
 
 ## `services/prod/api.yaml`
 
@@ -60,6 +76,8 @@ services:
     # tag: provided at deploy via `--tag api=$(git rev-parse HEAD)`
     depends_on: [redis, otel]
     networks: [api, redis, otel]            # api dials redis + otel
+    domain: api.example.com                 # bundled proxy fronts this
+    upstream_h2c: true                      # gRPC + HTTP/1.1 over one h2c upstream
     secrets: [DATABASE_URL, JWT_SIGNING_KEY]
     env_from_secrets:
       # Same secret store, different env-var name on the container
@@ -115,28 +133,9 @@ services:
         network_aliases: [redis]
 ```
 
-## `services/prod/caddy.yaml`
+## Reverse proxy
 
-```yaml
-services:
-  - name: caddy
-    image: lucaslorentz/caddy-docker-proxy
-    tag: 2.10-alpine
-    depends_on: [api, web]
-    networks: [public, api, web]
-    binds:
-      - "/var/run/docker.sock:/var/run/docker.sock:ro"
-      - "/srv/caddy/data:/data:rw"           # cert storage; explicit :rw
-    run:
-      publish:
-        - "80:80"
-        - "443:443"
-        - "443:443/udp"                       # HTTP/3
-      options:
-        memory: "128Mi"
-        cpus: "0.5"
-        cap_add: [NET_BIND_SERVICE]           # needed for :80/:443
-```
+There is no `caddy.yaml` fragment in this layout. Yoink's bundled proxy is synthesized from the top-level `proxy:` block plus each service's `domain:` field — no explicit Caddy service to declare, no Caddyfile to maintain, no `caddy_data` volume to babysit. See [the proxy guide](/docs/guide/proxy) for the full surface (mTLS, h2c, multi-domain canonical redirects, snippets).
 
 ## `services/prod/otel.yaml`
 
@@ -202,10 +201,11 @@ See [PR-comment dry-run](/docs/recipes/pr-comment-dry-run) for the complete work
 
 ## What this exercises
 
-- **Multi-tier networks** — `redis` only on `redis`; `caddy` only on `public/api/web`; otel isolated on `otel`. Per-service blast radius.
+- **Multi-tier networks** — `redis` only on `redis`; otel isolated on `otel`; api joined to `api/redis/otel` per its dial-out needs. Per-service blast radius.
+- **Bundled reverse proxy** — `domain:` on api/web, `proxy.tls` block once at the top, no `caddy.yaml` fragment to maintain. The proxy auto-joins `yoink-ingress` along with every routed service.
 - **Pre-deploy hooks** — `api-migrate` runs once per up, before the api swap, with the same image as the runtime.
 - **`env_from_secrets`** — secret stored under one name, exposed under a different env-var name on the container. Pattern for legacy env-var conventions.
 - **`files:` mounts** — content-hashed bind that feeds into `spec_hash`. Edit the otel config, redeploy → the otel container reroles automatically because its hash changed.
-- **Surgical security opt-outs** — `caddy` keeps everything default-on except `NET_BIND_SERVICE`; `otel` opts out of the hardened defaults entirely (with a comment explaining why); everything else inherits the defaults.
+- **Surgical security opt-outs** — `otel` opts out of the hardened defaults (with a comment explaining why); everything else inherits the defaults.
 - **Config fragmentation** — one file per service, glob-included. Each fragment is independent; renaming a service is a one-file operation.
 - **Staging alongside prod** — see [the recipe](/docs/recipes/staging-alongside-prod) for the same hosts running a `yoink.staging.yaml` with `name: api-staging` etc.

--- a/docs/content/docs/guide/_index.md
+++ b/docs/content/docs/guide/_index.md
@@ -8,7 +8,9 @@ sidebar:
 The mental model. Read this once; come back to recipes / reference for the rest.
 
 {{< cards cols="2" >}}
-  {{< card link="/docs/guide/deploy-modes" title="Three deploy modes" subtitle="CI-built, kamal-style local-build, no-registry standalone." icon="server" >}}
+  {{< card link="/docs/guide/deploy-modes" title="Three deploy modes" subtitle="CI-built, local-build push-then-deploy, no-registry standalone." icon="server" >}}
   {{< card link="/docs/guide/security-defaults" title="Secure by default" subtitle="cap_drop=ALL, read-only rootfs, no-new-privileges, etc. — the hardened RunOptions every yoink container gets by default." icon="shield-check" >}}
-  {{< card link="/docs/guide/pairing" title="Pairing with Tailscale + caddy" subtitle="What yoink owns and what it leaves to other tools." icon="link" >}}
+  {{< card link="/docs/guide/architecture" title="How it works" subtitle="Drift detection, deploy lock, spec_hash, dependency-ordered waves, healthcheck-gated rolling swap." icon="bulb" >}}
+  {{< card link="/docs/guide/proxy" title="Reverse proxy" subtitle="Bundled Caddy. One field exposes a service over HTTPS with Let's Encrypt or sealed Cloudflare origin certs (mTLS optional)." icon="globe" >}}
+  {{< card link="/docs/guide/pairing" title="Pairing with Tailscale" subtitle="What yoink owns and what it leaves to other tools." icon="link" >}}
 {{< /cards >}}

--- a/docs/content/docs/guide/deploy-modes.md
+++ b/docs/content/docs/guide/deploy-modes.md
@@ -15,7 +15,7 @@ Yoink treats **where the image is built** and **how it gets to the host** as ind
 
 | Build origin → / Distribution ↓ | In CI | On operator's machine |
 |---|---|---|
-| **Via registry** | CI pushes, hosts pull. The default for production. | `yoink build --push` then `yoink up`. Kamal-style. |
+| **Via registry** | CI pushes, hosts pull. The default for production. | `yoink build --push` then `yoink up` — the classic two-step build+deploy. |
 | **Direct to host (no registry)** | Less common, but valid: CI builds then runs `yoink up --no-registry --transport=unregistry --tag api=<sha>`. | `yoink up --build --no-registry`, one command. The standalone loop. |
 
 The four cells share a deploy engine — drift detection, healthcheck-gated rolling swap, dependency-ordered waves work the same regardless of how the image arrived.
@@ -24,7 +24,7 @@ The four cells share a deploy engine — drift detection, healthcheck-gated roll
 
 Operator config has no `build:` block; CI builds the image and pushes it to a registry on every merge. `yoink up` pulls and rolls. The image reference is fully qualified (`image: ghcr.io/you/api`) and the tag typically gets overridden at deploy time via `--tag api=<sha>`.
 
-## Local-build, kamal-style
+## Local-build (push-then-deploy)
 
 ```yaml
 services:
@@ -46,9 +46,9 @@ yoink build api --push               # docker build → docker push ghcr.io/you/
 yoink up --service api               # docker pull on each host → rolling swap
 ```
 
-`yoink build --push` runs `docker build` against your local docker daemon, tagging as `<image>:<tag>` (which equals the registry path because of how `image:` is configured), then runs `docker push`. After that the standard deploy path takes over — exactly like kamal, except the build step is a separate command (so you can build without pushing for CI of your own; or push without rebuilding for re-tagging).
+`yoink build --push` runs `docker build` against your local docker daemon, tagging as `<image>:<tag>` (which equals the registry path because of how `image:` is configured), then runs `docker push`. After that the standard deploy path takes over.
 
-Two-step instead of one-shot is deliberate: `yoink build && yoink up` is the explicit version of `kamal deploy`, and the separation lets you run them on different machines (build on a beefy laptop, deploy from a thin runner) when you want to.
+Two-step instead of one-shot is deliberate: `yoink build && yoink up` keeps the two phases separate so you can build without pushing (for your own CI), push without rebuilding (for re-tagging), or run the steps on different machines (build on a beefy laptop, deploy from a thin runner).
 
 ## Standalone (no registry)
 

--- a/docs/content/docs/guide/pairing.md
+++ b/docs/content/docs/guide/pairing.md
@@ -6,7 +6,7 @@ weight: 5
 `yoink` doesn't try to solve "how do I reach my hosts." It expects you to bring an off-the-shelf SSH connectivity layer.
 
 {{< callout type="info" >}}
-**Routing changed:** earlier versions of yoink documented [caddy-docker-proxy](https://github.com/lucaslorentz/caddy-docker-proxy) as the routing pairing. **That's been replaced** by yoink's [first-class reverse proxy integration](/docs/guide/proxy) (admin-API push, deterministic deploy timing, no Docker labels). The CDP path still works — it's just no longer the recommended pattern. Migrate by removing `caddy.*` labels from services, adding `domain:` to each, and `proxy.email:` at the top level.
+**For routing**, yoink now ships a [bundled Caddy reverse proxy](/docs/guide/proxy) — set `domain:` on a service and you're done. This page covers the connectivity layer (Tailscale) and the rest of the stack split.
 {{< /callout >}}
 
 ## Tailscale for SSH (the connectivity layer)

--- a/docs/content/docs/intro/compared.md
+++ b/docs/content/docs/intro/compared.md
@@ -3,17 +3,49 @@ title: Compared to other tools
 weight: 2
 ---
 
-Yoink lives in a populated neighborhood. Pick the tool that fits your scale and operator headcount.
+Yoink lives in a populated neighborhood. Pick the tool that fits your scale, your operator headcount, and how much always-on infrastructure you want to operate just to run your apps.
 
 {{< callout type="info" >}}
 **Quick decision tree.**
 1 host, 1 app → **plain `docker compose`** is fine.
-1-3 hosts, Rails/Django/Phoenix-shaped app → **[Kamal](https://kamal-deploy.org)**.
-1-10 hosts, multi-service, want a web UI + agents on each host → **[Komodo](https://komo.do)**.
-1-10 hosts, multi-service, want a built-in WireGuard mesh + per-host daemon → **[Uncloud](https://uncloud.run)**.
-1-10 hosts, multi-service, want a single binary with no control plane and no agents → **yoink**.
+1–3 hosts, Rails/Django/Phoenix-shaped app → **[Kamal](https://kamal-deploy.org)**.
+1 host, want a Heroku-style "git push to deploy" experience → **[Dokku](https://dokku.com)**.
+1+ hosts, want a full self-hosted PaaS with a web UI + build pipelines → **[Coolify](https://coolify.io)**.
+1–10 hosts, multi-service, want a web UI + agents on each host → **[Komodo](https://komo.do)**.
+1–10 hosts, multi-service, want a built-in WireGuard mesh + per-host daemon → **[Uncloud](https://uncloud.run)**.
+1–10 hosts, multi-service, want a single binary with no control plane and no agents — driven equally well by humans, CI, or AI agents → **yoink**.
 Many hosts, autoscaling, multi-tenant, "real" infrastructure team → **Kubernetes**.
 {{< /callout >}}
+
+## At-a-glance matrix
+
+A high-level cross-section before the per-tool deep dives. ✓ = built-in, ◐ = partial / requires opt-in, ✗ = not in scope.
+
+| | **yoink** | **Kamal** | **Coolify** | **Dokku** | **Komodo** | **Uncloud** | **compose** | **k8s** |
+|---|---|---|---|---|---|---|---|---|
+| Single binary, no control plane | ✓ | ✓ | ✗ (web app + DB) | ◐ (host-side runtime) | ✗ (Core + per-host agents) | ✗ (per-host daemon) | ✓ | ✗ |
+| Always-on services to operate | none | none | Coolify Core + DB | Dokku on each host | Komodo Core + Periphery | `uncloudd` per host | none | etcd + control plane |
+| Config-as-code (YAML, in your repo) | ✓ | ✓ | ◐ (UI primary; GitOps opt-in) | ✗ (CLI + buildpacks) | ◐ (UI primary; "Resource Sync" opt-in) | ✓ | ✓ | ✓ |
+| **CLI + files only, no GUI required** | ✓ | ✓ | ✗ (UI is the primary surface) | ✓ | ✗ (UI is the primary surface) | ✓ | ✓ | ✓ |
+| Agent-friendly (scriptable end-to-end) | ✓ | ✓ | ◐ (REST API exists; UI-first) | ✓ | ◐ (API exists; UI-first) | ✓ | ✓ | ✓ |
+| Multiple services per host | ✓ | ◐ (one container per service per host) | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| Replicas behind a proxy | ✓ | ✗ | ✓ | ✗ | ✓ | ✓ | ◐ | ✓ |
+| Multi-host | ✓ | ✓ | ✓ | ✗ (single host) | ✓ | ✓ | ✗ | ✓ |
+| Per-tier network isolation | ✓ | ✗ | ◐ | ✗ | ◐ | ◐ | ✓ | ✓ |
+| Dependency-ordered deploys | ✓ | ✗ | ✓ | ✗ | ✓ | ✓ | ◐ | ✓ |
+| Bundled reverse proxy (HTTPS, ACME) | ✓ (Caddy) | ✓ (`kamal-proxy`) | ✓ (Traefik) | ✓ (nginx) | ✗ | ✓ (Caddy) | ✗ | ◐ (Ingress controller of choice) |
+| Healthcheck-gated rolling swap | ✓ | ✓ | ✓ | ◐ | ✓ | ✓ | ✗ | ✓ |
+| Drift detection | ✓ | ✗ | ✗ | ✗ | ✓ | ✓ | ✗ | ✓ |
+| Pre-merge dry-run / diff | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✓ (`kubectl diff`) |
+| Sealed in-repo secrets (no external service) | ✓ (`age`) | ✗ (external vault required) | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
+| Standalone deploy (no registry, no CI) | ✓ | ✗ | ✗ | ✓ (git push) | ✗ | ✗ | ✓ (local) | ✗ |
+| Secure-by-default container options | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ◐ (Pod Security Standards) |
+| TUI dashboard | ✓ (k9s-style) | ✗ | n/a (web UI) | ✗ | n/a (web UI) | ✗ | ✗ | ◐ (k9s, third-party) |
+| One-press rollback | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✗ | ✓ |
+| Auto-scaling | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✓ |
+| Multi-tenancy / RBAC | ✗ | ✗ | ✓ | ◐ | ✓ | ✗ | ✗ | ✓ |
+
+The columns yoink wins on: **single-binary operation, drift detection, sealed in-repo secrets, hardened container defaults, pre-merge diff, and standalone (no-registry) mode**. The columns it deliberately doesn't fight on: auto-scaling, multi-tenancy, web UIs.
 
 ## vs. [Kamal](https://kamal-deploy.org)
 
@@ -22,7 +54,7 @@ Kamal is the closest neighbor — both are "ship a Rust/Ruby binary, ssh into ho
 | Feature | **yoink** | **Kamal** |
 |---|---|---|
 | Image build | `yoink build [--push]` (optional) | `kamal build` (built-in) |
-| Reverse proxy | None — pairs with caddy-docker-proxy / Traefik | First-party `kamal-proxy` |
+| Reverse proxy | Bundled Caddy (admin-API push, mTLS, h2c, sealed certs) | First-party `kamal-proxy` |
 | Replicas (multiple containers per service) | ✓ (`replicas: N`) | ✗ (one container per service per host) |
 | Per-tier networks | ✓ (`networks: [api, redis]`) | ✗ (single shared network) |
 | Dependency-ordered deploys | ✓ (`depends_on:` topo-sort, parallel waves) | ✗ |
@@ -36,12 +68,58 @@ Kamal is the closest neighbor — both are "ship a Rust/Ruby binary, ssh into ho
 | Per-service `pids_limit` | ✓ | ✗ |
 | Secure-by-default RunOptions | ✓ (cap_drop=ALL, no-new-privileges, read_only=true, pids_limit=1024, init=tini, tmpfs noexec, binds default :ro) | ✗ (docker defaults) |
 | No-registry deploy | ✓ (`yoink up --build --no-registry` runs an ephemeral [unregistry](https://github.com/psviderski/unregistry) sidecar on the host and pushes only the missing layers via SSH; tarball fallback) | ✗ (registry required) |
+| Driven by AI agents / CI scripts | ✓ (CLI + YAML, identical local & remote) | ✓ (CLI + YAML) |
 | Maturity | New (born 2026) | Mature (born 2023, used at 37signals scale) |
 | Ecosystem | Rust-built, opinionated for "I run a few heterogeneous services" | Ruby/Rails ecosystem, `rails new` → `kamal init` is the canonical Rails deploy story today |
 
 **Pick Kamal when**: you have a Rails/Phoenix/Hanami app, you want one tool that builds + deploys + routes, and you don't need replicas or per-tier network isolation.
 
-**Pick yoink when**: you've got several services with different shapes (Rust API + Node web + Caddy + Postgres), you want drift detection and a k9s-style TUI for inspect/rollback, and you're willing to bring your own reverse proxy. Or when you want the no-registry, no-CI standalone loop for a hobby project.
+**Pick yoink when**: you've got several services with different shapes (Rust API + Node web + Postgres), you want drift detection, sealed in-repo secrets, and a k9s-style TUI for inspect/rollback. Or when you want the no-registry, no-CI standalone loop for a hobby project.
+
+## vs. [Coolify](https://coolify.io)
+
+Coolify is a self-hosted **PaaS** — think open-source Heroku/Render — running as a long-lived web app on one of your servers. It manages everything: build pipelines, databases, env vars, auto-deploys from git, a UI for non-engineers. Yoink is a much narrower tool that handles the "deploy these containers to these hosts" piece without any of the PaaS surface area.
+
+| | **yoink** | **Coolify** |
+|---|---|---|
+| Architecture | Single binary, runs on demand | Coolify Core (web app + DB + queue) on one host, agent on each managed host |
+| Operator interface | CLI + TUI (keyboard-only) | Web UI (primary), REST API (secondary) |
+| State of truth | The git repo's `yoink.yaml` | Coolify's database (UI-edited; environments + projects exported as JSON if you want) |
+| Build pipelines | Out of scope (use CI / `yoink build`) | Built-in (Nixpacks, Dockerfile, buildpacks) |
+| One-click databases (Postgres / MySQL / Mongo) | Out of scope | Built-in templates with backups |
+| Auto-deploy on git push | Out of scope (CI calls `yoink up`) | Built-in (webhook + build) |
+| Multi-user, RBAC, audit log | ✗ | ✓ |
+| Bundled reverse proxy | ✓ (Caddy) | ✓ (Traefik) |
+| Drift detection | ✓ | ✗ |
+| **Driven by AI agents / CI scripts** | ✓ (everything is CLI + YAML — no clicking) | ◐ (REST API exists, but UI is the primary surface; agents have to learn the API instead of just editing files) |
+| Best fit | Engineers who already have a CI + git workflow and want a thin deploy layer | Teams who want a Heroku-shaped product and are happy operating Coolify itself as a long-lived service |
+
+**Pick Coolify when**: you want batteries-included PaaS (build, deploy, database, web UI, multi-user) and you're comfortable operating Coolify itself as a long-running service on one of your boxes.
+
+**Pick yoink when**: you already have CI + git for the build pipeline, you want the deploy layer to be a thin CLI you run on demand, and you'd rather not run another web app + database to deploy your apps.
+
+## vs. [Dokku](https://dokku.com)
+
+Dokku is the original "Heroku in a box" — a single host runs Dokku, you `git push dokku main`, and a buildpack/Dockerfile flow ships your app behind nginx with auto-TLS. Light on infrastructure, deeply opinionated about the "git push to deploy" loop.
+
+| | **yoink** | **Dokku** |
+|---|---|---|
+| Architecture | Single binary, runs on demand | Per-host runtime (`dokku` on every server it manages) |
+| Number of hosts | Many | One per Dokku install (no native multi-host) |
+| Deploy trigger | `yoink up` from operator's laptop or CI | `git push dokku main` |
+| Image build | Optional (`yoink build`) or in CI | Built-in (Buildpacks, Dockerfile, Lambda) |
+| Bundled reverse proxy | ✓ (Caddy, ACME) | ✓ (nginx, Let's Encrypt plugin) |
+| Multiple services per host | ✓ | ✓ (multiple "apps") |
+| Replicas | ✓ | ✗ (one container per app process type) |
+| Per-tier networks | ✓ | ◐ (Dokku networks plugin) |
+| Drift detection | ✓ | ✗ |
+| Sealed in-repo secrets | ✓ (`age`) | ✗ (env vars set on the host) |
+| Driven by AI agents / CI scripts | ✓ (CLI + YAML, identical local & remote) | ✓ (CLI on the host; SSH to operate remotely) |
+| Best fit | Multi-host fleets where the deploy tool is a thin client | Single host you SSH into, "git push to deploy" is the daily loop |
+
+**Pick Dokku when**: one host is enough, the buildpack ergonomics fit your stack, and "git push to deploy" is the user experience you want.
+
+**Pick yoink when**: you want the same "drop a config and run a command" simplicity but across multiple hosts, with replicas, drift detection, and sealed in-repo secrets — and you'd rather not maintain a Dokku install on each box.
 
 ## vs. [Komodo](https://komo.do)
 
@@ -59,14 +137,15 @@ Komodo is a fellow Rust-built deploy/management tool for self-hosted containers,
 | Bring-your-own-host | yoink connects to any host you can ssh into | Each host needs `Periphery` installed + reachable from Core |
 | Container shape | Yoink-managed containers via per-service spec | Stacks (compose files) / Deployments / Builds / Repos |
 | Drift detection | ✓ (`yoink.spec_hash` label) | ✓ (UI shows diff between desired and live) |
-| Reverse proxy | None — pairs with caddy / Traefik | None — same |
+| Bundled reverse proxy | ✓ (Caddy) | ✗ (BYO) |
 | Healthcheck-gated rolling swap | ✓ | ✓ (compose-style) |
 | Audit log of who deployed what | git history of `yoink.yaml` + per-container deploy labels | First-class audit log in the database |
+| **Driven by AI agents / CI scripts** | ✓ (CLI + YAML, no GUI in the loop) | ◐ (API exists, but UI is the primary surface) |
 | Best fit team size | 1–3 operators sharing a repo | 3+ operators, a team that benefits from a UI + RBAC |
 
 **Pick Komodo when**: you want a UI for non-CLI users, you're managing more hosts than fit in one operator's head, RBAC matters, and the overhead of running a database + a web service + per-host agents is worth it for the control-plane affordances.
 
-**Pick yoink when**: a single binary on your laptop is the entire control surface, the git repo is the source of truth, and you'd rather not operate yet another service-with-database to deploy your services. The CLI/TUI shape works best for 1–3 operators who are already comfortable in a terminal.
+**Pick yoink when**: a single binary on your laptop is the entire control surface, the git repo is the source of truth, and you'd rather not operate yet another service-with-database to deploy your services. The CLI/TUI shape works best for 1–3 operators (or for AI agents and CI runners) who are already comfortable in a terminal.
 
 ## vs. [Uncloud](https://uncloud.run)
 
@@ -77,17 +156,18 @@ Uncloud is in the same neighborhood as yoink — small fleet, multi-service, del
 | Architecture | Single client binary; talks to docker on each host over ssh | Per-host daemon (`uncloudd`) on every managed machine, peer-to-peer (no master) |
 | Always-on services to operate | None | One daemon per host (auto-installed by `uncloud machine init`) |
 | Cross-host networking | None — yoink relies on docker's per-host networks; cross-host is your routing problem (Tailscale, public DNS, …) | First-class — Uncloud builds a WireGuard mesh between machines, services dial each other by name across hosts |
-| Reverse proxy / public ingress | None — pairs with caddy / Traefik / your own | First-class — built-in Caddy-based ingress with auto-TLS |
+| Reverse proxy / public ingress | ✓ (bundled Caddy with admin-API push, sealed certs, mTLS) | First-class — built-in Caddy-based ingress with auto-TLS |
 | State of truth | The git repo's `yoink.yaml` | Cluster state lives in the daemon mesh; YAML config is also supported |
 | Drift detection | ✓ (`yoink.spec_hash` label) | ✓ (compares running state to declared spec) |
 | Multi-host service replicas | ✓ (per-host counts, `services[].hosts:` whitelist) | ✓ (cluster-aware scheduling) |
 | Onboarding a new host | Already works if you can ssh into it | `uncloud machine init` to install + join the mesh |
-| What yoink leaves to other tools that Uncloud bundles | cross-host networking, ingress / TLS | — |
+| Driven by AI agents / CI scripts | ✓ (CLI + YAML, no daemon to coordinate with) | ✓ (CLI + YAML; daemon-aware) |
+| What yoink leaves to other tools that Uncloud bundles | cross-host service-to-service networking | — |
 | Best fit | "I have ssh access to my hosts and want a deploy tool that respects that" | "I want a self-hosted lightweight cluster with mesh + ingress baked in" |
 
-**Pick Uncloud when**: cross-host service-to-service networking matters (your api on one box talking to your worker on another), you'd rather have ingress + auto-TLS bundled than wire it up yourself, and you're OK with running a daemon per host as the price of those affordances.
+**Pick Uncloud when**: cross-host service-to-service networking matters (your api on one box talking to your worker on another), and you're OK with running a daemon per host as the price of that affordance.
 
-**Pick yoink when**: you already have a routing answer (Tailscale, a single edge box running caddy, public-DNS-everywhere), you don't want any always-on yoink-specific service running on the host, and the per-host docker daemon over ssh is enough surface area to manage from. The two tools converge on "small fleet of containers, opinionated defaults" — diverge on whether the deploy tool also owns the network fabric.
+**Pick yoink when**: you already have a routing answer (Tailscale, a single edge box, public-DNS-everywhere), you don't want any always-on yoink-specific service running on the host, and the per-host docker daemon over ssh is enough surface area to manage from. The two tools converge on "small fleet of containers, opinionated defaults" — diverge on whether the deploy tool also owns the network fabric.
 
 ## vs. plain `docker compose`
 
@@ -98,15 +178,17 @@ Compose is a YAML schema for declaring a stack on a single host. yoink is a depl
 | Multi-host | ✓ | ✗ (one host, or you script around it) |
 | Healthcheck-gated rolling swap | ✓ | ✗ (`docker compose up -d` recreates without gating) |
 | Per-service drift detection | ✓ | ✗ |
+| Bundled reverse proxy with HTTPS | ✓ (Caddy + ACME / sealed certs) | ✗ (BYO) |
 | Secure-by-default container options | ✓ | ✗ (compose's defaults are dev-friendly: full caps, writable rootfs, no pids cap) |
 | Pre-deploy hooks (migrations etc.) | ✓ (`hooks.pre_deploy`) | partial (`depends_on` + healthcheck dance) |
 | Secrets store | ✓ (age-sealed `secrets.age` in the repo by default, Infisical as opt-in) | ✗ (env file or external) |
 | TUI / drift dashboard | ✓ | ✗ |
+| Driven by AI agents / CI scripts | ✓ | ✓ |
 | Single binary, no Python/Compose runtime | ✓ | ✗ (Compose v2 ships with docker, but still a separate runtime) |
 
 **Pick compose when**: dev-machine local stack, single-host hobby project, or you're already comfortable scripting around compose for deploys.
 
-**Pick yoink when**: you want compose's "declarative containers" model with a real deploy story (rolling, multi-host, drift detection, secrets, hardened defaults).
+**Pick yoink when**: you want compose's "declarative containers" model with a real deploy story (rolling, multi-host, drift detection, secrets, hardened defaults, bundled proxy).
 
 ## vs. Kubernetes
 
@@ -123,11 +205,12 @@ Different leagues. Yoink is for people who don't want a control plane.
 | Per-tier network isolation | ✓ (named docker networks) | ✓ (NetworkPolicy + CNI) |
 | Resource limits (cpu/memory) | ✓ | ✓ |
 | Secrets management | ✓ (age-sealed in-repo by default, Infisical opt-in) | ✓ (Secrets / external store) |
+| Driven by AI agents / CI scripts | ✓ (CLI + one YAML file) | ✓ (kubectl + many YAML files) |
 | Imperative deploy command | `yoink up` | `kubectl apply -f` |
 
 **Pick Kubernetes when**: you have a real infrastructure team, you need autoscaling or multi-tenancy, you're operating across many regions, your engineering org standardized on it, you want a service mesh.
 
-**Pick yoink when**: you want the Kubernetes ideas that pay off at small scale (drift detection, per-tier networks, healthcheck-gated rolls, declarative config) **without** the control plane and the team to operate it.
+**Pick yoink when**: you want the Kubernetes ideas that pay off at small scale (drift detection, per-tier networks, healthcheck-gated rolls, declarative config, in-repo secrets) **without** the control plane and the team to operate it.
 
 ## vs. nothing — just `ssh` + `docker run`
 

--- a/docs/content/docs/intro/what-and-why.md
+++ b/docs/content/docs/intro/what-and-why.md
@@ -13,13 +13,13 @@ yoink history api         # who deployed what, when
 yoink rollback api        # roll back to the previous version
 ```
 
-A small, opinionated container deploy CLI + TUI for people who run a handful of services on a handful of bare-metal hosts. **Low ceremony**: drop a `yoink.yaml` next to your code describing where the app should go, run `yoink up`. **Batteries and best practices included** — the boring-but-important pieces (sealed secrets, hardened container defaults, healthcheck-gated rolling swaps, drift detection, dependency-ordered waves) are all on by default with no plugins to install. Sits between [Kamal](https://kamal-deploy.org) and Kubernetes — opinionated about the same things Kamal is, borrowing the few Kubernetes ideas that actually pay off at this scale.
+A small, opinionated container deploy CLI + TUI for people who run a handful of services on a handful of bare-metal hosts. **Low ceremony**: drop a `yoink.yaml` next to your code describing where the app should go, run `yoink up`. **Batteries and best practices included** — the boring-but-important pieces (sealed secrets, hardened container defaults, healthcheck-gated rolling swaps, drift detection, dependency-ordered waves, a bundled Caddy reverse proxy) are all on by default with no plugins to install. **CLI + YAML, no GUI** — everything is a subcommand or a config field, identical from your laptop, CI, or an AI coding agent.
 
 ## Why it exists
 
-Kamal is a lovely fit for "one app, one binary per host" but starts to creak the moment you want a second app on the same box, replicas of the same service, or any kind of network isolation between containers. Kubernetes solves all that — and a hundred other problems you don't have, in exchange for a control plane to operate, a YAML schema with a learning curve, and a vocabulary you have to teach every new operator.
+Single-host PaaS tools are wonderful for "one app, one host" but creak the moment you want a second app on the same box, replicas of the same service, or network isolation between tiers. Kubernetes solves all that — and a hundred other problems you don't have, in exchange for a control plane to operate, a YAML schema with a learning curve, and a vocabulary you have to teach every new operator.
 
-`yoink` is the thinnest tool that gives you the Kubernetes ideas that actually matter at small scale, while keeping Kamal's "one binary, ssh into the host, drive Docker directly" simplicity:
+`yoink` is the thinnest tool that gives you the few Kubernetes ideas that actually matter at small scale, while keeping the "one binary, ssh into the host, drive Docker directly" simplicity:
 
 - **Multiple services per host.** Declare them, deploy them, prune the ones that fall out of config.
 - **Replicas.** Want two `api` containers behind a reverse proxy? Set `replicas: 2`. Healthcheck-gated rolling swap.
@@ -29,6 +29,8 @@ Kamal is a lovely fit for "one app, one binary per host" but starts to creak the
 - **Build where it makes sense, ship how it makes sense.** Yoink treats build origin and distribution as independent choices. Build on a developer laptop OR in CI (both first-class — same `yoink up`). Ship from a real container registry OR push the locally-built image straight to each host with no registry in between. **Incremental layer push works on both paths**: a real registry dedupes natively, and the registry-less path (`--no-registry`) uses an ephemeral [unregistry](https://github.com/psviderski/unregistry) sidecar to get the same layer-level dedup over SSH. Pick whichever combination fits — drop the `build:` block for CI-built infra, keep it for app code, mix freely.
 - **Secure by default.** Containers run as a non-root uid (65534) with cap_drop=ALL, no-new-privileges, read-only rootfs, init=tini, tmpfs noexec, binds default :ro. Override per service when an image genuinely needs root or specific file ownership.
 - **Sealed secrets out of the box.** A single `secrets.age` file committed to the repo, decrypted at deploy time with one key resolved from `YOINK_AGE_KEY` (env in CI) or `YOINK_AGE_KEY_FILE` (a gitignored `age.key` next to your `yoink.yaml`). No remote vault required. Infisical stays available as an opt-in for teams already running it.
+- **Bundled reverse proxy.** Set `domain:` on a service and yoink's bundled Caddy fronts it with HTTPS — automatic Let's Encrypt or sealed Cloudflare origin certs (with optional origin-pull mTLS). h2c for gRPC, HSTS, compression, multi-host canonical redirects — all one-line opt-ins.
+- **CLI + YAML, no GUI.** The entire control surface is the `yoink` binary plus `yoink.yaml`. No web dashboard to click, no API to script. The same workflow that you run by hand drives CI runners and AI coding agents identically — yoink is happy to be driven by Claude Code, Cursor, or a GitHub Actions job.
 - **k9s-style TUI.** A `ratatui` dashboard with one-key reconcile, prune, kill, shell-into, debug-sidecar, log filter, deploy history with one-press rollback. Keyboard-only.
 
 ## Batteries included, extensible at the edges
@@ -49,7 +51,9 @@ The same shape applies elsewhere: registry credentials, CI integrations, host-le
 
 ## What it deliberately doesn't do
 
-- No control plane, no agent on the hosts. yoink is a single Rust binary on your laptop or in CI.
-- No service discovery, no scheduling — Docker's network alias DNS is plenty for a few services on a host.
-- No multi-cluster, no HA, no auto-scaling. One operator, one config, one deploy at a time.
-- No reverse proxy, load balancer, or stateful-accessory orchestration. Use the right tool for each — yoink [pairs cleanly with Tailscale + caddy-docker-proxy](/docs/guide/pairing) for the networking and routing pieces it punts on.
+- **No control plane, no agent on the hosts.** yoink is a single Rust binary on your laptop or in CI. Hosts run nothing but Docker + sshd.
+- **No service discovery beyond a host.** Docker's per-host network DNS is plenty for a few services on a box. Cross-host discovery is your routing problem (Tailscale, public DNS, etc.).
+- **No scheduling or auto-scaling.** Yoink deploys to a fixed set of hosts you declare; capacity decisions stay with you.
+- **No web dashboard or REST API.** Everything happens through the CLI and YAML. The TUI is a keyboard-driven inspector, not a control plane.
+- **No multi-cluster, HA failover, or geo-distribution.** One operator, one config, one deploy at a time. For multi-region, run separate yoink configs per region.
+- **No load balancer or geo-routing.** Yoink ships a [bundled Caddy reverse proxy](/docs/guide/proxy) for HTTPS + per-host routing, but it does not coordinate traffic across hosts. [Tailscale](/docs/guide/pairing) is a clean way to bridge several hosts into one network.

--- a/docs/content/docs/recipes/_index.md
+++ b/docs/content/docs/recipes/_index.md
@@ -10,6 +10,10 @@ Task-oriented how-tos. Each recipe stands alone — pick the one that matches wh
 {{< cards cols="2" >}}
   {{< card link="/docs/recipes/sealed-secrets" title="Sealed secrets (age)" subtitle="The default. Commit secrets.age, decrypt with one key. No remote vault needed." icon="lock-closed" >}}
   {{< card link="/docs/recipes/age-in-github-actions" title="AGE secrets in GitHub Actions" subtitle="Generate a CI-only identity, paste into a GitHub secret, deploy. One env var." icon="lightning-bolt" >}}
+  {{< card link="/docs/recipes/cloudflare-origin-certs" title="Cloudflare Origin Certificates" subtitle="Skip Let's Encrypt — 15-year cert + origin-pull mTLS that locks your origin to Cloudflare's edge." icon="cloud" >}}
+  {{< card link="/docs/recipes/grpc-hosting" title="Hosting gRPC backends" subtitle="`upstream_h2c: true` for native gRPC (Tonic, grpc-go, grpc-java) — covers REST too." icon="switch-horizontal" >}}
+  {{< card link="/docs/recipes/caddy-snippets" title="Caddy snippets cookbook" subtitle="Copy-paste recipes for forward_auth, basic_auth, IP allowlists, headers, redirects, body limits." icon="book-open" >}}
+  {{< card link="/docs/recipes/multi-host-redis-storage" title="Multi-host Let's Encrypt with Redis" subtitle="Share ACME state across hosts to avoid Let's Encrypt rate limits." icon="database" >}}
   {{< card link="/docs/recipes/staging-alongside-prod" title="Run staging alongside prod" subtitle="Same hosts, two configs, namespaced services + networks." icon="duplicate" >}}
   {{< card link="/docs/recipes/self-hosted-registry" title="Self-hosted registry on a yoink host" subtitle="Run registry:2 as a yoink service, expose via tailnet, push to it." icon="cube" >}}
   {{< card link="/docs/recipes/infisical-auth" title="Authenticate to Infisical" subtitle="Three modes: Universal Auth env vars (CI), raw bearer token, cached browser-flow login." icon="key" >}}

--- a/docs/content/docs/recipes/_index.md
+++ b/docs/content/docs/recipes/_index.md
@@ -8,6 +8,7 @@ sidebar:
 Task-oriented how-tos. Each recipe stands alone — pick the one that matches what you're doing.
 
 {{< cards cols="2" >}}
+  {{< card link="/docs/recipes/ai-agents" title="Driving yoink from an AI agent" subtitle="CLI + YAML, no GUI, deterministic exit codes. Patterns for Claude Code, Cursor, Aider, GitHub Copilot Workspace." icon="terminal" >}}
   {{< card link="/docs/recipes/sealed-secrets" title="Sealed secrets (age)" subtitle="The default. Commit secrets.age, decrypt with one key. No remote vault needed." icon="lock-closed" >}}
   {{< card link="/docs/recipes/age-in-github-actions" title="AGE secrets in GitHub Actions" subtitle="Generate a CI-only identity, paste into a GitHub secret, deploy. One env var." icon="lightning-bolt" >}}
   {{< card link="/docs/recipes/cloudflare-origin-certs" title="Cloudflare Origin Certificates" subtitle="Skip Let's Encrypt — 15-year cert + origin-pull mTLS that locks your origin to Cloudflare's edge." icon="cloud" >}}

--- a/docs/content/docs/recipes/ai-agents.md
+++ b/docs/content/docs/recipes/ai-agents.md
@@ -1,0 +1,70 @@
+---
+title: Driving yoink from an AI agent
+weight: 13
+---
+
+Yoink is unusually well-suited to being driven by AI coding agents (Claude Code, Cursor, Aider, OpenAI Codex, GitHub Copilot Workspace, Devin, …) because **its entire control surface is a CLI binary plus YAML files in your repo** — no web dashboard, no REST API to learn, no interactive prompts to navigate. Anything an agent can do at a terminal, it can do with yoink.
+
+This page is the short pitch + a few patterns that work well in practice.
+
+## Why it works
+
+| Property | Why an agent benefits |
+|---|---|
+| **Single binary, on-demand** | Agent runs `yoink up` like any other shell command. No long-running service to bootstrap, no auth flow to script. |
+| **YAML-only config** | Agent can read, edit, and grep `yoink.yaml` like any other source file. Diffs show up cleanly in PRs. |
+| **`--dry-run --format=markdown`** | Agent can ask "what would change?" before committing. Output is machine-readable enough to feed back into the conversation. |
+| **Deterministic exit codes** | Success / failure is unambiguous. No "click the button and see what happens." |
+| **Idempotent** | Re-running `yoink up` after a partial failure picks up where it left off. Safe to retry. |
+| **Drift detection in labels** | Agent can `docker inspect` (or `yoink status`) to see whether the live state matches the declared spec, without trusting its own memory. |
+| **Same workflow local & CI** | The agent's local commands work identically in a GitHub Actions runner. Nothing special to wire up. |
+
+## The agent-friendly loop
+
+The pattern that works:
+
+1. **Describe the change in YAML.** Edit `yoink.yaml` to add a service, change an image tag, bump a replica count, etc.
+2. **Preview the diff.** `yoink up --dry-run --format=markdown` — output is a markdown table the agent can paste into the chat or a PR comment.
+3. **Apply.** `yoink up` (or scoped: `yoink up --service api`).
+4. **Verify.** `yoink status` (one-shot table) and `curl` the public endpoint. The exit code on a failed healthcheck-gated swap is non-zero, so the agent knows immediately if rollout failed.
+5. **Roll back if needed.** `yoink rollback api` — atomic, no human in the loop required.
+
+Every step in this loop is a single shell command with predictable output. No screen-scraping, no waiting for a UI to render.
+
+## Useful subcommands for agents
+
+```sh
+yoink validate                          # Schema + Caddy-config sanity check, fast
+yoink up --dry-run --format=markdown    # "What would happen?" — paste into PR comment
+yoink up --service api                  # Reconcile one service in isolation
+yoink status                            # One-shot table; parses cleanly
+yoink history api                       # Who deployed what, when (last 10)
+yoink rollback api                      # Roll service back to its previous version
+yoink logs api -f                       # Stream logs (terminate when done)
+yoink prune --dry-run                   # See what stale containers would be removed
+yoink proxy-render                      # Print the rendered Caddy config (debugging)
+```
+
+The full surface is in the [CLI reference](/docs/reference/cli) — all flags, all subcommands, no hidden state.
+
+## A tip for prompt design
+
+When asking an agent to make a deploy change, anchor it on the **YAML diff** rather than on the deploy outcome. A good prompt looks like:
+
+> Add a new `worker` service to `yoink.yaml`: image `ghcr.io/me/worker:v1`, depends on `redis`, runs on the `api` and `redis` networks, healthcheck on `/health`. Then run `yoink up --dry-run` and show me the diff before applying.
+
+The agent edits the file, runs the dry-run, you skim the diff, the agent applies. This is the same loop a human would follow — yoink doesn't ask the agent to do anything fundamentally different.
+
+## CI is just an agent that doesn't talk back
+
+The GitHub Actions workflows yoink documents (see [PR-comment dry-run](/docs/recipes/pr-comment-dry-run)) are the same shape: an automated runner edits / reads `yoink.yaml`, calls `yoink up --dry-run`, posts the diff back to the PR, and on merge calls `yoink up` for real. Anything an AI agent does locally, you can graduate to CI by copying the same commands into a workflow file.
+
+## What doesn't work yet
+
+A couple of honest limitations:
+
+- **The TUI is keyboard-driven.** `yoink tui` is for humans. Agents should stick to `yoink status`, `yoink history`, `yoink logs` for inspection.
+- **Interactive prompts.** A few subcommands (`yoink secrets edit`) drop into `$EDITOR`. Agents should use `yoink secrets set KEY=value` style flags or pre-write the secrets file directly.
+- **No streaming structured output.** `yoink up` emits human-readable progress lines. The exit code tells you success/failure; for richer machine-readable output, use `--dry-run --format=markdown` or parse `yoink status`.
+
+These are tractable; if you hit a friction point that an agent can't work around, [open an issue](https://github.com/oddur/yoink/issues).

--- a/docs/content/docs/recipes/cloudflare-origin-certs.md
+++ b/docs/content/docs/recipes/cloudflare-origin-certs.md
@@ -3,7 +3,7 @@ title: Cloudflare Origin Certificates
 weight: 10
 ---
 
-If you're already on Cloudflare's edge, **Origin Certificates** are the simplest TLS story for your origin servers: free, valid for 15 years, no ACME, no Let's Encrypt rate limits, no port-80 reachability requirement. Yoink supports them out of the box.
+If you're already on Cloudflare's edge, **Origin Certificates** are the simplest TLS story for your origin hosts: free, valid for 15 years, no ACME, no Let's Encrypt rate limits, no port-80 reachability requirement. Yoink supports them out of the box.
 
 ## Why this and not Let's Encrypt?
 

--- a/docs/content/docs/start/first-deploy.md
+++ b/docs/content/docs/start/first-deploy.md
@@ -14,6 +14,8 @@ yoink up --build --no-registry       # builds locally, ships, runs
 
 Done. `yoink init` reads your `Dockerfile`, `git remote`, and (optionally) `~/.ssh/config` to fill in every field. `yoink up` builds the image locally, ships it to the host over SSH (no registry needed), and runs it through a healthcheck-gated rolling deploy.
 
+> **One small edit between the two commands**, if you want the no-registry standalone path: open the generated `yoink.yaml` and change `image:` to a bare name (e.g. `my-tool`) so it doesn't include a registry prefix. The walkthrough below shows the full flow.
+
 Edit a line of code, run `yoink up --build --no-registry` again — yoink rebuilds, ships only changed layers, rolls the new container behind the healthcheck. ~5–15 seconds for a small image.
 
 ## Prerequisites

--- a/docs/content/docs/start/install.md
+++ b/docs/content/docs/start/install.md
@@ -64,3 +64,17 @@ Yoink doesn't bootstrap docker; it expects:
 - **For local-build workflows**: docker on the operator's machine too (`yoink build` shells out to `docker build`)
 
 [Tailscale](https://tailscale.com) pairs especially cleanly with the SSH transport — see [Pairing](/docs/guide/pairing).
+
+## Next: your first deploy
+
+Yoink installed, host with Docker + SSH ready? Head to [**Five-minute first deploy**](/docs/start/first-deploy) — two commands take you from a fresh VPS to a running app behind a healthcheck-gated rolling deploy.
+
+## Upgrading
+
+```sh
+brew upgrade oddur/yoink/yoink              # Homebrew
+cargo install --git https://github.com/oddur/yoink yoink --force   # cargo
+curl -LsSf https://github.com/oddur/yoink/releases/latest/download/yoink-installer.sh | sh   # installer script
+```
+
+Release notes for every version are on the [GitHub releases page](https://github.com/oddur/yoink/releases). Yoink follows SemVer; minor bumps may add new fields but won't break existing `yoink.yaml` configs.


### PR DESCRIPTION
## Summary

A pass over the docs to:
1. **Reduce drive-by Kamal references** outside the comparison page — yoink should stand on its own; comparison page is the right home for tool-vs-tool framing.
2. **Add an at-a-glance matrix table** to the comparison page (top of page, before per-tool deep dives) covering 8 tools × 19 dimensions.
3. **Add Coolify and Dokku** as new neighbors in the comparison page (the user pointed out we'd been juxtaposing only against Kamal).
4. **Highlight agent-friendliness** — yoink is unusually well-suited for AI coding agents (Claude Code, Cursor) and CI runners because the entire control surface is CLI + YAML, no GUI. New recipe page, callouts on homepage and what-and-why, dedicated row in every comparison table.
5. **Surface hidden content** — bundled-proxy guide, architecture guide, and the four Caddy-era recipes (CF origin certs, gRPC, snippets cookbook, multi-host Redis) shipped with PR #15 but were never linked from their respective index pages.
6. **Smaller polish** — modernize the production example (drop standalone caddy.yaml, add `domain:` + `proxy.tls`), 'host' vs 'server' standardization, install→first-deploy CTA + upgrade hints, TL;DR caveat in first-deploy.

## Commits

- `4cd6dff` — drop drive-by Kamal refs from homepage / what-and-why; modernize production example to use bundled proxy
- `b4d7e16` — at-a-glance matrix table + Coolify + Dokku sections + agent-friendly row across every per-tool table
- `46103eb` — surface bundled-proxy and Caddy recipes in card grids; add Upgrade + 'Next: first deploy' CTA on install page
- `14be1a0` — new recipe: 'Driving yoink from an AI agent' (loop, useful subcommands, prompt-design tip, known limitations); cards on homepage + recipes index
- `f0a1345` — host/server consistency, kamal-style → push-then-deploy in deploy-modes, TL;DR caveat in first-deploy

## What this is *not*

Things flagged by the audit but deferred (worth follow-up PRs, not blocking this one):
- Expanded troubleshooting (more error scenarios)
- Dedicated 'understanding drift' how-to recipe
- Dedicated 'debugging broken deploys' recipe
- 'Migrating from Kamal' recipe (good for growth)
- Local-dev-with-yoink recipe

## Test plan

- [ ] Render the docs locally (`hugo server` in `docs/`) and click through:
  - [ ] Homepage cards (new agent-friendly card and updated recipes subtitle)
  - [ ] Comparison page renders the matrix table cleanly
  - [ ] Guide index now shows architecture + proxy cards
  - [ ] Recipes index shows AI-agents card first plus the four new Caddy cards
  - [ ] Install page CTA links to first-deploy
  - [ ] New `/docs/recipes/ai-agents` page renders
- [ ] No broken internal links (`hugo --printPathWarnings` or visual click-through)