### PR TITLE
feat(tui): lazydocker parity — resources, stats history, lifecycle, events

### DIFF
--- a/docs/content/docs/reference/tui.md
+++ b/docs/content/docs/reference/tui.md
@@ -21,7 +21,7 @@ Heavily inspired by [k9s](https://k9scli.io/) and [lazydocker](https://github.co
 | **Hosts** | per-host preflight (ssh, daemon version, kernel/OS) + aggregate CPU/mem across the host. Drill in for a per-host table. |
 | **HostDetail** | every running container on a host (yoink-managed *or not*) with live stats, plus a rolling per-host docker-events panel at the bottom. |
 | **Services** | one row per configured service with replica count + image. Drill in for `ServiceDetail` (every replica across every host) → `ServiceHistory` (every past deploy → roll back from here). |
-| **ContainerDetail** | k9s-style "describe": image, command, env (secrets redacted), ports, mounts, networks, security profile (cap_drop / read_only / pids_limit), restart count, **5-minute history charts** for CPU% + Mem%, and another for net rx/tx rate. `p` opens a `docker top` modal listing in-container processes. |
+| **ContainerDetail** | k9s-style "describe": image, command, env (secrets redacted), ports, mounts, networks, security profile (cap_drop / read_only / pids_limit), restart count, three **5-minute history charts** (CPU%, Mem, mirrored net tx/rx), and a `NET ↓rx ↑tx` cumulative line in the card. `p` opens a `docker top` modal listing in-container processes. |
 | **Logs** | a multiplexed live tail of every yoink-managed container (auto-piped through [`hl`](https://github.com/pamburus/hl) when present). `/` filters substring, `g`/`G` jump to top/bottom, `y` yanks the visible buffer to the system clipboard via OSC-52. |
 | **ContainerLogs** | same shape, scoped to one container. |
 | **Resources** | three sub-tabs (`Images`, `Volumes`, `Networks`) covering everything lazydocker exposes. Per-row remove with `d`; per-tab `P` prune (`A` for the aggressive image prune that goes beyond `<none>:<none>`). |
@@ -64,12 +64,17 @@ Heavily inspired by [k9s](https://k9scli.io/) and [lazydocker](https://github.co
 
 The detail pane renders four kinds of information for a single container:
 
-1. **Header card** — image, state (colored), command, restart count, started/finished/exit-code timestamps.
-2. **5-minute history charts** — left panel plots CPU% (cyan) and either Mem% (magenta) when a memory cap is set or absolute MB when uncapped, sharing a 0–100 y-axis when both metrics are percentages. Right panel plots network rx (green) / tx (yellow) rates derived from successive cumulative-bytes samples.
+1. **Header card** — image, state (colored), command, restart count, started/finished/exit-code timestamps. The right column has live `CPU` / `MEM` gauges and a `NET ↓rx ↑tx` cumulative-bytes line ("how much has this thing transferred since start").
+2. **5-minute history charts** — three side-by-side panels, each with the latest sampled value baked into its title so it's readable without squinting at the rightmost edge:
+   - **CPU %** (cyan) — own y-axis scaled to peak CPU
+   - **Mem** (magenta) — own y-axis. % when memory is capped, MB when uncapped
+   - **net tx / rx** (yellow / green) — btop-style mirrored: `tx` (outgoing) plots above the zero line, `rx` (incoming) mirrored below. The two series can never overlap. Title shows current rates: `↑1.2MB/s ↓340KB/s`. Y-axis labels carry the direction arrow on each side.
 3. **Runtime + security blocks** — published ports, mounts, attached networks, then `cap_drop` / `cap_add` / `security_opt` / `read_only` / `pids_limit` / effective `user` so you can see at a glance whether this container is hardened.
 4. **Env + labels** — sorted KEY=value with secret-ish keys (`*TOKEN*`, `*SECRET*`, `*PASSWORD*`, `*API_KEY*`, `*PRIVATE_KEY*`, `*DSN*`) auto-redacted; full label table including the `yoink.*` set.
 
 Plus, at the bottom of the pane, a rolling tail of the container's logs.
+
+**History is collected for every container, all the time** — a background poller samples `docker stats` for every running container across every configured host every 2 seconds, regardless of which view you're currently on. So when you drill into a container's detail pane, the chart is already populated with up to 5 minutes of context instead of starting from zero. Stale entries (containers that stopped and aged out) are GC'd automatically.
 
 | key | action |
 |---|---|

--- a/docs/content/docs/reference/tui.md
+++ b/docs/content/docs/reference/tui.md
@@ -7,13 +7,27 @@ weight: 3
 yoink tui
 ```
 
-Heavily inspired by [k9s](https://k9scli.io/). Keyboard-driven panes for dashboard (drift across all services), hosts (per-host detail with live CPU/mem), services (per-service detail with replica info), container logs (live tail with `/` filter), per-container detail (env, mounts, healthcheck, networks, security profile), service deploy history.
+Heavily inspired by [k9s](https://k9scli.io/) and [lazydocker](https://github.com/jesseduffield/lazydocker), but pointed at remote hosts you deploy to instead of just the local docker daemon. Keyboard-driven, real-time, and aware of yoink-specific concepts (services, drift, sealed secrets, deploy history) on top of the everyday docker introspection an operator wants when something is on fire.
 
 ![yoink TUI dashboard](https://github.com/user-attachments/assets/bcf956b1-937a-43d7-92f6-0f24a1d0cd98)
 
 ![yoink TUI container detail](https://github.com/user-attachments/assets/36d3cc00-355c-482b-addc-454a0070b58e)
 
-## Top-level modes
+## What it shows
+
+| pane | what it's for |
+|---|---|
+| **Dashboard** | one row per yoink-managed container across every host, with drift, CPU/mem, and exit-code colour. The "is anything broken right now" view. |
+| **Hosts** | per-host preflight (ssh, daemon version, kernel/OS) + aggregate CPU/mem across the host. Drill in for a per-host table. |
+| **HostDetail** | every running container on a host (yoink-managed *or not*) with live stats, plus a rolling per-host docker-events panel at the bottom. |
+| **Services** | one row per configured service with replica count + image. Drill in for `ServiceDetail` (every replica across every host) → `ServiceHistory` (every past deploy → roll back from here). |
+| **ContainerDetail** | k9s-style "describe": image, command, env (secrets redacted), ports, mounts, networks, security profile (cap_drop / read_only / pids_limit), restart count, **5-minute history charts** for CPU% + Mem%, and another for net rx/tx rate. `p` opens a `docker top` modal listing in-container processes. |
+| **Logs** | a multiplexed live tail of every yoink-managed container (auto-piped through [`hl`](https://github.com/pamburus/hl) when present). `/` filters substring, `g`/`G` jump to top/bottom, `y` yanks the visible buffer to the system clipboard via OSC-52. |
+| **ContainerLogs** | same shape, scoped to one container. |
+| **Resources** | three sub-tabs (`Images`, `Volumes`, `Networks`) covering everything lazydocker exposes. Per-row remove with `d`; per-tab `P` prune (`A` for the aggressive image prune that goes beyond `<none>:<none>`). |
+| **Secrets** | view / add / edit / remove individual sealed secrets without leaving the TUI; reuses the same on-disk format as `yoink secrets edit`. |
+
+## Top-level navigation
 
 | key | mode |
 |---|---|
@@ -21,28 +35,101 @@ Heavily inspired by [k9s](https://k9scli.io/). Keyboard-driven panes for dashboa
 | `h` | Hosts |
 | `s` | Services |
 | `l` | Logs |
+| `R` | Resources (Images / Volumes / Networks) |
 | `e` | Encrypted-secrets |
 | `Tab` / `Shift-Tab` | cycle modes forward / backward |
+| `?` | toggle help overlay (per-view keybinds) |
+| `q` / `Ctrl-C` | quit |
 
 ## Operator gestures from the dashboard
 
 | key | action |
 |---|---|
-| `↑` / `↓` / `j` / `k` | navigate |
-| `enter` | drill into selected row |
-| `i` | container inspect (security & limits, env, mounts, networks) |
-| `K` | kill (with confirmation) |
-| `U` | reconcile this service |
-| `A` | reconcile all services |
-| `P` | prune |
-| `!` | shell into container |
-| `D` | debug sidecar (alpine in target's pid+net ns) |
+| `↑` `↓` / `j` `k` | navigate |
+| `enter` | drill into selected row (container detail) |
+| `i` | container inspect (security & limits, env, mounts, networks) — also from HostDetail / ServiceDetail |
+| `K` | SIGKILL container (with confirmation) |
+| `S` / `X` / `R` | start / stop / restart container — from HostDetail or ContainerDetail |
+| `U` | reconcile this service (with confirmation) — drift-only services no-op |
+| `A` | reconcile **all** services (with confirmation) |
+| `P` | prune stale + orphan containers (with confirmation) |
+| `!` | shell into container (`bash` then fallback to `sh`) |
+| `D` | debug sidecar (alpine in target's pid+net ns — for distroless / shell-less images) |
 | `H` | service deploy history; on a stopped row press `r` to roll back |
 | `x` | toggle eXited containers visible in the table |
 | `r` | refresh |
 | `/` | filter substring (Esc clears) |
-| `?` | help overlay |
-| `q` | quit |
+
+## Container detail (`i` from any list view)
+
+The detail pane renders four kinds of information for a single container:
+
+1. **Header card** — image, state (colored), command, restart count, started/finished/exit-code timestamps.
+2. **5-minute history charts** — left panel plots CPU% (cyan) and either Mem% (magenta) when a memory cap is set or absolute MB when uncapped, sharing a 0–100 y-axis when both metrics are percentages. Right panel plots network rx (green) / tx (yellow) rates derived from successive cumulative-bytes samples.
+3. **Runtime + security blocks** — published ports, mounts, attached networks, then `cap_drop` / `cap_add` / `security_opt` / `read_only` / `pids_limit` / effective `user` so you can see at a glance whether this container is hardened.
+4. **Env + labels** — sorted KEY=value with secret-ish keys (`*TOKEN*`, `*SECRET*`, `*PASSWORD*`, `*API_KEY*`, `*PRIVATE_KEY*`, `*DSN*`) auto-redacted; full label table including the `yoink.*` set.
+
+Plus, at the bottom of the pane, a rolling tail of the container's logs.
+
+| key | action |
+|---|---|
+| `enter` / `l` | open dedicated logs view |
+| `!` | exec a shell inside (`bash` → `sh`) |
+| `D` | debug sidecar (alpine sharing pid+net ns) |
+| `S` / `X` / `R` | start / stop / restart |
+| `K` | SIGKILL (with confirmation) |
+| `U` | reconcile this service |
+| `p` | docker top — shows in-container processes in a modal (Esc to close) |
+| `r` | refresh |
+| `esc` | back to host detail |
+
+If your image is distroless or otherwise has no shell, `!` will fail. **Fall back to `D`** — the debug sidecar attaches an alpine container sharing the target's PID and network namespaces, so you can run `ps`, `ss`, `cat /proc/<pid>/...` against the target without modifying the production image. The sidecar auto-removes when you `exit` / Ctrl-D.
+
+## Hosts pane (`h`)
+
+Per-host summary table:
+
+| col | meaning |
+|---|---|
+| `host` | `user@address` from `yoink.yaml` |
+| `status` | ssh probe + bollard handshake — `ok` / `unreachable` (with classified hint for Tailscale auth, `ssh-add` reminders, etc.) |
+| `daemon` | docker server version, OS / kernel |
+| `cpu`, `mem` | aggregate across all running containers (sum of `docker stats`) — gauge-coloured |
+
+`Enter` drills into **HostDetail**, which shows every running container on the host (whether yoink manages it or not), with the same live CPU/mem cells, drift indicator, and per-container actions:
+
+| key | action |
+|---|---|
+| `↑↓` / `j` `k` | select container |
+| `enter` | live logs |
+| `i` | container detail (env, mounts, security, history charts, …) |
+| `!` | shell · `D` debug sidecar |
+| `S` / `X` / `R` | start · stop · restart |
+| `K` | SIGKILL (with confirmation) |
+| `U` | reconcile this service |
+| `/` | filter substring · `esc` clears |
+| `r` | refresh |
+| `esc` | back to Hosts (when no active filter) |
+
+The **events panel** at the bottom of HostDetail collects live `docker events` for that host (start / stop / die / health-status / kill / oom / restart). Each row is a one-line summary timestamped with relative time. The ring keeps the last 200 events per host — long enough that an operator returning to the pane after a reconcile sees the full sequence of swaps, not just the final state.
+
+## Services pane (`s`)
+
+`Services` lists every service in `yoink.yaml` with its current replica count and configured image. `Enter` opens **ServiceDetail** — one row per running replica across every host — with the same per-row container actions. `H` opens **ServiceHistory**: every yoink-managed container with `yoink.service=<name>` (running and exited), sorted newest-first by `yoink.deployed-at`. Pressing `r` on a row triggers a rollback confirmation pinned to that row's tag (same flow as `yoink rollback --tag <value>`).
+
+## Resources pane (`R`)
+
+Three sub-tabs covering the introspection lazydocker users expect, fanned out across every configured host:
+
+| tab | columns | actions |
+|---|---|---|
+| **Images** (`i` inside Resources) | host · 12-char id · size · age · dangling · tags | `d` remove · `P` prune dangling · `A` prune all unused |
+| **Volumes** (`v`) | host · name · driver · mountpoint | `d` remove · `P` prune unused |
+| **Networks** (`n`) | host · name · driver · scope · internal | `d` remove · `P` prune unused |
+
+`Tab` / `Shift-Tab` cycles between the three sub-tabs (instead of cycling the top-level modes — only inside Resources). `/` filters across host/name/tag substrings; partial fetch errors per host appear as a red footer ribbon rather than blanking the whole table. Dangling images sort to the top so they're trivial to prune.
+
+There's intentionally **no volume file browsing** — drop into the container with `!` (or, for distroless containers, `D` for the debug sidecar) and use the shell. That's strictly more capable than the half-baked file UI lazydocker has, and it's what most operators reach for anyway.
 
 ## Secrets pane (`e`)
 
@@ -50,7 +137,7 @@ View / add / edit / remove individual sealed secrets without leaving the TUI. Re
 
 | key | action |
 |---|---|
-| `↑` / `↓` / `j` / `k` | select key |
+| `↑↓` / `j` `k` | select key |
 | `r` | reveal/mask values |
 | `/` | filter substring |
 | `a` | add a new secret (age provider only) |
@@ -65,3 +152,30 @@ When the provider is Infisical the pane is read-only — edits go via the Infisi
 Structured log lines (JSON, logfmt, etc.) are hard to scan as raw text. The TUI's logs pane auto-detects [`hl`](https://github.com/pamburus/hl) (`brew install pamburus/tap/hl`) on the operator's `PATH` and transparently pipes every container's log stream through it before rendering — so JSON keys are colored, timestamps are dim, levels are highlighted, and stack traces stay readable. Falls back to raw output when `hl` isn't installed; no config knob to toggle.
 
 The `yoink logs <svc> -f` CLI doesn't auto-pipe (the operator decides their own shell pipeline), but `yoink logs api -f | hl` works the same way.
+
+## Keybinding cheat sheet
+
+A consistent set of letters has the same meaning everywhere they appear:
+
+| key | meaning |
+|---|---|
+| `j` `k` / `↑` `↓` | navigate up / down |
+| `enter` | drill in (logs from a list, modal-confirm from a dialog) |
+| `esc` | back / dismiss / clear filter |
+| `/` | begin filter input |
+| `r` | refresh the current pane |
+| `!` | shell into selection |
+| `D` | debug sidecar |
+| `i` | inspect (container detail) |
+| `K` | kill (SIGKILL with confirmation) |
+| `S` / `X` / `R` | start · stop · restart container |
+| `U` | reconcile current service |
+| `A` | reconcile all services |
+| `P` | prune (containers from Dashboard; resources from Resources) |
+| `H` | history (only on ServiceDetail) |
+| `p` | docker top (only on ContainerDetail) |
+| `y` | yank visible buffer to clipboard (logs / progress modals) |
+| `?` | help overlay scoped to the current view |
+| `q` / `Ctrl-C` | quit |
+
+Letters are case-sensitive — capital letters generally mean "destructive or expensive" (kill, restart, reconcile-all, prune-all-images, …) and require a `y`/Enter confirmation when state-changing, while lowercase letters are read-only navigation / refreshes.

--- a/yoink/src/docker_ops.rs
+++ b/yoink/src/docker_ops.rs
@@ -212,7 +212,7 @@ pub struct HostInfo {
 }
 
 /// One-shot snapshot of a container's CPU + memory utilization.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, Default, PartialEq)]
 pub struct ContainerStats {
     /// CPU% across all online CPUs — max ≈ `n_cpu * 100`.
     pub cpu_pct: f64,
@@ -220,6 +220,54 @@ pub struct ContainerStats {
     pub mem_used: i64,
     /// Limit in bytes if a memory cap is set, else None.
     pub mem_limit: Option<i64>,
+    /// Cumulative bytes received across every interface, since the
+    /// container started. Time-series consumers diff successive samples
+    /// to get rates.
+    pub net_rx_bytes: i64,
+    /// Cumulative bytes transmitted, see `net_rx_bytes`.
+    pub net_tx_bytes: i64,
+    /// Cumulative bytes read from block devices.
+    pub block_read_bytes: i64,
+    /// Cumulative bytes written to block devices.
+    pub block_write_bytes: i64,
+    /// Number of pids running inside the container at sample time.
+    pub pids: i64,
+}
+
+/// One image as the dashboard / `yoink images` show it.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
+pub struct ImageInfo {
+    pub host: String,
+    /// Short SHA-256 (first 12 hex chars).
+    pub id: String,
+    /// All `repo:tag` references this image is known by.
+    pub repo_tags: Vec<String>,
+    pub size_bytes: i64,
+    /// Unix epoch seconds, if reported.
+    pub created_unix: Option<i64>,
+    /// `true` when no container references this image (eligible for prune).
+    pub dangling: bool,
+}
+
+/// Single process row from `docker top` (output of `ps -ef` inside the
+/// container). Column meanings vary by container-side ps; we surface
+/// the daemon's reported titles verbatim alongside the values so the
+/// operator can interpret them.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
+pub struct ProcessTable {
+    pub titles: Vec<String>,
+    pub processes: Vec<Vec<String>>,
+}
+
+/// Result of a `docker {images,volumes,networks} prune` call. Object
+/// is uniform across all three so the TUI's prune-confirmation flow
+/// can render the same toast format.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct PruneReport {
+    /// Names / IDs reclaimed.
+    pub reclaimed: Vec<String>,
+    /// Bytes reclaimed (0 for prunes that don't free disk — networks).
+    pub space_reclaimed_bytes: i64,
 }
 
 /// Realtime change notification from a host's docker daemon. Currently
@@ -427,6 +475,88 @@ pub trait DockerOps: Send + Sync {
     /// List every docker volume on `host`. Used by `yoink volumes`.
     async fn list_volumes(&self, host: &Host) -> Result<Vec<VolumeInfo>, DockerError>;
 
+    /// List every image cached on `host`. The TUI's Resources pane
+    /// renders this as a sortable table with size + age columns.
+    /// Default impl returns an empty list so callers (Fake / future
+    /// alt backends) keep working without an explicit override.
+    async fn list_images(&self, _host: &Host) -> Result<Vec<ImageInfo>, DockerError> {
+        Ok(Vec::new())
+    }
+
+    /// Remove a single image by id or `repo:tag`. `force=true` removes
+    /// even when there are tag references; `false` errors out when
+    /// other tags point at the same image id.
+    async fn remove_image(
+        &self,
+        _host: &Host,
+        _name: &str,
+        _force: bool,
+    ) -> Result<(), DockerError> {
+        Err(DockerError::Invalid("remove_image not supported".into()))
+    }
+
+    /// Prune unused images. `dangling_only=true` matches `docker image
+    /// prune` (default — only `<none>:<none>` layers); `false` matches
+    /// `docker image prune -a` (every image with no live container
+    /// reference).
+    async fn prune_images(
+        &self,
+        _host: &Host,
+        _dangling_only: bool,
+    ) -> Result<PruneReport, DockerError> {
+        Ok(PruneReport::default())
+    }
+
+    /// Remove one volume. `force` corresponds to `docker volume rm -f`.
+    async fn remove_volume(
+        &self,
+        _host: &Host,
+        _name: &str,
+        _force: bool,
+    ) -> Result<(), DockerError> {
+        Err(DockerError::Invalid("remove_volume not supported".into()))
+    }
+
+    /// `docker volume prune` — drop volumes that no container references.
+    async fn prune_volumes(&self, _host: &Host) -> Result<PruneReport, DockerError> {
+        Ok(PruneReport::default())
+    }
+
+    /// Remove one user-defined network. Default networks (`bridge`,
+    /// `host`, `none`) reject removal.
+    async fn remove_network(&self, _host: &Host, _name: &str) -> Result<(), DockerError> {
+        Err(DockerError::Invalid("remove_network not supported".into()))
+    }
+
+    /// `docker network prune` — drop user-defined networks with no
+    /// attached containers.
+    async fn prune_networks(&self, _host: &Host) -> Result<PruneReport, DockerError> {
+        Ok(PruneReport::default())
+    }
+
+    /// `docker restart` with the standard 10s SIGTERM grace period.
+    /// Implemented separately from stop+start so the daemon does the
+    /// state transition atomically (no observer-visible "stopped" gap).
+    async fn restart_container(
+        &self,
+        _host: &Host,
+        _name: &str,
+        _drain: Duration,
+    ) -> Result<(), DockerError> {
+        Err(DockerError::Invalid(
+            "restart_container not supported".into(),
+        ))
+    }
+
+    /// `docker top` — list processes running inside the container.
+    /// Used by the container detail pane's `p` gesture.
+    async fn top_container(&self, _host: &Host, _name: &str) -> Result<ProcessTable, DockerError> {
+        Ok(ProcessTable {
+            titles: Vec::new(),
+            processes: Vec::new(),
+        })
+    }
+
     async fn pull_image(
         &self,
         host: &Host,
@@ -438,11 +568,7 @@ pub trait DockerOps: Send + Sync {
     /// Stream a `docker save`-style tarball into the host's docker
     /// daemon (`POST /images/load`). Body is a `Stream<Bytes>` so
     /// memory stays bounded by the chunk size, not the image size.
-    async fn load_image(
-        &self,
-        host: &Host,
-        body: ImageTarStream,
-    ) -> Result<(), DockerError>;
+    async fn load_image(&self, host: &Host, body: ImageTarStream) -> Result<(), DockerError>;
 
     /// `true` if `image:tag` is already present in the host's local
     /// image cache (no pull needed). Used to skip redundant pulls
@@ -918,6 +1044,166 @@ impl DockerOps for RealDockerOps {
             .collect())
     }
 
+    async fn list_images(&self, host: &Host) -> Result<Vec<ImageInfo>, DockerError> {
+        let docker = self.client_for(host).await?;
+        let opts = bollard::query_parameters::ListImagesOptionsBuilder::new()
+            .all(false)
+            .build();
+        let images = docker
+            .list_images(Some(opts))
+            .await
+            .map_err(|s| Self::err(host, s))?;
+        Ok(images
+            .into_iter()
+            .map(|img| {
+                let mut id = img.id;
+                if let Some(rest) = id.strip_prefix("sha256:") {
+                    id = rest.chars().take(12).collect();
+                }
+                let dangling = img
+                    .repo_tags
+                    .iter()
+                    .all(|t| t == "<none>:<none>" || t.is_empty());
+                ImageInfo {
+                    host: host.address.clone(),
+                    id,
+                    repo_tags: img.repo_tags,
+                    size_bytes: img.size,
+                    created_unix: Some(img.created),
+                    dangling,
+                }
+            })
+            .collect())
+    }
+
+    async fn remove_image(&self, host: &Host, name: &str, force: bool) -> Result<(), DockerError> {
+        let docker = self.client_for(host).await?;
+        let opts = bollard::query_parameters::RemoveImageOptionsBuilder::new()
+            .force(force)
+            .noprune(false)
+            .build();
+        // 404 is idempotent: image already gone.
+        match docker.remove_image(name, Some(opts), None).await {
+            Ok(_)
+            | Err(bollard::errors::Error::DockerResponseServerError {
+                status_code: 404, ..
+            }) => Ok(()),
+            Err(other) => Err(Self::err(host, other)),
+        }
+    }
+
+    async fn prune_images(
+        &self,
+        host: &Host,
+        dangling_only: bool,
+    ) -> Result<PruneReport, DockerError> {
+        let docker = self.client_for(host).await?;
+        // `dangling=true` → only `<none>` images. `dangling=false` →
+        // every image with no live container reference (matches `-a`).
+        let mut filters: HashMap<String, Vec<String>> = HashMap::new();
+        filters.insert(
+            "dangling".to_string(),
+            vec![if dangling_only { "true" } else { "false" }.to_string()],
+        );
+        let opts = bollard::query_parameters::PruneImagesOptionsBuilder::new()
+            .filters(&filters)
+            .build();
+        let resp = docker
+            .prune_images(Some(opts))
+            .await
+            .map_err(|s| Self::err(host, s))?;
+        let reclaimed = resp
+            .images_deleted
+            .unwrap_or_default()
+            .into_iter()
+            .filter_map(|d| d.deleted.or(d.untagged))
+            .collect();
+        Ok(PruneReport {
+            reclaimed,
+            space_reclaimed_bytes: resp.space_reclaimed.unwrap_or(0),
+        })
+    }
+
+    async fn remove_volume(&self, host: &Host, name: &str, force: bool) -> Result<(), DockerError> {
+        let docker = self.client_for(host).await?;
+        let opts = bollard::query_parameters::RemoveVolumeOptionsBuilder::new()
+            .force(force)
+            .build();
+        match docker.remove_volume(name, Some(opts)).await {
+            Ok(())
+            | Err(bollard::errors::Error::DockerResponseServerError {
+                status_code: 404, ..
+            }) => Ok(()),
+            Err(other) => Err(Self::err(host, other)),
+        }
+    }
+
+    async fn prune_volumes(&self, host: &Host) -> Result<PruneReport, DockerError> {
+        let docker = self.client_for(host).await?;
+        let resp = docker
+            .prune_volumes(None::<bollard::query_parameters::PruneVolumesOptions>)
+            .await
+            .map_err(|s| Self::err(host, s))?;
+        Ok(PruneReport {
+            reclaimed: resp.volumes_deleted.unwrap_or_default(),
+            space_reclaimed_bytes: resp.space_reclaimed.unwrap_or(0),
+        })
+    }
+
+    async fn remove_network(&self, host: &Host, name: &str) -> Result<(), DockerError> {
+        let docker = self.client_for(host).await?;
+        match docker.remove_network(name).await {
+            Ok(())
+            | Err(bollard::errors::Error::DockerResponseServerError {
+                status_code: 404, ..
+            }) => Ok(()),
+            Err(other) => Err(Self::err(host, other)),
+        }
+    }
+
+    async fn prune_networks(&self, host: &Host) -> Result<PruneReport, DockerError> {
+        let docker = self.client_for(host).await?;
+        let resp = docker
+            .prune_networks(None::<bollard::query_parameters::PruneNetworksOptions>)
+            .await
+            .map_err(|s| Self::err(host, s))?;
+        Ok(PruneReport {
+            reclaimed: resp.networks_deleted.unwrap_or_default(),
+            space_reclaimed_bytes: 0,
+        })
+    }
+
+    async fn restart_container(
+        &self,
+        host: &Host,
+        name: &str,
+        drain: Duration,
+    ) -> Result<(), DockerError> {
+        let docker = self.client_for(host).await?;
+        let opts = bollard::query_parameters::RestartContainerOptionsBuilder::new()
+            .t(i32::try_from(drain.as_secs()).unwrap_or(i32::MAX))
+            .build();
+        docker
+            .restart_container(name, Some(opts))
+            .await
+            .map_err(|s| Self::err(host, s))
+    }
+
+    async fn top_container(&self, host: &Host, name: &str) -> Result<ProcessTable, DockerError> {
+        let docker = self.client_for(host).await?;
+        let opts = bollard::query_parameters::TopOptionsBuilder::new()
+            .ps_args("-ef")
+            .build();
+        let resp = docker
+            .top_processes(name, Some(opts))
+            .await
+            .map_err(|s| Self::err(host, s))?;
+        Ok(ProcessTable {
+            titles: resp.titles.unwrap_or_default(),
+            processes: resp.processes.unwrap_or_default(),
+        })
+    }
+
     async fn pull_image(
         &self,
         host: &Host,
@@ -978,11 +1264,7 @@ impl DockerOps for RealDockerOps {
         }
     }
 
-    async fn load_image(
-        &self,
-        host: &Host,
-        body: ImageTarStream,
-    ) -> Result<(), DockerError> {
+    async fn load_image(&self, host: &Host, body: ImageTarStream) -> Result<(), DockerError> {
         use bollard::query_parameters::ImportImageOptions;
         let docker = self.client_for(host).await?;
         let mut stream = docker.import_image(
@@ -1702,10 +1984,57 @@ fn parse_stats(stats: &bollard::models::ContainerStatsResponse) -> ContainerStat
         .and_then(|m| m.limit)
         .and_then(|l| i64::try_from(l).ok());
 
+    // Sum bytes across every interface — bollard's `networks` is a map
+    // keyed by interface name (`eth0`, `eth1`, …). Container-side `lo`
+    // doesn't appear, so this is the meaningful "total network usage".
+    let (mut net_rx, mut net_tx): (i64, i64) = (0, 0);
+    if let Some(nets) = stats.networks.as_ref() {
+        for v in nets.values() {
+            if let Some(rx) = v.rx_bytes
+                && let Ok(rx) = i64::try_from(rx)
+            {
+                net_rx = net_rx.saturating_add(rx);
+            }
+            if let Some(tx) = v.tx_bytes
+                && let Ok(tx) = i64::try_from(tx)
+            {
+                net_tx = net_tx.saturating_add(tx);
+            }
+        }
+    }
+
+    let (mut block_read, mut block_write): (i64, i64) = (0, 0);
+    if let Some(io) = stats
+        .blkio_stats
+        .as_ref()
+        .and_then(|b| b.io_service_bytes_recursive.as_ref())
+    {
+        for entry in io {
+            let val = entry.value.and_then(|v| i64::try_from(v).ok()).unwrap_or(0);
+            match entry.op.as_deref() {
+                Some("read" | "Read") => block_read = block_read.saturating_add(val),
+                Some("write" | "Write") => block_write = block_write.saturating_add(val),
+                _ => {}
+            }
+        }
+    }
+
+    let pids: i64 = stats
+        .pids_stats
+        .as_ref()
+        .and_then(|p| p.current)
+        .and_then(|p| i64::try_from(p).ok())
+        .unwrap_or(0);
+
     ContainerStats {
         cpu_pct,
         mem_used,
         mem_limit,
+        net_rx_bytes: net_rx,
+        net_tx_bytes: net_tx,
+        block_read_bytes: block_read,
+        block_write_bytes: block_write,
+        pids,
     }
 }
 
@@ -1840,9 +2169,7 @@ fn parse_inspect(name: &str, resp: &bollard::models::ContainerInspectResponse) -
         security_opt: host_config
             .and_then(|h| h.security_opt.clone())
             .unwrap_or_default(),
-        read_only: host_config
-            .and_then(|h| h.readonly_rootfs)
-            .unwrap_or(false),
+        read_only: host_config.and_then(|h| h.readonly_rootfs).unwrap_or(false),
         labels,
     }
 }
@@ -2145,11 +2472,7 @@ impl DockerOps for FakeDockerOps {
         // returning false keeps existing test expectations intact.
         Ok(false)
     }
-    async fn load_image(
-        &self,
-        host: &Host,
-        _body: ImageTarStream,
-    ) -> Result<(), DockerError> {
+    async fn load_image(&self, host: &Host, _body: ImageTarStream) -> Result<(), DockerError> {
         let mut s = self.lock();
         s.calls.push(RecordedCall::LoadImage(host.clone()));
         pop(&mut s.load_image, "load_image")

--- a/yoink/src/tui/app.rs
+++ b/yoink/src/tui/app.rs
@@ -38,7 +38,7 @@ use crate::config::Config;
 use crate::docker_ops::{DockerEvent, DockerEventKind, DockerOps, Host, LogLine};
 use crate::status::StatusReport;
 
-use super::container_detail::{self, ContainerDetailRefresh, ContainerDetailState};
+use super::container_detail::{self, ContainerDetailRefresh, ContainerDetailState, StatsHistory};
 use super::dashboard::{self, DashboardRefresh, DashboardState};
 use super::host_detail::{self, HostDetailRefresh, HostDetailState};
 use super::hosts::{self, HostRow, HostsState};
@@ -67,6 +67,12 @@ const RESOURCES_TICK: Duration = Duration::from_secs(15);
 /// formatted line — generous so an operator returning to a `HostDetail`
 /// pane after lunch sees recent context.
 const EVENT_HISTORY_PER_HOST: usize = 200;
+/// Cadence of the always-on stats-history poller (one task per host).
+/// Matches `FAST_TICK` — by the time the operator opens a container
+/// detail pane, the chart has whatever back-history the poller managed
+/// to collect at this rate. 2s is the same cadence dashboard uses, so
+/// the docker daemon load is comparable.
+const STATS_HISTORY_TICK: Duration = Duration::from_secs(2);
 /// How often to re-stat + re-parse the on-disk config so a `vim
 /// services/api.yaml` is reflected without restarting the TUI. Polling
 /// (vs notify/inotify) keeps the dep tree small; 2s latency is fine
@@ -393,6 +399,13 @@ enum Update {
         container: String,
         result: Result<crate::docker_ops::ProcessTable, String>,
     },
+    /// Batch of `(host_address, container_name, stats)` samples produced
+    /// by the always-on background stats poller. Each sample is folded
+    /// into the per-container `StatsHistory` so that opening a
+    /// container's detail pane shows the rolling 5-minute history
+    /// regardless of which view the operator was on while it was being
+    /// collected.
+    StatsBatch(Vec<(String, String, crate::docker_ops::ContainerStats)>),
 }
 
 /// Auto-pop error overlay carrying the full text (including URLs
@@ -578,6 +591,7 @@ async fn run_loop(
     app.schedule_hosts_refresh();
     app.schedule_dashboard_refresh();
     app.start_event_subscriptions();
+    app.start_stats_history_pollers();
     app.spawn_secrets_loader();
     if matches!(app.view, View::Logs) {
         app.start_service_log_streams().await;
@@ -759,6 +773,18 @@ pub struct App {
     /// Newest entries pushed at the back. Drives the events panel
     /// at the bottom of the `HostDetail` pane.
     host_events: std::collections::HashMap<String, std::collections::VecDeque<String>>,
+    /// Per-container stats history, populated by the always-on
+    /// background stats poller. Keyed by `(host_address,
+    /// container_name)` so opening any container's detail pane
+    /// renders the rolling 5-minute history immediately rather than
+    /// starting from zero. Last-update tracking is implicit in each
+    /// `StatsHistory`'s elapsed-time anchor; entries are GC'd when
+    /// their newest sample falls outside `2 × HISTORY_WINDOW_SECS`.
+    container_history:
+        std::collections::HashMap<(String, String), super::container_detail::StatsHistory>,
+    /// Per-host `JoinHandle`s for the always-on stats poller. Aborted
+    /// on Drop and re-spawned on `hosts:` config reload.
+    stats_history_tasks: Vec<JoinHandle<()>>,
     update_tx: UnboundedSender<Update>,
     update_rx: UnboundedReceiver<Update>,
 
@@ -828,6 +854,8 @@ impl App {
             history_in_flight: false,
             resources_in_flight: false,
             host_events: std::collections::HashMap::new(),
+            container_history: std::collections::HashMap::new(),
+            stats_history_tasks: Vec::new(),
             update_tx,
             update_rx,
             log_tasks: Vec::new(),
@@ -865,6 +893,8 @@ impl App {
         if hosts_changed {
             self.stop_event_subscriptions();
             self.start_event_subscriptions();
+            self.stop_stats_history_pollers();
+            self.start_stats_history_pollers();
             self.schedule_hosts_refresh();
         }
         self.schedule_dashboard_refresh();
@@ -1171,6 +1201,106 @@ impl App {
         for task in self.event_tasks.drain(..) {
             task.abort();
         }
+    }
+
+    /// Spawn one always-on stats-history poller per configured host.
+    /// The poller lists running containers on its host every
+    /// `STATS_HISTORY_TICK` and fetches `container_stats` for each
+    /// one in parallel, then ships the batch back through `update_tx`
+    /// as `Update::StatsBatch`. This keeps the rolling 5-minute
+    /// window alive for every container regardless of which view
+    /// the operator is currently on, so opening a container detail
+    /// pane shows immediate context instead of an empty chart.
+    ///
+    /// Idempotent on re-spawn: callers must invoke
+    /// `stop_stats_history_pollers` first (we do that on `hosts:`
+    /// config-reload before respawning, and on Drop).
+    fn start_stats_history_pollers(&mut self) {
+        for host_cfg in &self.config.hosts {
+            let host = Host::from(host_cfg);
+            let ops = self.ops.clone();
+            let tx = self.update_tx.clone();
+            let task = tokio::spawn(async move {
+                let mut tick = tokio::time::interval(STATS_HISTORY_TICK);
+                // First tick fires immediately; eat it so we don't
+                // hammer the daemon during App startup when nothing's
+                // visible yet.
+                tick.tick().await;
+                loop {
+                    tick.tick().await;
+                    let containers = match ops.list_running_containers(&host).await {
+                        Ok(cs) => cs,
+                        Err(e) => {
+                            tracing::debug!(
+                                host = %host.address,
+                                error = %e,
+                                "stats poller: list_running_containers failed",
+                            );
+                            continue;
+                        }
+                    };
+                    if containers.is_empty() {
+                        // Still send an empty batch so the receiver
+                        // gets a heartbeat (useful for future GC
+                        // strategies that key off "we polled at T").
+                        if tx.send(Update::StatsBatch(Vec::new())).is_err() {
+                            return;
+                        }
+                        continue;
+                    }
+                    let stat_futs = containers.iter().map(|c| {
+                        let ops = ops.clone();
+                        let host = host.clone();
+                        let name = c.name.clone();
+                        async move {
+                            let res = ops.container_stats(&host, &name).await.ok();
+                            (host.address.clone(), name, res)
+                        }
+                    });
+                    let results = futures_util::future::join_all(stat_futs).await;
+                    let batch: Vec<(String, String, crate::docker_ops::ContainerStats)> = results
+                        .into_iter()
+                        .filter_map(|(h, n, s)| s.map(|stats| (h, n, stats)))
+                        .collect();
+                    if tx.send(Update::StatsBatch(batch)).is_err() {
+                        return;
+                    }
+                }
+            });
+            self.stats_history_tasks.push(task);
+        }
+    }
+
+    fn stop_stats_history_pollers(&mut self) {
+        for task in self.stats_history_tasks.drain(..) {
+            task.abort();
+        }
+    }
+
+    /// Push one stats sample into the per-container history store.
+    /// Cheap — each container gets its own bounded ring buffer.
+    fn record_stats_sample(
+        &mut self,
+        host: &str,
+        container: &str,
+        stats: &crate::docker_ops::ContainerStats,
+    ) {
+        let entry = self
+            .container_history
+            .entry((host.to_string(), container.to_string()))
+            .or_default();
+        entry.push(stats);
+    }
+
+    /// Drop history entries whose newest sample is older than
+    /// `2 × HISTORY_WINDOW_SECS`. Called from the slow ticks so a
+    /// long-running TUI doesn't slowly accumulate ghost containers.
+    fn gc_container_history(&mut self) {
+        // The `StatsHistory` window-trim logic already drops samples
+        // that have aged out, so an entry whose ring is empty has
+        // had no fresh sample for at least HISTORY_WINDOW_SECS — that's
+        // the GC signal.
+        self.container_history.retain(|_, h| !h.cpu_pct_is_empty());
     }
 
     /// Returns true when the loop should exit.
@@ -2420,6 +2550,12 @@ impl App {
                 self.resources.apply(data);
                 self.resources_in_flight = false;
             }
+            Update::StatsBatch(samples) => {
+                for (host, container, stats) in samples {
+                    self.record_stats_sample(&host, &container, &stats);
+                }
+                self.gc_container_history();
+            }
             Update::Top {
                 host,
                 container,
@@ -2614,7 +2750,7 @@ impl App {
                     &events,
                 );
             }
-            View::ContainerDetail { .. } => {
+            View::ContainerDetail { host, container } => {
                 // Split: top 2/3 = inspect data, bottom 1/3 = live log tail.
                 let split = ratatui::layout::Layout::default()
                     .direction(ratatui::layout::Direction::Vertical)
@@ -2623,7 +2759,10 @@ impl App {
                         ratatui::layout::Constraint::Length(12),
                     ])
                     .split(pane_area);
-                self.container_detail.render(frame, split[0]);
+                let history: Option<&StatsHistory> = self
+                    .container_history
+                    .get(&(host.address.clone(), container.clone()));
+                self.container_detail.render(frame, split[0], history);
                 self.logs.render(frame, split[1], &self.config);
             }
             View::Services => self.services.render(frame, pane_area, &self.config),
@@ -2859,6 +2998,7 @@ impl Drop for App {
     fn drop(&mut self) {
         self.stop_log_streams();
         self.stop_event_subscriptions();
+        self.stop_stats_history_pollers();
     }
 }
 

--- a/yoink/src/tui/app.rs
+++ b/yoink/src/tui/app.rs
@@ -213,8 +213,10 @@ impl View {
                 "  r            refresh",
                 "  esc          back to host detail",
                 "",
-                "the bottom card shows 5-minute history charts:",
-                "  cpu% + mem% (left) and net rx/tx rate (right)",
+                "5-minute history charts (collected for every container",
+                "across every host, even when not viewing them):",
+                "  cpu%   ·   mem   ·   net (tx ↑ above / rx ↓ below)",
+                "current values appear in each chart title.",
             ],
             View::Services => vec![
                 "services",

--- a/yoink/src/tui/app.rs
+++ b/yoink/src/tui/app.rs
@@ -43,6 +43,7 @@ use super::dashboard::{self, DashboardRefresh, DashboardState};
 use super::host_detail::{self, HostDetailRefresh, HostDetailState};
 use super::hosts::{self, HostRow, HostsState};
 use super::logs::{LogsState, RenderedLine};
+use super::resources::{self, ResourceTab, ResourceTarget, ResourcesRefresh, ResourcesState};
 use super::services::{ServiceDetailState, ServicesState};
 use super::shell::{SessionResult, ShellState};
 
@@ -57,6 +58,15 @@ const TOAST_TTL: Duration = Duration::from_secs(5);
 /// Cap on toast ring buffer — older events fall off.
 const TOAST_CAP: usize = 8;
 const HOSTS_TICK: Duration = Duration::from_secs(10);
+/// How often to refresh the Resources pane (images / volumes / networks)
+/// while it's visible. Slower than the dashboard tick: this data
+/// changes far less often (image pulls, volume creates) and the
+/// per-host fan-out is the heaviest list query in the codebase.
+const RESOURCES_TICK: Duration = Duration::from_secs(15);
+/// Per-host docker-events ring buffer cap. Each event is a single
+/// formatted line — generous so an operator returning to a `HostDetail`
+/// pane after lunch sees recent context.
+const EVENT_HISTORY_PER_HOST: usize = 200;
 /// How often to re-stat + re-parse the on-disk config so a `vim
 /// services/api.yaml` is reflected without restarting the TUI. Polling
 /// (vs notify/inotify) keeps the dep tree small; 2s latency is fine
@@ -71,6 +81,7 @@ pub enum Mode {
     Hosts,
     Services,
     Logs,
+    Resources,
     Secrets,
 }
 
@@ -109,6 +120,10 @@ pub enum View {
     /// Sealed-secrets management — view / add / edit / remove
     /// individual KEY=value entries without leaving the TUI.
     Secrets,
+    /// Per-host introspection of docker resources beyond yoink-managed
+    /// containers — Images / Volumes / Networks tabs. Reaches lazydocker
+    /// feature parity for browsing local docker state.
+    Resources,
 }
 
 impl View {
@@ -125,7 +140,8 @@ impl View {
             | View::ContainerDetail { .. } => 1,
             View::Services | View::ServiceDetail(_) | View::ServiceHistory(_) => 2,
             View::Logs => 3,
-            View::Secrets => 4,
+            View::Resources => 4,
+            View::Secrets => 5,
         }
     }
 
@@ -137,7 +153,8 @@ impl View {
         let global = vec![
             "global",
             "  q / Ctrl-C    quit yoink",
-            "  d h s l e     dashboard / hosts / services / logs / encrypted-secrets",
+            "  d h s l       dashboard / hosts / services / logs",
+            "  R e           resources / encrypted-secrets",
             "  Tab / S-Tab   cycle modes forward / backward",
             "  ?             toggle this help overlay",
             "",
@@ -166,23 +183,32 @@ impl View {
                 "host detail",
                 "  ↑↓ / j k     select container",
                 "  enter        live logs",
-                "  i            container detail (labels, env-ish, live cpu/mem)",
+                "  i            container detail (labels, env, live cpu/mem)",
                 "  !            shell into container (bash/sh)",
                 "  D            debug sidecar (alpine, target's pid+net ns)",
+                "  S            start · X stop · R restart container",
                 "  K            SIGKILL container (with confirmation)",
                 "  U            reconcile this service (with confirmation)",
                 "  /            filter substring · esc to clear",
                 "  r            refresh",
                 "  esc          back to hosts (when no active filter)",
+                "",
+                "events panel (bottom of pane) auto-collects start /",
+                "die / health-change events as they fire on the daemon",
             ],
             View::ContainerDetail { .. } => vec![
                 "container detail",
                 "  enter / l    live logs",
                 "  !            shell · D debug sidecar",
+                "  S            start · X stop · R restart container",
                 "  K            SIGKILL container (with confirmation)",
                 "  U            reconcile this service (with confirmation)",
+                "  p            processes (docker top)",
                 "  r            refresh",
                 "  esc          back to host detail",
+                "",
+                "the bottom card shows 5-minute history charts:",
+                "  cpu% + mem% (left) and net rx/tx rate (right)",
             ],
             View::Services => vec![
                 "services",
@@ -234,6 +260,20 @@ impl View {
                 "  e            edit selected value",
                 "  d            delete selected (with confirmation)",
                 "  esc          back",
+            ],
+            View::Resources => vec![
+                "resources (images / volumes / networks)",
+                "  Tab / S-Tab  cycle Images → Volumes → Networks",
+                "  ↑↓ / j k     select row",
+                "  d            remove selected (with confirmation)",
+                "  P            prune unused (with confirmation)",
+                "  A            (Images only) prune ALL unused, not just dangling",
+                "  /            filter substring · esc to clear",
+                "  r            refresh",
+                "",
+                "rows fan out across every configured host. dangling",
+                "images sort first; partial fetch errors per host appear",
+                "in red at the bottom rather than blanking the table.",
             ],
             View::ContainerShell { .. } => vec![
                 "shell",
@@ -290,6 +330,7 @@ impl View {
                 "detail".into(),
             ],
             View::Secrets => vec![root, "Secrets".into()],
+            View::Resources => vec![root, "Resources".into()],
         }
     }
 }
@@ -302,6 +343,7 @@ impl From<Mode> for View {
             Mode::Services => View::Services,
             Mode::Logs => View::Logs,
             Mode::Secrets => View::Secrets,
+            Mode::Resources => View::Resources,
         }
     }
 }
@@ -340,6 +382,17 @@ enum Update {
     /// failures the operator otherwise wouldn't see — log streams
     /// dying, event subscriptions failing, secrets loader blowing up.
     Toast(String),
+    /// Result of `schedule_resources_refresh` — drives the new
+    /// Resources pane.
+    Resources(ResourcesRefresh),
+    /// Result of a `docker top` background fetch. The receiver
+    /// pushes the table onto `ContainerDetailState` (or surfaces an
+    /// error toast on the failure path).
+    Top {
+        host: Host,
+        container: String,
+        result: Result<crate::docker_ops::ProcessTable, String>,
+    },
 }
 
 /// Auto-pop error overlay carrying the full text (including URLs
@@ -374,6 +427,26 @@ enum JobKind {
         statuses: std::collections::BTreeMap<String, ReconcileServiceStatus>,
     },
     Prune,
+}
+
+/// One-shot container lifecycle action — start / stop / restart.
+/// Routed through `App::spawn_lifecycle`; the docker-events stream
+/// drives the corresponding UI refresh, so there's no progress modal.
+#[derive(Debug, Clone, Copy)]
+enum LifecycleOp {
+    Start,
+    Stop,
+    Restart,
+}
+
+impl LifecycleOp {
+    fn label(self) -> &'static str {
+        match self {
+            Self::Start => "start",
+            Self::Stop => "stop",
+            Self::Restart => "restart",
+        }
+    }
 }
 
 /// Per-service state machine for the reconcile-all status table.
@@ -513,6 +586,7 @@ async fn run_loop(
     let mut events = EventStream::new();
     let mut fast_tick = interval(FAST_TICK);
     let mut hosts_tick = interval(HOSTS_TICK);
+    let mut resources_tick = interval(RESOURCES_TICK);
     let mut config_tick = interval(CONFIG_RELOAD_TICK);
     // Drives the "starting shell…" spinner animation. Fires only
     // matters when the shell view is up and `inner` is None; the
@@ -520,6 +594,7 @@ async fn run_loop(
     let mut shell_spin_tick = interval(Duration::from_millis(125));
     fast_tick.tick().await;
     hosts_tick.tick().await;
+    resources_tick.tick().await;
     config_tick.tick().await;
     shell_spin_tick.tick().await;
 
@@ -550,6 +625,14 @@ async fn run_loop(
                 // Re-entry to Hosts schedules a fresh refresh anyway.
                 if matches!(app.view, View::Hosts) {
                     app.schedule_hosts_refresh();
+                }
+            }
+            _ = resources_tick.tick() => {
+                // Same lazy guard as `hosts_tick`: the Resources pane's
+                // 3-way fan-out per host is the heaviest list query,
+                // so only fire while it's actually visible.
+                if matches!(app.view, View::Resources) {
+                    app.schedule_resources_refresh();
                 }
             }
             _ = config_tick.tick() => {
@@ -595,6 +678,7 @@ pub struct App {
     pub history: super::history::HistoryState,
     pub container_detail: ContainerDetailState,
     pub logs: LogsState,
+    pub resources: ResourcesState,
     pub secrets_state: super::secrets::SecretsState,
     /// `Some` while a `ContainerShell` view is active; cleared on exit.
     shell: Option<ShellState>,
@@ -622,6 +706,14 @@ pub struct App {
     /// Equivalent of `yoink up` (no `--service` filter): every service
     /// in config order across every host. `y` / Enter confirms.
     reconcile_all_target: bool,
+    /// `Some` while a resource-remove confirmation modal is open
+    /// over the Resources pane. Confirm with `y` / Enter; anything
+    /// else dismisses.
+    resource_remove_target: Option<ResourceTarget>,
+    /// `Some((tab, dangling_only))` while a resource-prune modal is
+    /// open. `dangling_only=false` is the aggressive "docker image
+    /// prune -a" form; ignored for non-image tabs.
+    resource_prune_target: Option<(ResourceTab, bool)>,
     /// `Some` while a reconcile is in flight or its progress modal
     /// is still on screen. Owns the streaming event log; cleared
     /// when the operator presses Esc after completion.
@@ -662,6 +754,11 @@ pub struct App {
     dashboard_in_flight: bool,
     container_detail_in_flight: bool,
     history_in_flight: bool,
+    resources_in_flight: bool,
+    /// Per-host docker-event ring buffer (formatted for display).
+    /// Newest entries pushed at the back. Drives the events panel
+    /// at the bottom of the `HostDetail` pane.
+    host_events: std::collections::HashMap<String, std::collections::VecDeque<String>>,
     update_tx: UnboundedSender<Update>,
     update_rx: UnboundedReceiver<Update>,
 
@@ -703,6 +800,7 @@ impl App {
             history: super::history::HistoryState::new(),
             container_detail: ContainerDetailState::new(),
             logs: LogsState::new(),
+            resources: ResourcesState::new(),
             secrets_state: super::secrets::SecretsState::new(),
             shell: None,
             show_help: false,
@@ -712,6 +810,8 @@ impl App {
             reconcile_target: None,
             prune_target: false,
             reconcile_all_target: false,
+            resource_remove_target: None,
+            resource_prune_target: None,
             job_progress: None,
             job_tx,
             job_rx,
@@ -726,6 +826,8 @@ impl App {
             dashboard_in_flight: false,
             container_detail_in_flight: false,
             history_in_flight: false,
+            resources_in_flight: false,
+            host_events: std::collections::HashMap::new(),
             update_tx,
             update_rx,
             log_tasks: Vec::new(),
@@ -1167,6 +1269,28 @@ impl App {
             return false;
         }
 
+        // Resource remove confirmation modal — same gesture as kill.
+        if self.resource_remove_target.is_some() {
+            let confirm = matches!(key.code, KeyCode::Char('y') | KeyCode::Enter);
+            let target = self.resource_remove_target.take();
+            if confirm && let Some(t) = target {
+                self.spawn_resource_remove(t);
+                self.schedule_resources_refresh();
+            }
+            return false;
+        }
+
+        // Resource prune confirmation modal.
+        if self.resource_prune_target.is_some() {
+            let confirm = matches!(key.code, KeyCode::Char('y') | KeyCode::Enter);
+            let target = self.resource_prune_target.take();
+            if confirm && let Some((kind, dangling_only)) = target {
+                self.spawn_resource_prune(kind, dangling_only);
+                self.schedule_resources_refresh();
+            }
+            return false;
+        }
+
         // Secrets remove-confirmation modal: same shape as kill.
         if self.secrets_state.confirming_remove() {
             let confirm = matches!(key.code, KeyCode::Char('y') | KeyCode::Enter);
@@ -1276,14 +1400,35 @@ impl App {
                 self.transition(View::Secrets).await;
                 return false;
             }
+            KeyCode::Char('R') if !matches!(self.view, View::Resources) => {
+                // Capital `R` enters the Resources pane from any other
+                // top-level view. While *inside* Resources, we let the
+                // per-view match below own the `R` key (lower-case is
+                // already used for refresh; the per-view handler can
+                // map capital R to other things if needed).
+                self.transition(View::Resources).await;
+                return false;
+            }
             // Tab / Shift-Tab cycle through the top-level modes
             // (k9s-friendly alternative to direct-letter access).
+            // Inside Resources we override Tab to cycle sub-tabs
+            // (Images / Volumes / Networks); that match arm runs
+            // before the global one because we early-return below.
+            KeyCode::Tab if matches!(self.view, View::Resources) => {
+                self.resources.cycle_tab_forward();
+                return false;
+            }
+            KeyCode::BackTab if matches!(self.view, View::Resources) => {
+                self.resources.cycle_tab_backward();
+                return false;
+            }
             KeyCode::Tab => {
                 let next = match self.view.top_section() {
                     0 => View::Hosts,
                     1 => View::Services,
                     2 => View::Logs,
-                    3 => View::Secrets,
+                    3 => View::Resources,
+                    4 => View::Secrets,
                     _ => View::Dashboard,
                 };
                 self.transition(next).await;
@@ -1295,7 +1440,8 @@ impl App {
                     1 => View::Dashboard,
                     2 => View::Hosts,
                     3 => View::Services,
-                    _ => View::Logs,
+                    4 => View::Logs,
+                    _ => View::Resources,
                 };
                 self.transition(prev).await;
                 return false;
@@ -1369,6 +1515,30 @@ impl App {
                         self.kill_target = Some((host, container));
                     }
                 }
+                KeyCode::Char('S') => {
+                    if let (Some(host), Some(container)) = (
+                        self.host_detail.host().cloned(),
+                        self.host_detail.selected_container(),
+                    ) {
+                        self.spawn_lifecycle(host, container, LifecycleOp::Start);
+                    }
+                }
+                KeyCode::Char('X') => {
+                    if let (Some(host), Some(container)) = (
+                        self.host_detail.host().cloned(),
+                        self.host_detail.selected_container(),
+                    ) {
+                        self.spawn_lifecycle(host, container, LifecycleOp::Stop);
+                    }
+                }
+                KeyCode::Char('R') => {
+                    if let (Some(host), Some(container)) = (
+                        self.host_detail.host().cloned(),
+                        self.host_detail.selected_container(),
+                    ) {
+                        self.spawn_lifecycle(host, container, LifecycleOp::Restart);
+                    }
+                }
                 KeyCode::Char('U') => {
                     if let Some(service) = self.host_detail.selected_service() {
                         self.open_reconcile_modal(&service);
@@ -1379,6 +1549,21 @@ impl App {
                 _ => {}
             },
             View::ContainerDetail { host, container } => match key.code {
+                KeyCode::Esc if self.container_detail.top_visible() => {
+                    self.container_detail.dismiss_top();
+                }
+                KeyCode::Char('p') => {
+                    self.schedule_top_fetch();
+                }
+                KeyCode::Char('S') => {
+                    self.spawn_lifecycle(host.clone(), container.clone(), LifecycleOp::Start);
+                }
+                KeyCode::Char('X') => {
+                    self.spawn_lifecycle(host.clone(), container.clone(), LifecycleOp::Stop);
+                }
+                KeyCode::Char('R') => {
+                    self.spawn_lifecycle(host.clone(), container.clone(), LifecycleOp::Restart);
+                }
                 KeyCode::Char('K') => {
                     self.kill_target = Some((host.clone(), container.clone()));
                 }
@@ -1622,6 +1807,28 @@ impl App {
                 KeyCode::Char('d') => self.secrets_state.begin_remove_selected(),
                 _ => {}
             },
+            View::Resources => match key.code {
+                KeyCode::Up | KeyCode::Char('k') => self.resources.select_prev(),
+                KeyCode::Down | KeyCode::Char('j') => self.resources.select_next(),
+                KeyCode::Char('i') => self.resources.set_tab(ResourceTab::Images),
+                KeyCode::Char('v') => self.resources.set_tab(ResourceTab::Volumes),
+                KeyCode::Char('n') => self.resources.set_tab(ResourceTab::Networks),
+                KeyCode::Char('d') => {
+                    if let Some(target) = self.resources.selected_target(&self.config) {
+                        self.resource_remove_target = Some(target);
+                    }
+                }
+                KeyCode::Char('P') => {
+                    self.resource_prune_target = Some((self.resources.current_tab(), true));
+                }
+                KeyCode::Char('A') if self.resources.current_tab() == ResourceTab::Images => {
+                    // Aggressive image prune ("docker image prune -a")
+                    // — only meaningful on the Images tab.
+                    self.resource_prune_target = Some((ResourceTab::Images, false));
+                }
+                KeyCode::Char('r') => self.schedule_resources_refresh(),
+                _ => {}
+            },
         }
         false
     }
@@ -1727,6 +1934,8 @@ impl App {
         self.reconcile_target = None;
         self.prune_target = false;
         self.reconcile_all_target = false;
+        self.resource_remove_target = None;
+        self.resource_prune_target = None;
         // Don't clear job_progress on transition — operator
         // may want to navigate around with the deploy still in flight.
         // It clears itself on Esc-after-finished.
@@ -1819,6 +2028,9 @@ impl App {
                 // via `ensure_loaded`. Clear any half-finished edit
                 // from a previous visit so the operator starts fresh.
                 self.secrets_state.cancel_edit();
+            }
+            View::Resources => {
+                self.schedule_resources_refresh();
             }
         }
         self.view = new_view;
@@ -1923,6 +2135,9 @@ impl App {
             View::HostDetail(_) => self.schedule_host_detail_refresh(),
             View::ContainerDetail { .. } => self.schedule_container_detail_refresh(),
             View::ContainerShell { .. } => self.shell_tick(),
+            // Resources fetches are heavier (3 list calls × N hosts);
+            // gate behind the dedicated `resources_tick` that fires
+            // less often. The fast tick is a no-op for the rest.
             _ => {}
         }
     }
@@ -1996,6 +2211,134 @@ impl App {
                 container,
                 data: Box::new(data),
             });
+        });
+    }
+
+    fn schedule_resources_refresh(&mut self) {
+        if self.resources_in_flight {
+            return;
+        }
+        self.resources_in_flight = true;
+        let ops = self.ops.clone();
+        let config = self.config.clone();
+        let tx = self.update_tx.clone();
+        tokio::spawn(async move {
+            let data = resources::fetch_owned(ops, config).await;
+            let _ = tx.send(Update::Resources(data));
+        });
+    }
+
+    /// Spawn a background `docker top` for the currently-selected
+    /// container in `ContainerDetail`. Result lands via `Update::Top`
+    /// and is pushed onto `container_detail` for modal rendering.
+    fn schedule_top_fetch(&mut self) {
+        let Some((host, container)) = self.container_detail.target().cloned() else {
+            return;
+        };
+        self.container_detail.begin_top_load();
+        let ops = self.ops.clone();
+        let tx = self.update_tx.clone();
+        let host_for_msg = host.clone();
+        let container_for_msg = container.clone();
+        tokio::spawn(async move {
+            let result = container_detail::fetch_top(ops, host, container).await;
+            let _ = tx.send(Update::Top {
+                host: host_for_msg,
+                container: container_for_msg,
+                result,
+            });
+        });
+    }
+
+    /// Send a one-off lifecycle command (start / stop / restart) for
+    /// the given container; show a toast on failure. Stays on the
+    /// event loop because docker's lifecycle endpoints are usually
+    /// fast enough not to need a progress modal — and the operator
+    /// gets immediate feedback via the docker-events stream which
+    /// repaints the dashboard within milliseconds.
+    fn spawn_lifecycle(&self, host: Host, container: String, op: LifecycleOp) {
+        let ops = self.ops.clone();
+        let tx = self.update_tx.clone();
+        tokio::spawn(async move {
+            let res = match op {
+                LifecycleOp::Start => ops.start_container(&host, &container).await,
+                LifecycleOp::Stop => {
+                    ops.stop_container(&host, &container, Duration::from_secs(10))
+                        .await
+                }
+                LifecycleOp::Restart => {
+                    ops.restart_container(&host, &container, Duration::from_secs(10))
+                        .await
+                }
+            };
+            if let Err(e) = res {
+                let _ = tx.send(Update::Toast(format!(
+                    "✗ {} {}/{container}: {e}",
+                    op.label(),
+                    host.address
+                )));
+            } else {
+                let _ = tx.send(Update::Toast(format!("✓ {} {}", op.label(), container)));
+            }
+        });
+    }
+
+    /// Background remove-resource. Same toast UX as `spawn_lifecycle`.
+    fn spawn_resource_remove(&self, target: ResourceTarget) {
+        let ops = self.ops.clone();
+        let tx = self.update_tx.clone();
+        let label = target.label.clone();
+        tokio::spawn(async move {
+            let res = match target.kind {
+                ResourceTab::Images => ops.remove_image(&target.host, &target.id, false).await,
+                ResourceTab::Volumes => ops.remove_volume(&target.host, &target.id, false).await,
+                ResourceTab::Networks => ops.remove_network(&target.host, &target.id).await,
+            };
+            match res {
+                Ok(()) => {
+                    let _ = tx.send(Update::Toast(format!("✓ removed {label}")));
+                }
+                Err(e) => {
+                    let _ = tx.send(Update::Toast(format!("✗ remove {label}: {e}")));
+                }
+            }
+        });
+    }
+
+    /// Background prune for whichever resource tab is active. Each
+    /// branch maps to the equivalent `docker {kind} prune` call
+    /// fanned out across every host.
+    fn spawn_resource_prune(&self, kind: ResourceTab, dangling_only: bool) {
+        let ops = self.ops.clone();
+        let hosts: Vec<Host> = self.config.hosts.iter().map(Host::from).collect();
+        let tx = self.update_tx.clone();
+        tokio::spawn(async move {
+            let mut summaries: Vec<String> = Vec::new();
+            for host in hosts {
+                let res = match kind {
+                    ResourceTab::Images => ops.prune_images(&host, dangling_only).await,
+                    ResourceTab::Volumes => ops.prune_volumes(&host).await,
+                    ResourceTab::Networks => ops.prune_networks(&host).await,
+                };
+                match res {
+                    Ok(report) => summaries.push(format!(
+                        "{}: -{} ({} items)",
+                        host.address,
+                        crate::output::format_bytes(report.space_reclaimed_bytes),
+                        report.reclaimed.len()
+                    )),
+                    Err(e) => summaries.push(format!("{}: failed: {e}", host.address)),
+                }
+            }
+            let kind_label = match kind {
+                ResourceTab::Images => "image prune",
+                ResourceTab::Volumes => "volume prune",
+                ResourceTab::Networks => "network prune",
+            };
+            let _ = tx.send(Update::Toast(format!(
+                "✓ {kind_label} · {}",
+                summaries.join(" · ")
+            )));
         });
     }
 
@@ -2073,6 +2416,27 @@ impl App {
             }
             Update::Event { host, event } => self.on_docker_event(&host, &event),
             Update::Toast(msg) => self.push_toast(msg),
+            Update::Resources(data) => {
+                self.resources.apply(data);
+                self.resources_in_flight = false;
+            }
+            Update::Top {
+                host,
+                container,
+                result,
+            } => match result {
+                Ok(table) => {
+                    if self.container_detail.target().map(|(h, c)| (h, c.as_str()))
+                        == Some((&host, container.as_str()))
+                    {
+                        self.container_detail.set_top(table);
+                    }
+                }
+                Err(e) => {
+                    self.container_detail.dismiss_top();
+                    self.push_toast(format!("✗ docker top {container}: {e}"));
+                }
+            },
         }
     }
 
@@ -2109,6 +2473,25 @@ impl App {
         // Surface the event as a toast in the breadcrumb header.
         let container = event.container.as_deref().unwrap_or("?");
         let line = format!("{} · {} {}", host.address, container, event.action);
+        // Append to the per-host ring so HostDetail's events panel
+        // can show recent activity. Format includes a relative
+        // timestamp ("now") that ages on each render — kept simple
+        // for now (just the action), but the entry is timestamped
+        // below for future "5m ago" rendering.
+        let ring = self.host_events.entry(host.address.clone()).or_default();
+        let now_secs = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map_or(0, |d| d.as_secs());
+        let stamped = format!(
+            "{}  {} {}",
+            crate::output::format_relative_time(i64::try_from(now_secs).ok()),
+            container,
+            event.action
+        );
+        ring.push_back(stamped);
+        while ring.len() > EVENT_HISTORY_PER_HOST {
+            ring.pop_front();
+        }
         self.toasts
             .push_back((std::time::Instant::now() + TOAST_TTL, line));
         while self.toasts.len() > TOAST_CAP {
@@ -2159,10 +2542,7 @@ impl App {
             Ok(rx) => rx,
             Err(e) => {
                 warn!(host = %host.address, container = %container, error = %e, "open_log_stream failed");
-                self.push_toast(format!(
-                    "✗ logs {}/{container}: {e}",
-                    host.address
-                ));
+                self.push_toast(format!("✗ logs {}/{container}: {e}", host.address));
                 return;
             }
         };
@@ -2202,7 +2582,14 @@ impl App {
             },
             |(_, msg)| format!("● {msg}"),
         );
-        let tabs = ["Dashboard", "Hosts", "Services", "Logs", "Secrets"];
+        let tabs = [
+            "Dashboard",
+            "Hosts",
+            "Services",
+            "Logs",
+            "Resources",
+            "Secrets",
+        ];
         let selected_tab = Some(self.view.top_section());
         super::ui::render_header(frame, header_area, &tabs, selected_tab, &crumbs, &right);
 
@@ -2213,9 +2600,19 @@ impl App {
                     .render(frame, pane_area, &self.config, secrets.as_deref());
             }
             View::Hosts => self.hosts.render(frame, pane_area, &self.config),
-            View::HostDetail(_) => {
-                self.host_detail
-                    .render(frame, pane_area, &self.config, secrets.as_deref());
+            View::HostDetail(host) => {
+                let events: Vec<String> = self
+                    .host_events
+                    .get(&host.address)
+                    .map(|q| q.iter().cloned().collect())
+                    .unwrap_or_default();
+                self.host_detail.render(
+                    frame,
+                    pane_area,
+                    &self.config,
+                    secrets.as_deref(),
+                    &events,
+                );
             }
             View::ContainerDetail { .. } => {
                 // Split: top 2/3 = inspect data, bottom 1/3 = live log tail.
@@ -2255,6 +2652,9 @@ impl App {
             View::Secrets => {
                 self.secrets_state.ensure_loaded(&self.config, false);
                 self.secrets_state.render(frame, pane_area);
+            }
+            View::Resources => {
+                self.resources.render(frame, pane_area, &self.config);
             }
         }
 
@@ -2325,6 +2725,67 @@ impl App {
                 "[any]         cancel",
             ];
             super::ui::render_modal(frame, "reconcile ALL services?", &lines);
+        }
+        if let Some(target) = &self.resource_remove_target {
+            let kind = match target.kind {
+                ResourceTab::Images => "image",
+                ResourceTab::Volumes => "volume",
+                ResourceTab::Networks => "network",
+            };
+            let host_line = format!("host:   {}", target.host.address);
+            let target_line = format!("target: {}", target.label);
+            let title = format!("remove {kind}?");
+            let lines = vec![
+                "About to remove the selected resource.",
+                "",
+                host_line.as_str(),
+                target_line.as_str(),
+                "",
+                "Container references that point at the resource will",
+                "block removal — the daemon returns an error and the",
+                "row is left in place. Force removal isn't wired up;",
+                "kill referencing containers first.",
+                "",
+                "[y] / Enter   confirm",
+                "[any]         cancel",
+            ];
+            super::ui::render_modal(frame, &title, &lines);
+        }
+        if let Some((kind, dangling_only)) = &self.resource_prune_target {
+            let host_count = format!("hosts:  {}", self.config.hosts.len());
+            let title = match kind {
+                ResourceTab::Images => {
+                    if *dangling_only {
+                        "prune dangling images?"
+                    } else {
+                        "prune ALL unused images?"
+                    }
+                }
+                ResourceTab::Volumes => "prune unused volumes?",
+                ResourceTab::Networks => "prune unused networks?",
+            };
+            let body_line = match kind {
+                ResourceTab::Images => {
+                    if *dangling_only {
+                        "Removes <none>:<none> layers (no live tag) on every host."
+                    } else {
+                        "Removes every image with NO live container reference."
+                    }
+                }
+                ResourceTab::Volumes => "Removes named volumes with no attached container.",
+                ResourceTab::Networks => {
+                    "Removes user-defined networks with no attached container."
+                }
+            };
+            let lines = vec![
+                body_line,
+                "",
+                host_count.as_str(),
+                "",
+                "[y] / Enter   confirm",
+                "[any]         cancel",
+            ];
+            super::ui::render_modal(frame, title, &lines);
         }
         if self.prune_target {
             let host_count = format!("hosts:    {}", self.config.hosts.len());

--- a/yoink/src/tui/app.rs
+++ b/yoink/src/tui/app.rs
@@ -2734,8 +2734,13 @@ impl App {
         let secrets = self.secrets.try_read().ok().and_then(|g| g.clone());
         match &self.view {
             View::Dashboard => {
-                self.dashboard
-                    .render(frame, pane_area, &self.config, secrets.as_deref());
+                self.dashboard.render(
+                    frame,
+                    pane_area,
+                    &self.config,
+                    secrets.as_deref(),
+                    &self.container_history,
+                );
             }
             View::Hosts => self.hosts.render(frame, pane_area, &self.config),
             View::HostDetail(host) => {
@@ -2750,6 +2755,7 @@ impl App {
                     &self.config,
                     secrets.as_deref(),
                     &events,
+                    &self.container_history,
                 );
             }
             View::ContainerDetail { host, container } => {

--- a/yoink/src/tui/container_detail.rs
+++ b/yoink/src/tui/container_detail.rs
@@ -126,8 +126,18 @@ impl StatsHistory {
         }
     }
 
+    #[allow(dead_code)] // Useful for tests + future "reset on disconnect" hooks.
     pub fn clear(&mut self) {
         *self = Self::default();
+    }
+
+    /// True when the CPU samples ring is empty — used by the App-level
+    /// GC sweep to drop history entries whose newest sample has aged
+    /// out of the window (i.e. the container hasn't been seen by the
+    /// poller for at least `HISTORY_WINDOW_SECS`).
+    #[must_use]
+    pub fn cpu_pct_is_empty(&self) -> bool {
+        self.cpu_pct.is_empty()
     }
 
     fn x_window(&self) -> (f64, f64) {
@@ -163,7 +173,6 @@ pub struct ContainerDetailState {
     stats: Option<ContainerStats>,
     last_error: Option<String>,
     loaded: bool,
-    history: StatsHistory,
     /// `Some` when the operator pressed `p` and the docker-top result
     /// has landed; rendered as a modal overlay until dismissed with Esc.
     top: Option<ProcessTable>,
@@ -188,7 +197,6 @@ impl ContainerDetailState {
             self.inspect = None;
             self.stats = None;
             self.loaded = false;
-            self.history.clear();
             self.top = None;
             self.top_loading = false;
         }
@@ -223,18 +231,18 @@ impl ContainerDetailState {
         // Flip loaded unconditionally so the pane renders the error
         // path (which already exists at the top of `render`) instead
         // of looping on `(loading…)`. Last-known good inspect/stats
-        // stay around to ride out transient blips.
+        // stay around to ride out transient blips. Stats history is
+        // owned by the App-level shared store now (see
+        // `App::container_history`); the per-render fetch only
+        // refreshes the inspect block + the latest gauge sample.
         self.loaded = true;
         if self.last_error.is_none() {
             self.inspect = data.inspect;
-            if let Some(stats) = data.stats.as_ref() {
-                self.history.push(stats);
-            }
             self.stats = data.stats;
         }
     }
 
-    pub fn render(&mut self, frame: &mut Frame<'_>, area: Rect) {
+    pub fn render(&mut self, frame: &mut Frame<'_>, area: Rect, history: Option<&StatsHistory>) {
         if let Some(err) = &self.last_error {
             let block = Block::default().borders(Borders::ALL).title(" container ");
             frame.render_widget(
@@ -273,7 +281,7 @@ impl ContainerDetailState {
             ])
             .split(area);
         Self::render_card(frame, chunks[0], inspect, self.stats.as_ref());
-        self.render_history(frame, chunks[1]);
+        Self::render_history(frame, chunks[1], history);
 
         let cols = Layout::default()
             .direction(Direction::Horizontal)
@@ -299,7 +307,7 @@ impl ContainerDetailState {
         clippy::cast_possible_truncation,
         clippy::too_many_lines
     )]
-    fn render_history(&self, frame: &mut Frame<'_>, area: Rect) {
+    fn render_history(frame: &mut Frame<'_>, area: Rect, history: Option<&StatsHistory>) {
         let cols = Layout::default()
             .direction(Direction::Horizontal)
             .constraints([
@@ -309,9 +317,25 @@ impl ContainerDetailState {
             ])
             .split(area);
 
-        let (xmin, xmax) = self.history.x_window();
-        let cpu_data: Vec<(f64, f64)> = self.history.cpu_pct.iter().copied().collect();
-        let mem_data: Vec<(f64, f64)> = self.history.mem_pct.iter().copied().collect();
+        let Some(history) = history else {
+            // Empty store — render three "(collecting…)" placeholders.
+            for (i, title) in ["CPU %", "Mem %", "net rx / tx"].iter().enumerate() {
+                let block = Block::default()
+                    .borders(Borders::ALL)
+                    .title(format!(" {title} (5 min) "));
+                frame.render_widget(
+                    Paragraph::new("(collecting…)")
+                        .style(Style::default().fg(Color::DarkGray))
+                        .block(block),
+                    cols[i],
+                );
+            }
+            return;
+        };
+
+        let (xmin, xmax) = history.x_window();
+        let cpu_data: Vec<(f64, f64)> = history.cpu_pct.iter().copied().collect();
+        let mem_data: Vec<(f64, f64)> = history.mem_pct.iter().copied().collect();
 
         // ── Panel 1: CPU% over time ───────────────────────────────────
         let cpu_now = cpu_data.last().map(|(_, v)| *v);
@@ -360,7 +384,7 @@ impl ContainerDetailState {
 
         // ── Panel 2: Mem (own y-axis, % when capped, MB when uncapped) ─
         let mem_now = mem_data.last().map(|(_, v)| *v);
-        let mem_unit = if self.history.mem_uncapped { "MB" } else { "%" };
+        let mem_unit = if history.mem_uncapped { "MB" } else { "%" };
         let mem_title = match mem_now {
             Some(m) => format!(" Mem {m:>5.1}{mem_unit} (5 min) "),
             None => format!(" Mem {mem_unit} (5 min) "),
@@ -374,7 +398,7 @@ impl ContainerDetailState {
                 cols[1],
             );
         } else {
-            let mem_max = if self.history.mem_uncapped {
+            let mem_max = if history.mem_uncapped {
                 mem_data
                     .iter()
                     .map(|(_, v)| *v)
@@ -385,7 +409,7 @@ impl ContainerDetailState {
             };
             let datasets = vec![
                 Dataset::default()
-                    .name(if self.history.mem_uncapped { "mem MB" } else { "mem%" })
+                    .name(if history.mem_uncapped { "mem MB" } else { "mem%" })
                     .marker(Marker::Braille)
                     .graph_type(GraphType::Line)
                     .style(Style::default().fg(Color::Magenta))
@@ -403,31 +427,31 @@ impl ContainerDetailState {
                     Axis::default()
                         .style(Style::default().fg(Color::DarkGray))
                         .bounds([0.0, mem_max])
-                        .labels(percent_axis_labels(mem_max, self.history.mem_uncapped)),
+                        .labels(percent_axis_labels(mem_max, history.mem_uncapped)),
                 );
             frame.render_widget(chart, cols[1]);
         }
 
         // ── Panel 3: network rx/tx rate, btop-style mirrored ──────────
-        // rx (incoming) plots above the zero line; tx (outgoing) plots
-        // mirrored below. The two series no longer overlap — at a
-        // glance you see "what's coming in" vs "what's going out"
-        // without having to disambiguate two same-axis lines.
-        let rx_rates = StatsHistory::rate_series(&self.history.net_rx);
-        let tx_rates_pos = StatsHistory::rate_series(&self.history.net_tx);
-        // Mirror tx below the zero line by negating each y value. The
+        // tx (outgoing) plots above the zero line; rx (incoming) plots
+        // mirrored below. Outgoing-on-top reads naturally as "this
+        // container is pushing X out to the world", and the two series
+        // can no longer overlap.
+        let rx_rates_pos = StatsHistory::rate_series(&history.net_rx);
+        let tx_rates = StatsHistory::rate_series(&history.net_tx);
+        // Mirror rx below the zero line by negating each y value. The
         // rendered line still tracks the same magnitude — just on the
         // negative side of the axis.
-        let tx_rates: Vec<(f64, f64)> = tx_rates_pos.iter().map(|(t, v)| (*t, -*v)).collect();
-        let rx_now = rx_rates.last().map_or(0.0, |(_, v)| *v);
-        let tx_now = tx_rates_pos.last().map_or(0.0, |(_, v)| *v);
+        let rx_rates: Vec<(f64, f64)> = rx_rates_pos.iter().map(|(t, v)| (*t, -*v)).collect();
+        let rx_now = rx_rates_pos.last().map_or(0.0, |(_, v)| *v);
+        let tx_now = tx_rates.last().map_or(0.0, |(_, v)| *v);
         let net_title = if rx_rates.is_empty() && tx_rates.is_empty() {
             " net rx / tx (5 min) ".to_string()
         } else {
             format!(
-                " net ↓{} ↑{} (5 min) ",
-                format_rate(rx_now),
-                format_rate(tx_now)
+                " net ↑{} ↓{} (5 min) ",
+                format_rate(tx_now),
+                format_rate(rx_now)
             )
         };
         let net_block = Block::default().borders(Borders::ALL).title(net_title);
@@ -439,11 +463,11 @@ impl ContainerDetailState {
                 cols[2],
             );
         } else {
-            let rx_peak = rx_rates
+            let rx_peak = rx_rates_pos
                 .iter()
                 .map(|(_, v)| *v)
                 .fold(0.0_f64, f64::max);
-            let tx_peak = tx_rates_pos
+            let tx_peak = tx_rates
                 .iter()
                 .map(|(_, v)| *v)
                 .fold(0.0_f64, f64::max);
@@ -454,17 +478,17 @@ impl ContainerDetailState {
             let max_rate = rx_peak.max(tx_peak).max(1.0);
             let datasets = vec![
                 Dataset::default()
-                    .name("↓ rx")
-                    .marker(Marker::Braille)
-                    .graph_type(GraphType::Line)
-                    .style(Style::default().fg(Color::Green))
-                    .data(&rx_rates),
-                Dataset::default()
                     .name("↑ tx")
                     .marker(Marker::Braille)
                     .graph_type(GraphType::Line)
                     .style(Style::default().fg(Color::Yellow))
                     .data(&tx_rates),
+                Dataset::default()
+                    .name("↓ rx")
+                    .marker(Marker::Braille)
+                    .graph_type(GraphType::Line)
+                    .style(Style::default().fg(Color::Green))
+                    .data(&rx_rates),
             ];
             let chart = Chart::new(datasets)
                 .block(net_block)
@@ -894,18 +918,19 @@ fn percent_axis_labels(max: f64, uncapped: bool) -> Vec<Span<'static>> {
     }
 }
 
-/// Labels for the mirrored rx/tx panel: bottom is `↑ tx_max`, middle
-/// is `0`, top is `↓ rx_max`. Both magnitudes are positive (the y
-/// values are signed but the operator reads the magnitude with the
-/// arrow indicating direction).
+/// Labels for the mirrored rx/tx panel: bottom is `↓ rx_max` (green —
+/// incoming, plotted below zero), middle is `0`, top is `↑ tx_max`
+/// (yellow — outgoing, plotted above zero). Both magnitudes are
+/// positive (the y values are signed but the operator reads the
+/// magnitude with the arrow indicating direction).
 fn mirrored_rate_labels(max: f64) -> Vec<Span<'static>> {
     let dim = Style::default().fg(Color::DarkGray);
     let up = Style::default().fg(Color::Yellow);
     let down = Style::default().fg(Color::Green);
     vec![
-        Span::styled(format!("↑{}", format_rate(max)), up),
-        Span::styled("0".to_string(), dim),
         Span::styled(format!("↓{}", format_rate(max)), down),
+        Span::styled("0".to_string(), dim),
+        Span::styled(format!("↑{}", format_rate(max)), up),
     ]
 }
 

--- a/yoink/src/tui/container_detail.rs
+++ b/yoink/src/tui/container_detail.rs
@@ -7,18 +7,35 @@
 //! inside: `Enter`/`l` opens the dedicated logs view, `!` shells in,
 //! `D` spawns the debug sidecar, `Esc` returns to host detail.
 
+use std::collections::VecDeque;
 use std::sync::Arc;
+use std::time::Instant;
 
 use ratatui::Frame;
 use ratatui::layout::{Constraint, Direction, Layout, Rect};
 use ratatui::style::{Color, Modifier, Style};
+use ratatui::symbols::Marker;
 use ratatui::text::{Line, Span};
-use ratatui::widgets::{Block, Borders, Cell, Paragraph, Row, Table, Wrap};
+use ratatui::widgets::{
+    Axis, Block, Borders, Cell, Chart, Dataset, GraphType, Paragraph, Row, Table, Wrap,
+};
 
-use crate::docker_ops::{ContainerDetail, ContainerStats, DockerOps, Host};
+use crate::docker_ops::{ContainerDetail, ContainerStats, DockerOps, Host, ProcessTable};
 use crate::output::{format_bytes, format_relative_time};
 
 use super::ui::{bold, gauge_color, health_style, inline_gauge, kv, kv_styled, state_style};
+
+/// Total wall-clock window the history charts cover. Picked to be long
+/// enough that an operator can correlate "I deployed X" with "memory
+/// climbed for 4 minutes" without having to scroll, but short enough
+/// that the underlying ring buffer stays cheap (≈150 samples at the 2s
+/// fast-tick).
+const HISTORY_WINDOW_SECS: f64 = 300.0;
+/// Cap on samples retained in `StatsHistory` — generous overhead for
+/// the case where the operator's terminal stays open longer than the
+/// fast tick can keep up. At ~1 sample / second this is ~10 minutes
+/// worth of headroom; older points are dropped.
+const HISTORY_CAP: usize = 600;
 
 /// Substrings that mark an env var as secret-ish — values are
 /// rendered as `<redacted>` so an over-the-shoulder operator can't
@@ -33,6 +50,112 @@ const REDACT_HINTS: &[&str] = &[
     "DSN",
 ];
 
+/// Bounded ring of `(elapsed_seconds, value)` pairs covering at most
+/// [`HISTORY_WINDOW_SECS`]. `started` anchors elapsed-time so the chart
+/// keeps a stable x-axis as samples slide off.
+#[derive(Default)]
+pub struct StatsHistory {
+    started: Option<Instant>,
+    cpu_pct: VecDeque<(f64, f64)>,
+    /// Memory utilization as a 0..=100 percentage when a memory cap
+    /// is set; absolute MB when uncapped (chart auto-scales the y-axis
+    /// in that case).
+    mem_pct: VecDeque<(f64, f64)>,
+    /// Cumulative bytes — the chart renderer diffs successive samples
+    /// to derive a per-second rate.
+    net_rx: VecDeque<(f64, f64)>,
+    net_tx: VecDeque<(f64, f64)>,
+    /// True when memory is uncapped on the container — the y-axis on
+    /// the mem chart switches to "MB" labelling instead of "0–100%".
+    mem_uncapped: bool,
+    /// Last absolute mem bytes (for the uncapped case so the y-axis
+    /// max can grow).
+    mem_max_bytes: i64,
+}
+
+impl StatsHistory {
+    fn now_elapsed(&mut self) -> f64 {
+        let started = self.started.get_or_insert_with(Instant::now);
+        started.elapsed().as_secs_f64()
+    }
+
+    /// Record a fresh sample. Drops points that fall outside the
+    /// history window so the chart keeps a fixed time horizon.
+    pub fn push(&mut self, stats: &ContainerStats) {
+        let t = self.now_elapsed();
+        self.cpu_pct.push_back((t, stats.cpu_pct.max(0.0)));
+
+        match stats.mem_limit {
+            Some(limit) if limit > 0 => {
+                self.mem_uncapped = false;
+                #[allow(clippy::cast_precision_loss)]
+                let pct = (stats.mem_used as f64 / limit as f64) * 100.0;
+                self.mem_pct.push_back((t, pct.clamp(0.0, 100.0)));
+            }
+            _ => {
+                self.mem_uncapped = true;
+                #[allow(clippy::cast_precision_loss)]
+                let mb = (stats.mem_used as f64) / 1_048_576.0;
+                self.mem_pct.push_back((t, mb.max(0.0)));
+                if stats.mem_used > self.mem_max_bytes {
+                    self.mem_max_bytes = stats.mem_used;
+                }
+            }
+        }
+
+        #[allow(clippy::cast_precision_loss)]
+        {
+            self.net_rx.push_back((t, stats.net_rx_bytes.max(0) as f64));
+            self.net_tx.push_back((t, stats.net_tx_bytes.max(0) as f64));
+        }
+
+        // Trim by both time-window and absolute cap.
+        let cutoff = t - HISTORY_WINDOW_SECS;
+        for q in [
+            &mut self.cpu_pct,
+            &mut self.mem_pct,
+            &mut self.net_rx,
+            &mut self.net_tx,
+        ] {
+            while q.front().is_some_and(|(s, _)| *s < cutoff) {
+                q.pop_front();
+            }
+            while q.len() > HISTORY_CAP {
+                q.pop_front();
+            }
+        }
+    }
+
+    pub fn clear(&mut self) {
+        *self = Self::default();
+    }
+
+    fn x_window(&self) -> (f64, f64) {
+        let now = self.started.map_or(0.0, |s| s.elapsed().as_secs_f64());
+        let lo = (now - HISTORY_WINDOW_SECS).max(0.0);
+        (lo, now.max(HISTORY_WINDOW_SECS))
+    }
+
+    /// Convert cumulative-bytes samples into per-second rates suitable
+    /// for plotting. The first sample produces no rate; pairs of
+    /// successive samples produce `(t_b, (b - a) / (t_b - t_a))`.
+    fn rate_series(samples: &VecDeque<(f64, f64)>) -> Vec<(f64, f64)> {
+        let mut out = Vec::with_capacity(samples.len());
+        let mut prev: Option<&(f64, f64)> = None;
+        for cur in samples {
+            if let Some(p) = prev {
+                let dt = cur.0 - p.0;
+                if dt > 0.0 {
+                    let rate = ((cur.1 - p.1) / dt).max(0.0);
+                    out.push((cur.0, rate));
+                }
+            }
+            prev = Some(cur);
+        }
+        out
+    }
+}
+
 #[derive(Default)]
 pub struct ContainerDetailState {
     target: Option<(Host, String)>,
@@ -40,6 +163,13 @@ pub struct ContainerDetailState {
     stats: Option<ContainerStats>,
     last_error: Option<String>,
     loaded: bool,
+    history: StatsHistory,
+    /// `Some` when the operator pressed `p` and the docker-top result
+    /// has landed; rendered as a modal overlay until dismissed with Esc.
+    top: Option<ProcessTable>,
+    /// `true` once the user has requested processes — drives the
+    /// "(loading…)" modal state until the result lands.
+    top_loading: bool,
 }
 
 pub struct ContainerDetailRefresh {
@@ -58,8 +188,30 @@ impl ContainerDetailState {
             self.inspect = None;
             self.stats = None;
             self.loaded = false;
+            self.history.clear();
+            self.top = None;
+            self.top_loading = false;
         }
         self.target = Some((host, container));
+    }
+
+    pub fn begin_top_load(&mut self) {
+        self.top_loading = true;
+    }
+
+    pub fn set_top(&mut self, table: ProcessTable) {
+        self.top_loading = false;
+        self.top = Some(table);
+    }
+
+    pub fn dismiss_top(&mut self) {
+        self.top = None;
+        self.top_loading = false;
+    }
+
+    /// True when the top modal is on screen (renderer adds the overlay).
+    pub fn top_visible(&self) -> bool {
+        self.top_loading || self.top.is_some()
     }
 
     pub fn target(&self) -> Option<&(Host, String)> {
@@ -75,6 +227,9 @@ impl ContainerDetailState {
         self.loaded = true;
         if self.last_error.is_none() {
             self.inspect = data.inspect;
+            if let Some(stats) = data.stats.as_ref() {
+                self.history.push(stats);
+            }
             self.stats = data.stats;
         }
     }
@@ -106,20 +261,247 @@ impl ContainerDetailState {
             return;
         };
 
-        // Layout: header card (8 rows) · two-column data (rest split
-        // horizontally between env+labels and ports+mounts+networks).
+        // Layout: header card · 5-min stats history strip · two-column
+        // data block (env+labels on the right, ports/mounts/networks/
+        // security on the left).
         let chunks = Layout::default()
             .direction(Direction::Vertical)
-            .constraints([Constraint::Length(8), Constraint::Min(0)])
+            .constraints([
+                Constraint::Length(8),
+                Constraint::Length(10),
+                Constraint::Min(0),
+            ])
             .split(area);
         Self::render_card(frame, chunks[0], inspect, self.stats.as_ref());
+        self.render_history(frame, chunks[1]);
 
         let cols = Layout::default()
             .direction(Direction::Horizontal)
             .constraints([Constraint::Percentage(50), Constraint::Percentage(50)])
-            .split(chunks[1]);
+            .split(chunks[2]);
         Self::render_runtime(frame, cols[0], inspect);
         Self::render_env_labels(frame, cols[1], inspect);
+
+        if self.top_visible() {
+            self.render_top_modal(frame);
+        }
+    }
+
+    /// Side-by-side line charts for the rolling 5-minute window. Left:
+    /// CPU% (cyan) + Mem% (magenta). Right: network rx (green) + tx
+    /// (yellow), bytes-per-second derived from successive samples.
+    /// Both panels render an axis label legend; empty data falls back
+    /// to a "(collecting…)" centred line so the panel doesn't look broken
+    /// in the first 2-3 seconds before the first stats sample lands.
+    #[allow(
+        clippy::cast_precision_loss,
+        clippy::cast_possible_truncation,
+        clippy::too_many_lines
+    )]
+    fn render_history(&self, frame: &mut Frame<'_>, area: Rect) {
+        let cols = Layout::default()
+            .direction(Direction::Horizontal)
+            .constraints([Constraint::Percentage(50), Constraint::Percentage(50)])
+            .split(area);
+
+        // ── Left panel: CPU% + Mem% over time ─────────────────────────
+        let (xmin, xmax) = self.history.x_window();
+        let cpu_data: Vec<(f64, f64)> = self.history.cpu_pct.iter().copied().collect();
+        let mem_data: Vec<(f64, f64)> = self.history.mem_pct.iter().copied().collect();
+
+        let left_block = Block::default()
+            .borders(Borders::ALL)
+            .title(" CPU % · Mem % (5 min) ");
+
+        if cpu_data.is_empty() {
+            frame.render_widget(
+                Paragraph::new("(collecting samples…)")
+                    .style(Style::default().fg(Color::DarkGray))
+                    .block(left_block),
+                cols[0],
+            );
+        } else {
+            let cpu_max = cpu_data
+                .iter()
+                .map(|(_, v)| *v)
+                .fold(0.0_f64, f64::max)
+                .max(100.0);
+            let mem_max = if self.history.mem_uncapped {
+                let m = mem_data.iter().map(|(_, v)| *v).fold(0.0_f64, f64::max);
+                m.max(1.0)
+            } else {
+                100.0
+            };
+            // Both metrics share a y-axis scaled to the larger of the
+            // two — keeping them in one panel saves vertical real estate
+            // and makes "memory leaked while CPU was idle" patterns
+            // jump out at a glance.
+            let y_max = cpu_max.max(mem_max);
+            let datasets = vec![
+                Dataset::default()
+                    .name("cpu%")
+                    .marker(Marker::Braille)
+                    .graph_type(GraphType::Line)
+                    .style(Style::default().fg(Color::Cyan))
+                    .data(&cpu_data),
+                Dataset::default()
+                    .name(if self.history.mem_uncapped {
+                        "mem MB"
+                    } else {
+                        "mem%"
+                    })
+                    .marker(Marker::Braille)
+                    .graph_type(GraphType::Line)
+                    .style(Style::default().fg(Color::Magenta))
+                    .data(&mem_data),
+            ];
+            let chart = Chart::new(datasets)
+                .block(left_block)
+                .x_axis(
+                    Axis::default()
+                        .style(Style::default().fg(Color::DarkGray))
+                        .bounds([xmin, xmax])
+                        .labels(time_axis_labels(xmin, xmax)),
+                )
+                .y_axis(
+                    Axis::default()
+                        .style(Style::default().fg(Color::DarkGray))
+                        .bounds([0.0, y_max])
+                        .labels(percent_axis_labels(y_max, self.history.mem_uncapped)),
+                );
+            frame.render_widget(chart, cols[0]);
+        }
+
+        // ── Right panel: network rx/tx rate ───────────────────────────
+        let rx_rates = StatsHistory::rate_series(&self.history.net_rx);
+        let tx_rates = StatsHistory::rate_series(&self.history.net_tx);
+        let right_block = Block::default()
+            .borders(Borders::ALL)
+            .title(" net rx / tx (5 min, B/s) ");
+
+        if rx_rates.is_empty() && tx_rates.is_empty() {
+            frame.render_widget(
+                Paragraph::new("(collecting samples…)")
+                    .style(Style::default().fg(Color::DarkGray))
+                    .block(right_block),
+                cols[1],
+            );
+        } else {
+            let max_rate = rx_rates
+                .iter()
+                .chain(tx_rates.iter())
+                .map(|(_, v)| *v)
+                .fold(0.0_f64, f64::max)
+                .max(1.0);
+            let datasets = vec![
+                Dataset::default()
+                    .name("rx")
+                    .marker(Marker::Braille)
+                    .graph_type(GraphType::Line)
+                    .style(Style::default().fg(Color::Green))
+                    .data(&rx_rates),
+                Dataset::default()
+                    .name("tx")
+                    .marker(Marker::Braille)
+                    .graph_type(GraphType::Line)
+                    .style(Style::default().fg(Color::Yellow))
+                    .data(&tx_rates),
+            ];
+            let chart = Chart::new(datasets)
+                .block(right_block)
+                .x_axis(
+                    Axis::default()
+                        .style(Style::default().fg(Color::DarkGray))
+                        .bounds([xmin, xmax])
+                        .labels(time_axis_labels(xmin, xmax)),
+                )
+                .y_axis(
+                    Axis::default()
+                        .style(Style::default().fg(Color::DarkGray))
+                        .bounds([0.0, max_rate])
+                        .labels(rate_axis_labels(max_rate)),
+                );
+            frame.render_widget(chart, cols[1]);
+        }
+    }
+
+    /// Centre-modal overlay listing `docker top` rows. Same dimensions
+    /// as the help/error modals so the visual language stays consistent.
+    fn render_top_modal(&self, frame: &mut Frame<'_>) {
+        use ratatui::widgets::Clear;
+        let area = frame.area();
+        let modal_width = (area.width.saturating_sub(4)).clamp(60, 140);
+        let modal_height = (area.height.saturating_sub(4)).clamp(8, 30);
+        let x = (area.width.saturating_sub(modal_width)) / 2;
+        let y = (area.height.saturating_sub(modal_height)) / 2;
+        let modal_area = Rect {
+            x,
+            y,
+            width: modal_width,
+            height: modal_height,
+        };
+        let block = Block::default()
+            .borders(Borders::ALL)
+            .style(Style::default().fg(Color::Cyan))
+            .title(" processes (docker top — esc to close) ");
+        frame.render_widget(Clear, modal_area);
+
+        if self.top_loading && self.top.is_none() {
+            let body = Paragraph::new("(loading…)")
+                .style(Style::default().fg(Color::DarkGray))
+                .block(block);
+            frame.render_widget(body, modal_area);
+            return;
+        }
+
+        let Some(table) = self.top.as_ref() else {
+            return;
+        };
+        if table.processes.is_empty() {
+            let body = Paragraph::new("(no processes — container exited?)")
+                .style(Style::default().fg(Color::DarkGray))
+                .block(block);
+            frame.render_widget(body, modal_area);
+            return;
+        }
+        // Compute per-column widths from the longest cell in each column
+        // (titles + rows). Cap each column to 24 so a single huge `CMD`
+        // doesn't crowd everything else off-screen.
+        let n_cols = table
+            .titles
+            .len()
+            .max(table.processes.iter().map(Vec::len).max().unwrap_or(0));
+        let mut widths_chars: Vec<usize> = vec![0; n_cols];
+        for (i, t) in table.titles.iter().enumerate() {
+            if let Some(w) = widths_chars.get_mut(i) {
+                *w = (*w).max(t.chars().count());
+            }
+        }
+        for row in &table.processes {
+            for (i, cell) in row.iter().enumerate() {
+                if let Some(w) = widths_chars.get_mut(i) {
+                    *w = (*w).max(cell.chars().count().min(48));
+                }
+            }
+        }
+        let widths: Vec<Constraint> = widths_chars
+            .iter()
+            .map(|w| Constraint::Length(u16::try_from(*w + 2).unwrap_or(u16::MAX)))
+            .collect();
+        let header = Row::new(
+            table
+                .titles
+                .iter()
+                .map(|t| Cell::from(t.clone()).style(bold()))
+                .collect::<Vec<_>>(),
+        );
+        let rows: Vec<Row<'_>> = table
+            .processes
+            .iter()
+            .map(|p| Row::new(p.iter().map(|c| Cell::from(c.clone())).collect::<Vec<_>>()))
+            .collect();
+        let widget = Table::new(rows, widths).header(header).block(block);
+        frame.render_widget(widget, modal_area);
     }
 
     /// Top "card" — image, state, command, restart info, live gauges.
@@ -401,6 +783,72 @@ fn parse_unix_seconds(s: &str) -> Option<i64> {
     let doe = yoe * 365 + yoe / 4 - yoe / 100 + doy;
     let days = era * 146_097 + doe - 719_468;
     Some(days * 86400 + h * 3600 + mi * 60 + se)
+}
+
+/// Build x-axis tick labels for the rolling window. Three ticks: oldest,
+/// midpoint, newest. Labels are minutes:seconds relative to "now".
+fn time_axis_labels(xmin: f64, xmax: f64) -> Vec<Span<'static>> {
+    let dim = Style::default().fg(Color::DarkGray);
+    let span = (xmax - xmin).max(1.0);
+    let oldest = format!("-{:.0}m", (span / 60.0).floor());
+    let middle = format!("-{:.0}m", (span / 120.0).floor());
+    vec![
+        Span::styled(oldest, dim),
+        Span::styled(middle, dim),
+        Span::styled("now".to_string(), dim),
+    ]
+}
+
+fn percent_axis_labels(max: f64, uncapped: bool) -> Vec<Span<'static>> {
+    let dim = Style::default().fg(Color::DarkGray);
+    if uncapped {
+        vec![
+            Span::styled("0".to_string(), dim),
+            Span::styled(format!("{:.0}M", max / 2.0), dim),
+            Span::styled(format!("{max:.0}M"), dim),
+        ]
+    } else {
+        vec![
+            Span::styled("0%".to_string(), dim),
+            Span::styled(format!("{:.0}%", max / 2.0), dim),
+            Span::styled(format!("{max:.0}%"), dim),
+        ]
+    }
+}
+
+fn rate_axis_labels(max: f64) -> Vec<Span<'static>> {
+    let dim = Style::default().fg(Color::DarkGray);
+    let half = max / 2.0;
+    vec![
+        Span::styled("0".to_string(), dim),
+        Span::styled(format_rate(half), dim),
+        Span::styled(format_rate(max), dim),
+    ]
+}
+
+#[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+fn format_rate(bytes_per_sec: f64) -> String {
+    if bytes_per_sec < 1024.0 {
+        format!("{bytes_per_sec:.0}B/s")
+    } else if bytes_per_sec < 1024.0 * 1024.0 {
+        format!("{:.1}KB/s", bytes_per_sec / 1024.0)
+    } else if bytes_per_sec < 1024.0 * 1024.0 * 1024.0 {
+        format!("{:.1}MB/s", bytes_per_sec / (1024.0 * 1024.0))
+    } else {
+        format!("{:.2}GB/s", bytes_per_sec / (1024.0 * 1024.0 * 1024.0))
+    }
+}
+
+/// Background-friendly `docker top` fetch — runs off the event loop
+/// so a slow daemon doesn't freeze the TUI.
+pub async fn fetch_top(
+    ops: Arc<dyn DockerOps>,
+    host: Host,
+    container: String,
+) -> Result<ProcessTable, String> {
+    ops.top_container(&host, &container)
+        .await
+        .map_err(|e| e.to_string())
 }
 
 /// Background-friendly fetch — `'static + Send` so it can be `tokio::spawn`-ed.

--- a/yoink/src/tui/container_detail.rs
+++ b/yoink/src/tui/container_detail.rs
@@ -71,6 +71,11 @@ pub struct StatsHistory {
     /// Last absolute mem bytes (for the uncapped case so the y-axis
     /// max can grow).
     mem_max_bytes: i64,
+    /// The newest raw `ContainerStats` sample we ingested. Cached
+    /// alongside the derived rings so list views (Dashboard,
+    /// `HostDetail`) can render their CPU/Mem cells directly from the
+    /// always-on poller's data instead of duplicating the stats fetch.
+    latest: Option<ContainerStats>,
 }
 
 impl StatsHistory {
@@ -80,9 +85,12 @@ impl StatsHistory {
     }
 
     /// Record a fresh sample. Drops points that fall outside the
-    /// history window so the chart keeps a fixed time horizon.
+    /// history window so the chart keeps a fixed time horizon. Also
+    /// caches the raw `ContainerStats` so list views can read it
+    /// without their own per-container fetch.
     pub fn push(&mut self, stats: &ContainerStats) {
         let t = self.now_elapsed();
+        self.latest = Some(stats.clone());
         self.cpu_pct.push_back((t, stats.cpu_pct.max(0.0)));
 
         match stats.mem_limit {
@@ -129,6 +137,14 @@ impl StatsHistory {
     #[allow(dead_code)] // Useful for tests + future "reset on disconnect" hooks.
     pub fn clear(&mut self) {
         *self = Self::default();
+    }
+
+    /// Most recent raw stats sample, if any. Used by Dashboard /
+    /// `HostDetail` to render their CPU/Mem cells without duplicating
+    /// the stats fetch.
+    #[must_use]
+    pub fn latest(&self) -> Option<&ContainerStats> {
+        self.latest.as_ref()
     }
 
     /// True when the CPU samples ring is empty — used by the App-level

--- a/yoink/src/tui/container_detail.rs
+++ b/yoink/src/tui/container_detail.rs
@@ -408,11 +408,19 @@ impl ContainerDetailState {
             frame.render_widget(chart, cols[1]);
         }
 
-        // ── Panel 3: network rx/tx rate ───────────────────────────────
+        // ── Panel 3: network rx/tx rate, btop-style mirrored ──────────
+        // rx (incoming) plots above the zero line; tx (outgoing) plots
+        // mirrored below. The two series no longer overlap — at a
+        // glance you see "what's coming in" vs "what's going out"
+        // without having to disambiguate two same-axis lines.
         let rx_rates = StatsHistory::rate_series(&self.history.net_rx);
-        let tx_rates = StatsHistory::rate_series(&self.history.net_tx);
+        let tx_rates_pos = StatsHistory::rate_series(&self.history.net_tx);
+        // Mirror tx below the zero line by negating each y value. The
+        // rendered line still tracks the same magnitude — just on the
+        // negative side of the axis.
+        let tx_rates: Vec<(f64, f64)> = tx_rates_pos.iter().map(|(t, v)| (*t, -*v)).collect();
         let rx_now = rx_rates.last().map_or(0.0, |(_, v)| *v);
-        let tx_now = tx_rates.last().map_or(0.0, |(_, v)| *v);
+        let tx_now = tx_rates_pos.last().map_or(0.0, |(_, v)| *v);
         let net_title = if rx_rates.is_empty() && tx_rates.is_empty() {
             " net rx / tx (5 min) ".to_string()
         } else {
@@ -431,21 +439,28 @@ impl ContainerDetailState {
                 cols[2],
             );
         } else {
-            let max_rate = rx_rates
+            let rx_peak = rx_rates
                 .iter()
-                .chain(tx_rates.iter())
                 .map(|(_, v)| *v)
-                .fold(0.0_f64, f64::max)
-                .max(1.0);
+                .fold(0.0_f64, f64::max);
+            let tx_peak = tx_rates_pos
+                .iter()
+                .map(|(_, v)| *v)
+                .fold(0.0_f64, f64::max);
+            // Symmetric y-axis around zero so the visual zero-line
+            // sits halfway down the panel regardless of whether
+            // download or upload is dominant. `.max(1.0)` keeps the
+            // axis non-degenerate during idle quiet periods.
+            let max_rate = rx_peak.max(tx_peak).max(1.0);
             let datasets = vec![
                 Dataset::default()
-                    .name("rx")
+                    .name("↓ rx")
                     .marker(Marker::Braille)
                     .graph_type(GraphType::Line)
                     .style(Style::default().fg(Color::Green))
                     .data(&rx_rates),
                 Dataset::default()
-                    .name("tx")
+                    .name("↑ tx")
                     .marker(Marker::Braille)
                     .graph_type(GraphType::Line)
                     .style(Style::default().fg(Color::Yellow))
@@ -462,8 +477,8 @@ impl ContainerDetailState {
                 .y_axis(
                     Axis::default()
                         .style(Style::default().fg(Color::DarkGray))
-                        .bounds([0.0, max_rate])
-                        .labels(rate_axis_labels(max_rate)),
+                        .bounds([-max_rate, max_rate])
+                        .labels(mirrored_rate_labels(max_rate)),
                 );
             frame.render_widget(chart, cols[2]);
         }
@@ -879,13 +894,18 @@ fn percent_axis_labels(max: f64, uncapped: bool) -> Vec<Span<'static>> {
     }
 }
 
-fn rate_axis_labels(max: f64) -> Vec<Span<'static>> {
+/// Labels for the mirrored rx/tx panel: bottom is `↑ tx_max`, middle
+/// is `0`, top is `↓ rx_max`. Both magnitudes are positive (the y
+/// values are signed but the operator reads the magnitude with the
+/// arrow indicating direction).
+fn mirrored_rate_labels(max: f64) -> Vec<Span<'static>> {
     let dim = Style::default().fg(Color::DarkGray);
-    let half = max / 2.0;
+    let up = Style::default().fg(Color::Yellow);
+    let down = Style::default().fg(Color::Green);
     vec![
+        Span::styled(format!("↑{}", format_rate(max)), up),
         Span::styled("0".to_string(), dim),
-        Span::styled(format_rate(half), dim),
-        Span::styled(format_rate(max), dim),
+        Span::styled(format!("↓{}", format_rate(max)), down),
     ]
 }
 

--- a/yoink/src/tui/container_detail.rs
+++ b/yoink/src/tui/container_detail.rs
@@ -287,12 +287,13 @@ impl ContainerDetailState {
         }
     }
 
-    /// Side-by-side line charts for the rolling 5-minute window. Left:
-    /// CPU% (cyan) + Mem% (magenta). Right: network rx (green) + tx
-    /// (yellow), bytes-per-second derived from successive samples.
-    /// Both panels render an axis label legend; empty data falls back
-    /// to a "(collecting…)" centred line so the panel doesn't look broken
-    /// in the first 2-3 seconds before the first stats sample lands.
+    /// Three side-by-side line charts covering the rolling 5-minute
+    /// window — one each for CPU%, Mem (% when capped, MB when not),
+    /// and network rx/tx rate. Splitting CPU and Mem into separate
+    /// panels means each y-axis scales to its own metric: a 4 GB
+    /// memory peak no longer flattens the CPU line into the bottom
+    /// pixel row. The latest sampled value is rendered in each panel
+    /// title so it's readable without squinting at the rightmost edge.
     #[allow(
         clippy::cast_precision_loss,
         clippy::cast_possible_truncation,
@@ -301,23 +302,29 @@ impl ContainerDetailState {
     fn render_history(&self, frame: &mut Frame<'_>, area: Rect) {
         let cols = Layout::default()
             .direction(Direction::Horizontal)
-            .constraints([Constraint::Percentage(50), Constraint::Percentage(50)])
+            .constraints([
+                Constraint::Percentage(33),
+                Constraint::Percentage(34),
+                Constraint::Percentage(33),
+            ])
             .split(area);
 
-        // ── Left panel: CPU% + Mem% over time ─────────────────────────
         let (xmin, xmax) = self.history.x_window();
         let cpu_data: Vec<(f64, f64)> = self.history.cpu_pct.iter().copied().collect();
         let mem_data: Vec<(f64, f64)> = self.history.mem_pct.iter().copied().collect();
 
-        let left_block = Block::default()
-            .borders(Borders::ALL)
-            .title(" CPU % · Mem % (5 min) ");
-
+        // ── Panel 1: CPU% over time ───────────────────────────────────
+        let cpu_now = cpu_data.last().map(|(_, v)| *v);
+        let cpu_title = match cpu_now {
+            Some(c) => format!(" CPU {c:>5.1}% (5 min) "),
+            None => " CPU % (5 min) ".to_string(),
+        };
+        let cpu_block = Block::default().borders(Borders::ALL).title(cpu_title);
         if cpu_data.is_empty() {
             frame.render_widget(
-                Paragraph::new("(collecting samples…)")
+                Paragraph::new("(collecting…)")
                     .style(Style::default().fg(Color::DarkGray))
-                    .block(left_block),
+                    .block(cpu_block),
                 cols[0],
             );
         } else {
@@ -326,17 +333,6 @@ impl ContainerDetailState {
                 .map(|(_, v)| *v)
                 .fold(0.0_f64, f64::max)
                 .max(100.0);
-            let mem_max = if self.history.mem_uncapped {
-                let m = mem_data.iter().map(|(_, v)| *v).fold(0.0_f64, f64::max);
-                m.max(1.0)
-            } else {
-                100.0
-            };
-            // Both metrics share a y-axis scaled to the larger of the
-            // two — keeping them in one panel saves vertical real estate
-            // and makes "memory leaked while CPU was idle" patterns
-            // jump out at a glance.
-            let y_max = cpu_max.max(mem_max);
             let datasets = vec![
                 Dataset::default()
                     .name("cpu%")
@@ -344,19 +340,9 @@ impl ContainerDetailState {
                     .graph_type(GraphType::Line)
                     .style(Style::default().fg(Color::Cyan))
                     .data(&cpu_data),
-                Dataset::default()
-                    .name(if self.history.mem_uncapped {
-                        "mem MB"
-                    } else {
-                        "mem%"
-                    })
-                    .marker(Marker::Braille)
-                    .graph_type(GraphType::Line)
-                    .style(Style::default().fg(Color::Magenta))
-                    .data(&mem_data),
             ];
             let chart = Chart::new(datasets)
-                .block(left_block)
+                .block(cpu_block)
                 .x_axis(
                     Axis::default()
                         .style(Style::default().fg(Color::DarkGray))
@@ -366,25 +352,83 @@ impl ContainerDetailState {
                 .y_axis(
                     Axis::default()
                         .style(Style::default().fg(Color::DarkGray))
-                        .bounds([0.0, y_max])
-                        .labels(percent_axis_labels(y_max, self.history.mem_uncapped)),
+                        .bounds([0.0, cpu_max])
+                        .labels(percent_axis_labels(cpu_max, false)),
                 );
             frame.render_widget(chart, cols[0]);
         }
 
-        // ── Right panel: network rx/tx rate ───────────────────────────
+        // ── Panel 2: Mem (own y-axis, % when capped, MB when uncapped) ─
+        let mem_now = mem_data.last().map(|(_, v)| *v);
+        let mem_unit = if self.history.mem_uncapped { "MB" } else { "%" };
+        let mem_title = match mem_now {
+            Some(m) => format!(" Mem {m:>5.1}{mem_unit} (5 min) "),
+            None => format!(" Mem {mem_unit} (5 min) "),
+        };
+        let mem_block = Block::default().borders(Borders::ALL).title(mem_title);
+        if mem_data.is_empty() {
+            frame.render_widget(
+                Paragraph::new("(collecting…)")
+                    .style(Style::default().fg(Color::DarkGray))
+                    .block(mem_block),
+                cols[1],
+            );
+        } else {
+            let mem_max = if self.history.mem_uncapped {
+                mem_data
+                    .iter()
+                    .map(|(_, v)| *v)
+                    .fold(0.0_f64, f64::max)
+                    .max(1.0)
+            } else {
+                100.0
+            };
+            let datasets = vec![
+                Dataset::default()
+                    .name(if self.history.mem_uncapped { "mem MB" } else { "mem%" })
+                    .marker(Marker::Braille)
+                    .graph_type(GraphType::Line)
+                    .style(Style::default().fg(Color::Magenta))
+                    .data(&mem_data),
+            ];
+            let chart = Chart::new(datasets)
+                .block(mem_block)
+                .x_axis(
+                    Axis::default()
+                        .style(Style::default().fg(Color::DarkGray))
+                        .bounds([xmin, xmax])
+                        .labels(time_axis_labels(xmin, xmax)),
+                )
+                .y_axis(
+                    Axis::default()
+                        .style(Style::default().fg(Color::DarkGray))
+                        .bounds([0.0, mem_max])
+                        .labels(percent_axis_labels(mem_max, self.history.mem_uncapped)),
+                );
+            frame.render_widget(chart, cols[1]);
+        }
+
+        // ── Panel 3: network rx/tx rate ───────────────────────────────
         let rx_rates = StatsHistory::rate_series(&self.history.net_rx);
         let tx_rates = StatsHistory::rate_series(&self.history.net_tx);
-        let right_block = Block::default()
-            .borders(Borders::ALL)
-            .title(" net rx / tx (5 min, B/s) ");
-
+        let rx_now = rx_rates.last().map_or(0.0, |(_, v)| *v);
+        let tx_now = tx_rates.last().map_or(0.0, |(_, v)| *v);
+        let net_title = if rx_rates.is_empty() && tx_rates.is_empty() {
+            " net rx / tx (5 min) ".to_string()
+        } else {
+            format!(
+                " net ↓{} ↑{} (5 min) ",
+                format_rate(rx_now),
+                format_rate(tx_now)
+            )
+        };
+        let net_block = Block::default().borders(Borders::ALL).title(net_title);
         if rx_rates.is_empty() && tx_rates.is_empty() {
             frame.render_widget(
-                Paragraph::new("(collecting samples…)")
+                Paragraph::new("(collecting…)")
                     .style(Style::default().fg(Color::DarkGray))
-                    .block(right_block),
-                cols[1],
+                    .block(net_block),
+                cols[2],
             );
         } else {
             let max_rate = rx_rates
@@ -408,7 +452,7 @@ impl ContainerDetailState {
                     .data(&tx_rates),
             ];
             let chart = Chart::new(datasets)
-                .block(right_block)
+                .block(net_block)
                 .x_axis(
                     Axis::default()
                         .style(Style::default().fg(Color::DarkGray))
@@ -421,7 +465,7 @@ impl ContainerDetailState {
                         .bounds([0.0, max_rate])
                         .labels(rate_axis_labels(max_rate)),
                 );
-            frame.render_widget(chart, cols[1]);
+            frame.render_widget(chart, cols[2]);
         }
     }
 
@@ -578,6 +622,25 @@ impl ContainerDetailState {
             let mut mem_spans = vec![Span::raw(label)];
             mem_spans.extend(inline_gauge(ratio, 16, gauge_color(ratio)));
             right_lines.push(Line::from(mem_spans));
+
+            // Cumulative network bytes since the container started.
+            // Per-second rate lives in the history chart's title; this
+            // line answers "how much has this thing transferred in
+            // total" — useful for spotting the runaway egress case.
+            right_lines.push(Line::from(vec![
+                Span::styled("NET ", Style::default().fg(Color::DarkGray)),
+                Span::styled(
+                    "↓ ".to_string(),
+                    Style::default().fg(Color::Green),
+                ),
+                Span::raw(format_bytes(s.net_rx_bytes)),
+                Span::raw("  "),
+                Span::styled(
+                    "↑ ".to_string(),
+                    Style::default().fg(Color::Yellow),
+                ),
+                Span::raw(format_bytes(s.net_tx_bytes)),
+            ]));
         } else {
             right_lines.push(Line::from(Span::styled(
                 "(no live stats yet)",

--- a/yoink/src/tui/dashboard.rs
+++ b/yoink/src/tui/dashboard.rs
@@ -502,6 +502,7 @@ services:
             cpu_pct: 12.5,
             mem_used: 64 * 1024 * 1024,
             mem_limit: Some(512 * 1024 * 1024),
+            ..Default::default()
         }));
         let mut state = DashboardState::new();
         state.refresh(&ops, &config()).await;

--- a/yoink/src/tui/dashboard.rs
+++ b/yoink/src/tui/dashboard.rs
@@ -4,7 +4,6 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
-use futures_util::future::join_all;
 use ratatui::Frame;
 use ratatui::layout::Constraint;
 use ratatui::style::{Color, Style};
@@ -12,11 +11,12 @@ use ratatui::text::{Line, Span};
 use ratatui::widgets::{Block, Borders, Cell, Paragraph, Row, Table, TableState};
 
 use crate::config::Config;
-use crate::docker_ops::{ContainerStats, DockerOps, Host};
+use crate::docker_ops::{ContainerStats, DockerOps};
 use crate::output::{format_bytes, format_relative_time};
 use crate::secrets::SecretsBundle;
 use crate::status::StatusReport;
 
+use super::container_detail::StatsHistory;
 use super::ui::{
     FilterState, bold, clamp_selection, filter_footer, gauge_color, health_style, inline_gauge,
     pane_layout, render_drift_cell, state_style,
@@ -24,16 +24,12 @@ use super::ui::{
 
 pub struct DashboardRefresh {
     pub report: Option<StatusReport>,
-    pub stats: HashMap<String, ContainerStats>,
     pub error: Option<String>,
 }
 
 #[derive(Default)]
 pub struct DashboardState {
     report: Option<StatusReport>,
-    /// Keyed by `<host>/<container>` so the render layer can look up live
-    /// stats alongside the container info from the listing.
-    stats: HashMap<String, ContainerStats>,
     last_error: Option<String>,
     loaded: bool,
     /// When `true`, render also includes containers in the `exited` /
@@ -177,7 +173,6 @@ impl DashboardState {
         self.loaded = true;
         if let Some(report) = data.report {
             self.report = Some(report);
-            self.stats = data.stats;
         }
     }
 
@@ -187,6 +182,7 @@ impl DashboardState {
         area: ratatui::layout::Rect,
         config: &Config,
         secrets: Option<&SecretsBundle>,
+        history: &HashMap<(String, String), StatsHistory>,
     ) {
         let layout = pane_layout(area);
 
@@ -200,7 +196,7 @@ impl DashboardState {
             Paragraph::new(format!("yoink dashboard · services: {services}")).style(bold());
         frame.render_widget(header, layout[0]);
 
-        let rows = self.build_rows(config, secrets);
+        let rows = self.build_rows(config, secrets, history);
         let widths = [
             Constraint::Length(18), // host
             Constraint::Length(14), // service
@@ -251,7 +247,12 @@ impl DashboardState {
         frame.render_widget(footer, layout[2]);
     }
 
-    fn build_rows(&self, config: &Config, secrets: Option<&SecretsBundle>) -> Vec<Row<'static>> {
+    fn build_rows(
+        &self,
+        config: &Config,
+        secrets: Option<&SecretsBundle>,
+        history: &HashMap<(String, String), StatsHistory>,
+    ) -> Vec<Row<'static>> {
         let Some(report) = &self.report else {
             // No cached report. If the first fetch already finished
             // and errored (loaded=true), don't pretend we're still
@@ -298,8 +299,9 @@ impl DashboardState {
                     continue;
                 }
                 let health = c.health_hint().unwrap_or("-");
-                let key = stats_key(&host.host, &c.name);
-                let stats = self.stats.get(&key);
+                let stats = history
+                    .get(&(host.host.clone(), c.name.clone()))
+                    .and_then(StatsHistory::latest);
 
                 let cpu_cell = render_cpu_cell(stats);
                 let mem_cell = render_mem_cell(stats);
@@ -322,10 +324,6 @@ impl DashboardState {
         }
         rows
     }
-}
-
-fn stats_key(host: &str, container: &str) -> String {
-    format!("{host}/{container}")
 }
 
 /// Comma-joined network list for the dashboard cell. Truncates with
@@ -399,66 +397,27 @@ pub async fn fetch_owned(ops: Arc<dyn DockerOps>, config: Arc<Config>) -> Dashbo
     fetch(ops.as_ref(), config.as_ref()).await
 }
 
+/// Just the container listing — live CPU/Mem stats arrive separately
+/// via the always-on stats poller and live in `App::container_history`.
+/// This keeps the docker daemon from being asked for the same stats
+/// twice on every fast tick.
 async fn fetch(ops: &dyn DockerOps, config: &Config) -> DashboardRefresh {
-    let report = match StatusReport::collect(ops, config).await {
-        Ok(r) => r,
-        Err(e) => {
-            return DashboardRefresh {
-                report: None,
-                stats: HashMap::new(),
-                error: Some(format!("{e:#}")),
-            };
-        }
-    };
-    let host_user_by_address: HashMap<String, String> = config
-        .hosts
-        .iter()
-        .map(|h| (h.address.clone(), h.user.clone()))
-        .collect();
-    let stats_futs = report
-        .hosts
-        .iter()
-        .flat_map(|h| {
-            let host_addr = h.host.clone();
-            let user = host_user_by_address
-                .get(&host_addr)
-                .cloned()
-                .unwrap_or_default();
-            h.containers
-                .iter()
-                .filter(|c| c.is_running())
-                .map(move |c| {
-                    let host = Host {
-                        user: user.clone(),
-                        address: host_addr.clone(),
-                    };
-                    let key = stats_key(&host_addr, &c.name);
-                    let name = c.name.clone();
-                    async move {
-                        let result = ops.container_stats(&host, &name).await;
-                        (key, result)
-                    }
-                })
-        })
-        .collect::<Vec<_>>();
-    let stats_results = join_all(stats_futs).await;
-    let mut stats = HashMap::new();
-    for (key, result) in stats_results {
-        if let Ok(s) = result {
-            stats.insert(key, s);
-        }
-    }
-    DashboardRefresh {
-        report: Some(report),
-        stats,
-        error: None,
+    match StatusReport::collect(ops, config).await {
+        Ok(r) => DashboardRefresh {
+            report: Some(r),
+            error: None,
+        },
+        Err(e) => DashboardRefresh {
+            report: None,
+            error: Some(format!("{e:#}")),
+        },
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::docker_ops::{ContainerInfo, ContainerStats, FakeDockerOps};
+    use crate::docker_ops::{ContainerInfo, FakeDockerOps};
     use std::collections::BTreeMap;
 
     fn config() -> Config {
@@ -495,46 +454,14 @@ services:
     }
 
     #[tokio::test]
-    async fn refresh_collects_listing_then_stats_per_running_container() {
+    async fn refresh_populates_report() {
         let ops = FakeDockerOps::new();
         ops.push_list_containers(Ok(vec![running_container()]));
-        ops.push_container_stats(Ok(ContainerStats {
-            cpu_pct: 12.5,
-            mem_used: 64 * 1024 * 1024,
-            mem_limit: Some(512 * 1024 * 1024),
-            ..Default::default()
-        }));
+        // Stats fetching no longer happens here — the always-on
+        // poller in App owns it. Refresh just collects the listing.
         let mut state = DashboardState::new();
         state.refresh(&ops, &config()).await;
         assert!(state.report.is_some());
-        assert_eq!(state.stats.len(), 1);
-        let s = state.stats.get("host-a/app-a-a1b2c3d").unwrap();
-        assert!((s.cpu_pct - 12.5).abs() < f64::EPSILON);
-        assert_eq!(s.mem_used, 64 * 1024 * 1024);
-    }
-
-    #[tokio::test]
-    async fn refresh_skips_stats_for_non_running_containers() {
-        let ops = FakeDockerOps::new();
-        let mut stopped = running_container();
-        stopped.state = "exited".into();
-        ops.push_list_containers(Ok(vec![stopped]));
-        // No push_container_stats — refresh shouldn't attempt one.
-        let mut state = DashboardState::new();
-        state.refresh(&ops, &config()).await;
-        assert!(state.stats.is_empty());
-    }
-
-    #[tokio::test]
-    async fn refresh_keeps_report_when_individual_stats_fails() {
-        let ops = FakeDockerOps::new();
-        ops.push_list_containers(Ok(vec![running_container()]));
-        // No stats response — fetch returns FakeExhausted, which we
-        // tolerate; report is still populated, stats map stays empty.
-        let mut state = DashboardState::new();
-        state.refresh(&ops, &config()).await;
-        assert!(state.report.is_some());
-        assert!(state.stats.is_empty());
     }
 
     #[tokio::test]

--- a/yoink/src/tui/host_detail.rs
+++ b/yoink/src/tui/host_detail.rs
@@ -5,7 +5,6 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
-use futures_util::future::join_all;
 use ratatui::Frame;
 use ratatui::layout::{Constraint, Direction, Layout};
 use ratatui::style::{Color, Modifier, Style};
@@ -17,6 +16,7 @@ use crate::docker_ops::{ContainerInfo, ContainerStats, DockerOps, Host, HostInfo
 use crate::output::format_bytes;
 use crate::secrets::SecretsBundle;
 
+use super::container_detail::StatsHistory;
 use super::ui::{
     FilterState, bold, clamp_selection, filter_footer, gauge_color, health_style, inline_gauge,
     render_drift_cell, short_image, state_style,
@@ -24,7 +24,6 @@ use super::ui::{
 
 pub struct HostDetailRefresh {
     pub containers: Vec<ContainerInfo>,
-    pub stats: HashMap<String, ContainerStats>,
     pub host_info: Option<HostInfo>,
     pub error: Option<String>,
 }
@@ -33,7 +32,6 @@ pub struct HostDetailRefresh {
 pub struct HostDetailState {
     host: Option<Host>,
     containers: Vec<ContainerInfo>,
-    stats: HashMap<String, ContainerStats>,
     host_info: Option<HostInfo>,
     last_error: Option<String>,
     table: TableState,
@@ -51,7 +49,6 @@ impl HostDetailState {
     pub fn set_host(&mut self, host: Host) {
         if self.host.as_ref() != Some(&host) {
             self.containers.clear();
-            self.stats.clear();
             self.table.select(None);
             self.loaded = false;
         }
@@ -78,7 +75,6 @@ impl HostDetailState {
         self.loaded = true;
         if self.last_error.is_none() {
             self.containers = data.containers;
-            self.stats = data.stats;
             self.host_info = data.host_info;
         }
         clamp_selection(&mut self.table, self.containers.len());
@@ -154,6 +150,7 @@ impl HostDetailState {
         config: &Config,
         secrets: Option<&SecretsBundle>,
         events: &[String],
+        history: &HashMap<(String, String), StatsHistory>,
     ) {
         // 5-section layout: header · summary · containers (Min) · events (Length 8 when present) · footer.
         // The event panel collapses to 0 when no events are recorded yet.
@@ -184,7 +181,7 @@ impl HostDetailState {
         let header = Paragraph::new(header_text).style(bold());
         frame.render_widget(header, header_area);
 
-        self.render_summary(frame, summary_area);
+        self.render_summary(frame, summary_area, history);
 
         let widths = [
             Constraint::Length(14), // service
@@ -215,7 +212,14 @@ impl HostDetailState {
                 .iter()
                 .map(|i| {
                     let c = &self.containers[*i];
-                    let stats = self.stats.get(&c.name);
+                    let host_addr = self
+                        .host
+                        .as_ref()
+                        .map(|h| h.address.clone())
+                        .unwrap_or_default();
+                    let stats = history
+                        .get(&(host_addr, c.name.clone()))
+                        .and_then(StatsHistory::latest);
                     let health = c.health_hint().unwrap_or("-");
                     Row::new(vec![
                         Cell::from(c.yoink_service.clone().unwrap_or_else(|| "-".into())),
@@ -305,7 +309,12 @@ impl HostDetailState {
         clippy::cast_sign_loss,
         clippy::cast_lossless
     )]
-    fn render_summary(&self, frame: &mut Frame<'_>, area: ratatui::layout::Rect) {
+    fn render_summary(
+        &self,
+        frame: &mut Frame<'_>,
+        area: ratatui::layout::Rect,
+        history: &HashMap<(String, String), StatsHistory>,
+    ) {
         let block = Block::default()
             .borders(Borders::ALL)
             .title(" host summary ");
@@ -321,8 +330,23 @@ impl HostDetailState {
             ])
             .split(inner);
 
-        let cpu_total: f32 = self.stats.values().map(|s| s.cpu_pct as f32).sum();
-        let mem_total: u64 = self.stats.values().map(|s| s.mem_used.max(0) as u64).sum();
+        // Sum across the latest stats sample of every container we
+        // know is on this host. The history store is keyed by
+        // (host_address, container_name) so we filter to the rows that
+        // belong to the current host.
+        let host_addr = self
+            .host
+            .as_ref()
+            .map(|h| h.address.as_str())
+            .unwrap_or_default();
+        let host_stats: Vec<&ContainerStats> = self
+            .containers
+            .iter()
+            .filter_map(|c| history.get(&(host_addr.to_string(), c.name.clone())))
+            .filter_map(StatsHistory::latest)
+            .collect();
+        let cpu_total: f32 = host_stats.iter().map(|s| s.cpu_pct as f32).sum();
+        let mem_total: u64 = host_stats.iter().map(|s| s.mem_used.max(0) as u64).sum();
         let n_cpu = self
             .host_info
             .as_ref()
@@ -443,42 +467,30 @@ pub async fn fetch_owned(ops: Arc<dyn DockerOps>, host: Host) -> HostDetailRefre
     fetch(ops.as_ref(), &host).await
 }
 
+/// List running containers + host info, in parallel. Live stats are
+/// owned by the App-level always-on poller and read from
+/// `App::container_history` at render time.
 async fn fetch(ops: &dyn DockerOps, host: &Host) -> HostDetailRefresh {
-    // Containers + host info concurrently.
     let (containers_res, host_info_res) =
-        tokio::join!(ops.list_running_containers(host), ops.host_info(host),);
-    let containers = match containers_res {
-        Ok(c) => c,
-        Err(e) => {
-            return HostDetailRefresh {
-                containers: Vec::new(),
-                stats: HashMap::new(),
-                host_info: None,
-                error: Some(format!("{e:#}")),
-            };
-        }
-    };
-    let stat_futs = containers.iter().map(|c| {
-        let name = c.name.clone();
-        async move { (name.clone(), ops.container_stats(host, &name).await) }
-    });
-    let stats: HashMap<String, ContainerStats> = join_all(stat_futs)
-        .await
-        .into_iter()
-        .filter_map(|(name, r)| r.ok().map(|s| (name, s)))
-        .collect();
-    HostDetailRefresh {
-        containers,
-        stats,
-        host_info: host_info_res.ok(),
-        error: None,
+        tokio::join!(ops.list_running_containers(host), ops.host_info(host));
+    match containers_res {
+        Ok(containers) => HostDetailRefresh {
+            containers,
+            host_info: host_info_res.ok(),
+            error: None,
+        },
+        Err(e) => HostDetailRefresh {
+            containers: Vec::new(),
+            host_info: None,
+            error: Some(format!("{e:#}")),
+        },
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::docker_ops::{ContainerStats, FakeDockerOps};
+    use crate::docker_ops::FakeDockerOps;
     use std::collections::BTreeMap;
 
     fn host() -> Host {
@@ -507,25 +519,15 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn refresh_populates_containers_and_stats() {
+    async fn refresh_populates_containers() {
         let ops = FakeDockerOps::new();
         ops.push_list_containers(Ok(vec![container("a"), container("b")]));
-        ops.push_container_stats(Ok(ContainerStats {
-            cpu_pct: 100.0,
-            mem_used: 64 * 1024 * 1024,
-            ..Default::default()
-        }));
-        ops.push_container_stats(Ok(ContainerStats {
-            cpu_pct: 50.0,
-            mem_used: 32 * 1024 * 1024,
-            ..Default::default()
-        }));
-
+        // Stats are owned by the always-on poller now; refresh just
+        // collects the listing.
         let mut state = HostDetailState::new();
         state.set_host(host());
         state.refresh(&ops).await;
         assert_eq!(state.containers.len(), 2);
-        assert_eq!(state.stats.len(), 2);
         assert_eq!(state.selected_container().as_deref(), Some("a"));
     }
 
@@ -533,8 +535,6 @@ mod tests {
     async fn select_next_and_prev_clamp_to_bounds() {
         let ops = FakeDockerOps::new();
         ops.push_list_containers(Ok(vec![container("a"), container("b")]));
-        ops.push_container_stats(Ok(ContainerStats::default()));
-        ops.push_container_stats(Ok(ContainerStats::default()));
         let mut state = HostDetailState::new();
         state.set_host(host());
         state.refresh(&ops).await;

--- a/yoink/src/tui/host_detail.rs
+++ b/yoink/src/tui/host_detail.rs
@@ -153,21 +153,26 @@ impl HostDetailState {
         area: ratatui::layout::Rect,
         config: &Config,
         secrets: Option<&SecretsBundle>,
+        events: &[String],
     ) {
-        // 4-section layout: header (1) · summary panel (5) · table (rest) · footer (1).
+        // 5-section layout: header · summary · containers (Min) · events (Length 8 when present) · footer.
+        // The event panel collapses to 0 when no events are recorded yet.
+        let event_height: u16 = if events.is_empty() { 0 } else { 8 };
         let layout = Layout::default()
             .direction(Direction::Vertical)
             .constraints([
                 Constraint::Length(1),
                 Constraint::Length(5),
                 Constraint::Min(0),
+                Constraint::Length(event_height),
                 Constraint::Length(1),
             ])
             .split(area);
         let header_area = layout[0];
         let summary_area = layout[1];
         let table_area = layout[2];
-        let footer_area = layout[3];
+        let events_area = layout[3];
+        let footer_area = layout[4];
 
         let header_text = match &self.host {
             Some(h) => format!(
@@ -259,9 +264,36 @@ impl HostDetailState {
         }
         let footer = filter_footer(
             &self.filter,
-            "q quit · esc back · ↑↓ select · enter logs · ! shell · D debug · r refresh",
+            "↑↓ select · enter logs · i inspect · ! shell · D debug · S start · X stop · R restart · K kill · U reconcile · r refresh",
         );
         frame.render_widget(footer, footer_area);
+
+        if !events.is_empty() && event_height > 0 {
+            Self::render_events(frame, events_area, events);
+        }
+    }
+
+    /// Bottom-of-pane scrolling event log showing the most recent
+    /// docker events for this host (start / die / health-change /
+    /// network create / volume mount …). Newest at the top — same
+    /// reading order as `docker events --since` truncated to the
+    /// most operator-relevant `EVENT_HISTORY_PER_HOST` lines.
+    fn render_events(frame: &mut Frame<'_>, area: ratatui::layout::Rect, events: &[String]) {
+        let block = Block::default()
+            .borders(Borders::ALL)
+            .border_style(Style::default().fg(Color::DarkGray))
+            .title(Span::styled(
+                " events (newest first) ",
+                Style::default().fg(Color::Gray),
+            ));
+        let inner_h = block.inner(area).height as usize;
+        let lines: Vec<Line<'static>> = events
+            .iter()
+            .rev()
+            .take(inner_h.max(1))
+            .map(|s| Line::from(s.clone()))
+            .collect();
+        frame.render_widget(Paragraph::new(lines).block(block), area);
     }
 
     /// Host-aggregate summary panel: bordered block hosting two
@@ -481,12 +513,12 @@ mod tests {
         ops.push_container_stats(Ok(ContainerStats {
             cpu_pct: 100.0,
             mem_used: 64 * 1024 * 1024,
-            mem_limit: None,
+            ..Default::default()
         }));
         ops.push_container_stats(Ok(ContainerStats {
             cpu_pct: 50.0,
             mem_used: 32 * 1024 * 1024,
-            mem_limit: None,
+            ..Default::default()
         }));
 
         let mut state = HostDetailState::new();
@@ -501,16 +533,8 @@ mod tests {
     async fn select_next_and_prev_clamp_to_bounds() {
         let ops = FakeDockerOps::new();
         ops.push_list_containers(Ok(vec![container("a"), container("b")]));
-        ops.push_container_stats(Ok(ContainerStats {
-            cpu_pct: 0.0,
-            mem_used: 0,
-            mem_limit: None,
-        }));
-        ops.push_container_stats(Ok(ContainerStats {
-            cpu_pct: 0.0,
-            mem_used: 0,
-            mem_limit: None,
-        }));
+        ops.push_container_stats(Ok(ContainerStats::default()));
+        ops.push_container_stats(Ok(ContainerStats::default()));
         let mut state = HostDetailState::new();
         state.set_host(host());
         state.refresh(&ops).await;

--- a/yoink/src/tui/hosts.rs
+++ b/yoink/src/tui/hosts.rs
@@ -173,8 +173,9 @@ impl HostsState {
                 HostStatus::Ok(_) => None,
             });
         let footer = match selected_error {
-            Some(err) => Paragraph::new(format!("⚠ {err}"))
-                .style(Style::default().fg(Color::Yellow)),
+            Some(err) => {
+                Paragraph::new(format!("⚠ {err}")).style(Style::default().fg(Color::Yellow))
+            }
             None => filter_footer(
                 &self.filter,
                 "q quit · ↑↓ select · enter detail · r refresh · ? help",
@@ -421,12 +422,12 @@ services:
         ops.push_container_stats(Ok(ContainerStats {
             cpu_pct: 50.0,
             mem_used: 100 * 1024 * 1024,
-            mem_limit: None,
+            ..Default::default()
         }));
         ops.push_container_stats(Ok(ContainerStats {
             cpu_pct: 25.0,
             mem_used: 200 * 1024 * 1024,
-            mem_limit: None,
+            ..Default::default()
         }));
         // host-b: version errors → no further calls expected
         ops.push_version(Err(DockerError::FakeExhausted("test")));

--- a/yoink/src/tui/mod.rs
+++ b/yoink/src/tui/mod.rs
@@ -9,6 +9,7 @@ mod host_detail;
 mod hosts;
 mod logs;
 mod progress;
+mod resources;
 mod secrets;
 mod services;
 mod shell;

--- a/yoink/src/tui/resources.rs
+++ b/yoink/src/tui/resources.rs
@@ -1,0 +1,595 @@
+//! Resources pane — per-host docker resource introspection. Three
+//! sub-tabs for the three resource families lazydocker exposes:
+//!
+//! - **Images**  (`i`) — every cached image across every host, with
+//!   tag list, size, and an "is this dangling?" hint. Actions: remove
+//!   one image (`d`), prune dangling (`P`), prune all unused (`A`).
+//! - **Volumes** (`v`) — named volumes with driver + mountpoint.
+//!   Actions: remove one (`d`), prune unused (`P`).
+//! - **Networks** (`n`) — user-defined networks with driver + scope.
+//!   Built-ins (`bridge`, `host`, `none`) appear but reject removal.
+//!   Actions: remove one (`d`), prune unused (`P`).
+//!
+//! Refreshes fan out across every configured host in parallel — same
+//! shape `Hosts` uses — so the pane converges in roughly one round-trip
+//! to the slowest daemon. Errors per host are surfaced as a footer line
+//! rather than blanking the table; last-known good rows stay rendered.
+
+use std::sync::Arc;
+
+use futures_util::future::join_all;
+use ratatui::Frame;
+use ratatui::layout::{Constraint, Rect};
+use ratatui::style::{Color, Modifier, Style};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Block, Borders, Cell, Paragraph, Row, Table, TableState, Tabs};
+
+use crate::config::Config;
+use crate::docker_ops::{DockerOps, Host, ImageInfo, NetworkInfo, VolumeInfo};
+use crate::output::{format_bytes, format_relative_time};
+
+use super::ui::{
+    FilterState, TABLE_HIGHLIGHT_SYMBOL, bold, clamp_selection, filter_footer, pane_layout,
+    table_highlight_style,
+};
+
+/// Which sub-tab inside `View::Resources` is active. `Tab` / `BackTab`
+/// (or direct letters `i` / `v` / `n`) cycles between them.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ResourceTab {
+    Images,
+    Volumes,
+    Networks,
+}
+
+impl ResourceTab {
+    pub fn next(self) -> Self {
+        match self {
+            Self::Images => Self::Volumes,
+            Self::Volumes => Self::Networks,
+            Self::Networks => Self::Images,
+        }
+    }
+
+    pub fn prev(self) -> Self {
+        match self {
+            Self::Images => Self::Networks,
+            Self::Volumes => Self::Images,
+            Self::Networks => Self::Volumes,
+        }
+    }
+
+    fn index(self) -> usize {
+        match self {
+            Self::Images => 0,
+            Self::Volumes => 1,
+            Self::Networks => 2,
+        }
+    }
+}
+
+/// One identifier the resources pane needs to know about. Used as the
+/// "what was I selected on" anchor for the kill/prune flows in `app.rs`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ResourceTarget {
+    pub host: Host,
+    pub kind: ResourceTab,
+    /// Image id / volume name / network name.
+    pub id: String,
+    /// Human display string for the confirmation modal.
+    pub label: String,
+}
+
+pub struct ResourcesRefresh {
+    pub images: Vec<(Host, Result<Vec<ImageInfo>, String>)>,
+    pub volumes: Vec<(Host, Result<Vec<VolumeInfo>, String>)>,
+    pub networks: Vec<(Host, Result<Vec<NetworkInfo>, String>)>,
+}
+
+#[derive(Default)]
+pub struct ResourcesState {
+    pub tab: Option<ResourceTab>,
+    images: Vec<ImageInfo>,
+    volumes: Vec<VolumeInfo>,
+    networks: Vec<NetworkInfo>,
+    /// Per-host fetch errors (one row per failing host), rendered as a
+    /// footer line under the table.
+    errors: Vec<String>,
+    images_table: TableState,
+    volumes_table: TableState,
+    networks_table: TableState,
+    loaded: bool,
+    pub filter: FilterState,
+}
+
+impl ResourcesState {
+    pub fn new() -> Self {
+        Self {
+            tab: Some(ResourceTab::Images),
+            ..Self::default()
+        }
+    }
+
+    pub fn current_tab(&self) -> ResourceTab {
+        self.tab.unwrap_or(ResourceTab::Images)
+    }
+
+    pub fn set_tab(&mut self, tab: ResourceTab) {
+        self.tab = Some(tab);
+    }
+
+    pub fn cycle_tab_forward(&mut self) {
+        let next = self.current_tab().next();
+        self.tab = Some(next);
+    }
+
+    pub fn cycle_tab_backward(&mut self) {
+        let prev = self.current_tab().prev();
+        self.tab = Some(prev);
+    }
+
+    pub fn select_next(&mut self) {
+        let n = self.visible_indices().len();
+        let table = self.active_table_mut();
+        if n == 0 {
+            return;
+        }
+        let i = table.selected().unwrap_or(0);
+        table.select(Some((i + 1).min(n - 1)));
+    }
+
+    pub fn select_prev(&mut self) {
+        if self.visible_indices().is_empty() {
+            return;
+        }
+        let table = self.active_table_mut();
+        let i = table.selected().unwrap_or(0);
+        table.select(Some(i.saturating_sub(1)));
+    }
+
+    fn active_table_mut(&mut self) -> &mut TableState {
+        match self.current_tab() {
+            ResourceTab::Images => &mut self.images_table,
+            ResourceTab::Volumes => &mut self.volumes_table,
+            ResourceTab::Networks => &mut self.networks_table,
+        }
+    }
+
+    fn active_table_selected(&self) -> Option<usize> {
+        let t = match self.current_tab() {
+            ResourceTab::Images => &self.images_table,
+            ResourceTab::Volumes => &self.volumes_table,
+            ResourceTab::Networks => &self.networks_table,
+        };
+        t.selected()
+    }
+
+    /// Indices into the active tab's source list passing the filter.
+    fn visible_indices(&self) -> Vec<usize> {
+        match self.current_tab() {
+            ResourceTab::Images => self
+                .images
+                .iter()
+                .enumerate()
+                .filter_map(|(i, img)| {
+                    let target = format!("{} {} {}", img.host, img.id, img.repo_tags.join(" "));
+                    self.filter.matches(&target).then_some(i)
+                })
+                .collect(),
+            ResourceTab::Volumes => self
+                .volumes
+                .iter()
+                .enumerate()
+                .filter_map(|(i, v)| {
+                    let target = format!("{} {} {}", v.host, v.name, v.driver);
+                    self.filter.matches(&target).then_some(i)
+                })
+                .collect(),
+            ResourceTab::Networks => self
+                .networks
+                .iter()
+                .enumerate()
+                .filter_map(|(i, n)| {
+                    let target = format!("{} {} {} {}", n.host, n.name, n.driver, n.scope);
+                    self.filter.matches(&target).then_some(i)
+                })
+                .collect(),
+        }
+    }
+
+    /// Currently-selected target on the active tab, if any. Returns
+    /// `None` for the synthetic local host when the row points at it
+    /// (we don't want operators pruning their laptop's docker by
+    /// accident from a remote-deploy TUI session).
+    pub fn selected_target(&self, config: &Config) -> Option<ResourceTarget> {
+        let visible = self.visible_indices();
+        let i = self.active_table_selected()?;
+        let src = *visible.get(i)?;
+        match self.current_tab() {
+            ResourceTab::Images => {
+                let img = self.images.get(src)?;
+                let host = host_for_address(config, &img.host)?;
+                let label = if let Some(tag) = img.repo_tags.first() {
+                    format!("{tag} ({})", img.id)
+                } else {
+                    img.id.clone()
+                };
+                let id = img
+                    .repo_tags
+                    .first()
+                    .filter(|t| t.as_str() != "<none>:<none>")
+                    .cloned()
+                    .unwrap_or_else(|| img.id.clone());
+                Some(ResourceTarget {
+                    host,
+                    kind: ResourceTab::Images,
+                    id,
+                    label,
+                })
+            }
+            ResourceTab::Volumes => {
+                let v = self.volumes.get(src)?;
+                let host = host_for_address(config, &v.host)?;
+                Some(ResourceTarget {
+                    host,
+                    kind: ResourceTab::Volumes,
+                    id: v.name.clone(),
+                    label: v.name.clone(),
+                })
+            }
+            ResourceTab::Networks => {
+                let n = self.networks.get(src)?;
+                let host = host_for_address(config, &n.host)?;
+                Some(ResourceTarget {
+                    host,
+                    kind: ResourceTab::Networks,
+                    id: n.name.clone(),
+                    label: n.name.clone(),
+                })
+            }
+        }
+    }
+
+    pub fn apply(&mut self, data: ResourcesRefresh) {
+        self.loaded = true;
+        let mut errors = Vec::new();
+        let mut images = Vec::new();
+        for (host, res) in data.images {
+            match res {
+                Ok(rows) => images.extend(rows),
+                Err(e) => errors.push(format!("images@{}: {e}", host.address)),
+            }
+        }
+        // Sort: dangling first (so prune candidates jump out), then by
+        // size descending — operators usually want to know "what's
+        // taking up space".
+        images.sort_by(|a, b| {
+            b.dangling
+                .cmp(&a.dangling)
+                .then_with(|| b.size_bytes.cmp(&a.size_bytes))
+        });
+        self.images = images;
+
+        let mut volumes = Vec::new();
+        for (host, res) in data.volumes {
+            match res {
+                Ok(rows) => volumes.extend(rows),
+                Err(e) => errors.push(format!("volumes@{}: {e}", host.address)),
+            }
+        }
+        volumes.sort_by(|a, b| a.host.cmp(&b.host).then_with(|| a.name.cmp(&b.name)));
+        self.volumes = volumes;
+
+        let mut networks = Vec::new();
+        for (host, res) in data.networks {
+            match res {
+                Ok(rows) => networks.extend(rows),
+                Err(e) => errors.push(format!("networks@{}: {e}", host.address)),
+            }
+        }
+        networks.sort_by(|a, b| a.host.cmp(&b.host).then_with(|| a.name.cmp(&b.name)));
+        self.networks = networks;
+
+        self.errors = errors;
+        clamp_selection(&mut self.images_table, self.images.len());
+        clamp_selection(&mut self.volumes_table, self.volumes.len());
+        clamp_selection(&mut self.networks_table, self.networks.len());
+    }
+
+    pub fn render(&mut self, frame: &mut Frame<'_>, area: Rect, _config: &Config) {
+        let layout = pane_layout(area);
+        let header = layout[0];
+        let body = layout[1];
+        let footer = layout[2];
+
+        // Tab bar rendered inline at the top of the pane (the global
+        // header tabs already mark "Resources" as the active section;
+        // this row shows which sub-tab is selected).
+        let tab_titles: Vec<Line<'_>> = ["Images", "Volumes", "Networks"]
+            .iter()
+            .map(|t| Line::from(*t))
+            .collect();
+        let tabs = Tabs::new(tab_titles)
+            .style(Style::default().fg(Color::White))
+            .highlight_style(
+                Style::default()
+                    .fg(Color::Cyan)
+                    .add_modifier(Modifier::BOLD | Modifier::REVERSED),
+            )
+            .divider(Span::styled(" │ ", Style::default().fg(Color::Gray)))
+            .select(self.current_tab().index());
+        frame.render_widget(tabs, header);
+
+        match self.current_tab() {
+            ResourceTab::Images => self.render_images(frame, body),
+            ResourceTab::Volumes => self.render_volumes(frame, body),
+            ResourceTab::Networks => self.render_networks(frame, body),
+        }
+
+        // Footer: filter line + per-tab help on the right.
+        let help = match self.current_tab() {
+            ResourceTab::Images => {
+                "Tab cycle · d remove · P prune dangling · A prune all · r refresh · ?"
+            }
+            ResourceTab::Volumes | ResourceTab::Networks => {
+                "Tab cycle · d remove · P prune unused · r refresh · ?"
+            }
+        };
+        frame.render_widget(filter_footer(&self.filter, help), footer);
+
+        // Per-host errors render *above* the footer as a faint red
+        // ribbon when present — same shape the dashboard uses for
+        // partial fetch failures.
+        if !self.errors.is_empty() && body.height > 2 {
+            let line = self.errors.join(" · ");
+            let err_area = Rect {
+                x: body.x,
+                y: body.y + body.height - 1,
+                width: body.width,
+                height: 1,
+            };
+            frame.render_widget(
+                Paragraph::new(line).style(Style::default().fg(Color::Red)),
+                err_area,
+            );
+        }
+    }
+
+    fn render_images(&mut self, frame: &mut Frame<'_>, area: Rect) {
+        let widths = [
+            Constraint::Length(16), // host
+            Constraint::Length(14), // id
+            Constraint::Length(10), // size
+            Constraint::Length(10), // age
+            Constraint::Length(10), // dangling
+            Constraint::Min(20),    // tags
+        ];
+        let visible = self.visible_indices();
+        clamp_selection(&mut self.images_table, visible.len());
+        let total = self.images.iter().map(|i| i.size_bytes).sum::<i64>();
+        let dangling_count = self.images.iter().filter(|i| i.dangling).count();
+
+        let rows: Vec<Row<'_>> = if !self.loaded {
+            vec![Row::new(vec![Cell::from("(loading…)")])]
+        } else if self.images.is_empty() {
+            vec![Row::new(vec![Cell::from("(no images cached on any host)")])]
+        } else if visible.is_empty() {
+            vec![Row::new(vec![Cell::from("(no rows match the filter)")])]
+        } else {
+            visible
+                .iter()
+                .filter_map(|i| self.images.get(*i))
+                .map(|img| {
+                    let host = img.host.clone();
+                    let id = img.id.clone();
+                    let size = format_bytes(img.size_bytes);
+                    let age = format_relative_time(img.created_unix);
+                    let dangling = if img.dangling { "yes" } else { "" };
+                    let dang_cell = if img.dangling {
+                        Cell::from(dangling).style(Style::default().fg(Color::Yellow))
+                    } else {
+                        Cell::from(dangling)
+                    };
+                    let tags = if img.repo_tags.is_empty() {
+                        "<none>".to_string()
+                    } else {
+                        img.repo_tags.join(", ")
+                    };
+                    Row::new(vec![
+                        Cell::from(host),
+                        Cell::from(id),
+                        Cell::from(size),
+                        Cell::from(age),
+                        dang_cell,
+                        Cell::from(tags),
+                    ])
+                })
+                .collect()
+        };
+
+        let title = format!(
+            " images · {} total · {} dangling · {} on disk ",
+            self.images.len(),
+            dangling_count,
+            format_bytes(total)
+        );
+        let block = Block::default().borders(Borders::ALL).title(title);
+        let table = Table::new(rows, widths)
+            .header(Row::new(vec![
+                Cell::from("host").style(bold()),
+                Cell::from("id").style(bold()),
+                Cell::from("size").style(bold()),
+                Cell::from("age").style(bold()),
+                Cell::from("dangling").style(bold()),
+                Cell::from("tags").style(bold()),
+            ]))
+            .row_highlight_style(table_highlight_style())
+            .highlight_symbol(TABLE_HIGHLIGHT_SYMBOL)
+            .block(block);
+        frame.render_stateful_widget(table, area, &mut self.images_table);
+    }
+
+    fn render_volumes(&mut self, frame: &mut Frame<'_>, area: Rect) {
+        let widths = [
+            Constraint::Length(16), // host
+            Constraint::Length(28), // name
+            Constraint::Length(10), // driver
+            Constraint::Min(30),    // mountpoint
+        ];
+        let visible = self.visible_indices();
+        clamp_selection(&mut self.volumes_table, visible.len());
+
+        let rows: Vec<Row<'_>> = if !self.loaded {
+            vec![Row::new(vec![Cell::from("(loading…)")])]
+        } else if self.volumes.is_empty() {
+            vec![Row::new(vec![Cell::from("(no volumes on any host)")])]
+        } else if visible.is_empty() {
+            vec![Row::new(vec![Cell::from("(no rows match the filter)")])]
+        } else {
+            visible
+                .iter()
+                .filter_map(|i| self.volumes.get(*i))
+                .map(|v| {
+                    Row::new(vec![
+                        Cell::from(v.host.clone()),
+                        Cell::from(v.name.clone()),
+                        Cell::from(v.driver.clone()),
+                        Cell::from(v.mountpoint.clone()),
+                    ])
+                })
+                .collect()
+        };
+
+        let block = Block::default()
+            .borders(Borders::ALL)
+            .title(format!(" volumes · {} total ", self.volumes.len()));
+        let table = Table::new(rows, widths)
+            .header(Row::new(vec![
+                Cell::from("host").style(bold()),
+                Cell::from("name").style(bold()),
+                Cell::from("driver").style(bold()),
+                Cell::from("mountpoint").style(bold()),
+            ]))
+            .row_highlight_style(table_highlight_style())
+            .highlight_symbol(TABLE_HIGHLIGHT_SYMBOL)
+            .block(block);
+        frame.render_stateful_widget(table, area, &mut self.volumes_table);
+    }
+
+    fn render_networks(&mut self, frame: &mut Frame<'_>, area: Rect) {
+        let widths = [
+            Constraint::Length(16), // host
+            Constraint::Length(28), // name
+            Constraint::Length(10), // driver
+            Constraint::Length(10), // scope
+            Constraint::Length(10), // internal
+        ];
+        let visible = self.visible_indices();
+        clamp_selection(&mut self.networks_table, visible.len());
+
+        let rows: Vec<Row<'_>> = if !self.loaded {
+            vec![Row::new(vec![Cell::from("(loading…)")])]
+        } else if self.networks.is_empty() {
+            vec![Row::new(vec![Cell::from("(no networks)")])]
+        } else if visible.is_empty() {
+            vec![Row::new(vec![Cell::from("(no rows match the filter)")])]
+        } else {
+            visible
+                .iter()
+                .filter_map(|i| self.networks.get(*i))
+                .map(|n| {
+                    Row::new(vec![
+                        Cell::from(n.host.clone()),
+                        Cell::from(n.name.clone()),
+                        Cell::from(n.driver.clone()),
+                        Cell::from(n.scope.clone()),
+                        Cell::from(if n.internal { "yes" } else { "" }),
+                    ])
+                })
+                .collect()
+        };
+
+        let block = Block::default()
+            .borders(Borders::ALL)
+            .title(format!(" networks · {} total ", self.networks.len()));
+        let table = Table::new(rows, widths)
+            .header(Row::new(vec![
+                Cell::from("host").style(bold()),
+                Cell::from("name").style(bold()),
+                Cell::from("driver").style(bold()),
+                Cell::from("scope").style(bold()),
+                Cell::from("internal").style(bold()),
+            ]))
+            .row_highlight_style(table_highlight_style())
+            .highlight_symbol(TABLE_HIGHLIGHT_SYMBOL)
+            .block(block);
+        frame.render_stateful_widget(table, area, &mut self.networks_table);
+    }
+}
+
+fn host_for_address(config: &Config, address: &str) -> Option<Host> {
+    config
+        .hosts
+        .iter()
+        .find(|h| h.address == address)
+        .map(Host::from)
+}
+
+/// Background-friendly fetch — fans out per-host across all three
+/// resource families in parallel. Errors per host land in the result
+/// vec as `Err(String)` so the pane can render partial successes.
+pub async fn fetch_owned(ops: Arc<dyn DockerOps>, config: Arc<Config>) -> ResourcesRefresh {
+    let hosts: Vec<Host> = config.hosts.iter().map(Host::from).collect();
+
+    // Three concurrent fan-outs, one per resource family.
+    let images_fut = {
+        let ops = ops.clone();
+        let hosts = hosts.clone();
+        async move {
+            let futs = hosts.into_iter().map(|host| {
+                let ops = ops.clone();
+                async move {
+                    let res = ops.list_images(&host).await.map_err(|e| e.to_string());
+                    (host, res)
+                }
+            });
+            join_all(futs).await
+        }
+    };
+    let volumes_fut = {
+        let ops = ops.clone();
+        let hosts = hosts.clone();
+        async move {
+            let futs = hosts.into_iter().map(|host| {
+                let ops = ops.clone();
+                async move {
+                    let res = ops.list_volumes(&host).await.map_err(|e| e.to_string());
+                    (host, res)
+                }
+            });
+            join_all(futs).await
+        }
+    };
+    let networks_fut = {
+        let ops = ops.clone();
+        let hosts = hosts.clone();
+        async move {
+            let futs = hosts.into_iter().map(|host| {
+                let ops = ops.clone();
+                async move {
+                    let res = ops.list_networks(&host).await.map_err(|e| e.to_string());
+                    (host, res)
+                }
+            });
+            join_all(futs).await
+        }
+    };
+
+    let (images, volumes, networks) =
+        futures_util::future::join3(images_fut, volumes_fut, networks_fut).await;
+    ResourcesRefresh {
+        images,
+        volumes,
+        networks,
+    }
+}


### PR DESCRIPTION
## Summary

Brings yoink's TUI up to lazydocker feature parity, retargeted at remote docker hosts instead of just the local daemon. Driven by the gaps the operator hits when something goes sideways on prod and the dashboard alone isn't enough.

### What's new

- **Resources pane (`R`)** — three sub-tabs covering Images / Volumes / Networks across every configured host. Per-row remove (`d`), per-tab prune (`P`, plus `A` for the aggressive all-unused image prune). Partial-host fetch errors surface as a red footer instead of blanking the table.
- **ContainerDetail** — 5-minute rolling history charts: CPU% + Mem% on the left (shared 0–100 axis, or absolute MB when memory is uncapped), net rx/tx rate on the right (derived from successive cumulative-bytes samples). `p` opens a `docker top` modal listing in-container processes, sized off the daemon-reported `ps` titles.
- **Container lifecycle** — `S` / `X` / `R` on HostDetail and ContainerDetail map to docker start / stop / restart with the standard 10s SIGTERM grace. Toasts on success/failure; the docker-events stream drives the immediate dashboard repaint.
- **HostDetail events panel** — per-host docker-events ring buffer (capped at 200) renders at the bottom of HostDetail when populated, newest-first, timestamped relative. Captures start / stop / die / kill / health-status / oom / restart on each daemon as they happen.
- **DockerOps additions** — `list_images` / `remove_image` / `prune_images`, `remove_volume` / `prune_volumes`, `remove_network` / `prune_networks`, `restart_container`, `top_container`. All have default trait impls so alt backends aren't forced to implement everything. `parse_stats` now also extracts net rx/tx, block io, and pids count.
- **Fleshed-out TUI docs** — every pane, every keybinding, a consistent-letter cheat sheet, and an explicit pointer to `!` / `D` (debug sidecar) as the distroless-friendly stand-in for "volume file browsing" (which we deliberately don't add — drop into the container with `D` instead).

Skipped per discussion: volume file browsing.

### What's deliberately consistent

| key | meaning everywhere |
|---|---|
| `j` `k` / `↑` `↓` | navigate |
| `enter` | drill in / confirm |
| `esc` | back / dismiss / clear filter |
| `/` | filter input |
| `r` | refresh |
| `!` / `D` | shell / debug sidecar |
| `i` | inspect |
| `K` / `S` / `X` / `R` | kill / start / stop / restart |
| `U` / `A` | reconcile this / all |
| `P` | prune |
| `?` | per-view help overlay |

Capital letters consistently mean destructive or expensive (kill, reconcile-all, prune-all-images, restart, …) and require y/Enter confirmation when state-changing.

## Test plan

- [ ] `task tui` against a real fleet — verify the new tabs render across multi-host hosts, dangling images sort first, prune flows complete cleanly.
- [ ] ContainerDetail history charts: confirm CPU/Mem renders in the first 2-3s, the 5-minute window slides correctly past the first-rotation point, and the net rx/tx panel produces reasonable rates (not the cumulative noise pattern).
- [ ] `p` from ContainerDetail returns a usable process table on glibc images and gracefully fails on distroless / scratch (where `ps` isn't present).
- [ ] `S` / `X` / `R` lifecycle keys: stop a running api container with `X`, watch the dashboard repaint via the events stream within ~1s, then `S` to bring it back.
- [ ] HostDetail events panel populates as you stop/start containers from another shell, capped at 200, newest-first.
- [ ] `R` enters Resources from any view; Tab/Shift-Tab cycles Images → Volumes → Networks; `i`/`v`/`n` jump directly.
- [ ] Existing flows still work: dashboard drift, kill/reconcile/reconcile-all/prune modals, secrets, embedded shell, debug sidecar.

`cargo clippy --all-targets -- -D warnings` clean. 222 tests pass.