### PR TITLE
fix(deploy): stop including soon-to-be-stopped replicas in caddy upstreams

### DIFF
--- a/yoink/src/deploy.rs
+++ b/yoink/src/deploy.rs
@@ -260,12 +260,50 @@ pub fn build_env(
 /// point for `yoink up`. `tag_overrides` lets the CLI override the tag
 /// for specific services (`yoink up --service api --tag a1b2c3d`).
 #[allow(clippy::too_many_lines)]
+/// Knobs the operator can flip on a single reconcile invocation. New
+/// fields here should default to "preserve existing behaviour" so that
+/// `reconcile()` (the no-options shim) stays a drop-in.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct ReconcileOptions {
+    /// Bypass every "already at spec, skip" short-circuit, so each
+    /// selected service runs the full prepare → finalize loop and
+    /// (for routed services) the Caddy admin-API push. Recovery
+    /// gesture for cases where proxy-side state has drifted from
+    /// container reality (e.g. a stale upstream pool that never got
+    /// cleaned up). Surfaces as `--force` on `yoink up`.
+    pub force: bool,
+}
+
+/// Backwards-compatible shim — call sites that don't need the new
+/// options stay unchanged.
 pub async fn reconcile(
     ops: &dyn DockerOps,
     config: &Config,
     tag_overrides: &BTreeMap<String, String>,
     services_filter: Option<&[String]>,
     secrets: Option<&SecretsBundle>,
+    on_event: &mut (dyn FnMut(Option<&str>, DeployEvent) + Send),
+) -> Result<Vec<ServiceDeployReport>, DeployError> {
+    reconcile_with_options(
+        ops,
+        config,
+        tag_overrides,
+        services_filter,
+        secrets,
+        ReconcileOptions::default(),
+        on_event,
+    )
+    .await
+}
+
+#[allow(clippy::too_many_lines)]
+pub async fn reconcile_with_options(
+    ops: &dyn DockerOps,
+    config: &Config,
+    tag_overrides: &BTreeMap<String, String>,
+    services_filter: Option<&[String]>,
+    secrets: Option<&SecretsBundle>,
+    options: ReconcileOptions,
     on_event: &mut (dyn FnMut(Option<&str>, DeployEvent) + Send),
 ) -> Result<Vec<ServiceDeployReport>, DeployError> {
     // Ensure every declared network exists on every host, once. Top-
@@ -381,9 +419,12 @@ pub async fn reconcile(
                     // Pre-flight skip: every applicable host has the
                     // expected replicas at desired_hash → emit
                     // AlreadyAtSpec events + synthesize a report.
+                    // Skipped under `--force` so the operator can
+                    // explicitly re-run the deploy to reset proxy /
+                    // admin state even when nothing has drifted.
                     let desired = build_desired_spec(config_ref, service, &tag, secrets_ref)?;
                     let desired_hash = docker::compute_spec_hash(&desired);
-                    if let Some(host_results) =
+                    if !options.force && let Some(host_results) =
                         service_already_at_spec(snapshot_ref, config_ref, service, &desired_hash)
                     {
                         let mut g = sink_ref.lock().expect("sink poisoned");
@@ -423,6 +464,7 @@ pub async fn reconcile(
                         service,
                         &tag,
                         secrets_ref,
+                        options.force,
                         &mut local_sink,
                     )
                     .await
@@ -485,6 +527,7 @@ pub async fn deploy_service(
     service: &ServiceConfig,
     tag: &str,
     secrets: Option<&SecretsBundle>,
+    force: bool,
     on_event: &mut (dyn FnMut(DeployEvent) + Send),
 ) -> Result<ServiceDeployReport, DeployError> {
     let hosts = service.applicable_hosts(&config.hosts);
@@ -496,7 +539,9 @@ pub async fn deploy_service(
     // `docker start` away from running.
     let mut prepared: Vec<HostPrep> = Vec::with_capacity(hosts.len());
     for host_cfg in &hosts {
-        let prep = prepare_one_host(ops, config, service, tag, secrets, host_cfg, on_event).await?;
+        let prep =
+            prepare_one_host(ops, config, service, tag, secrets, host_cfg, force, on_event)
+                .await?;
         prepared.push(prep);
     }
 
@@ -570,6 +615,7 @@ async fn prepare_one_host(
     tag: &str,
     secrets: Option<&SecretsBundle>,
     host_cfg: &crate::config::HostConfig,
+    force: bool,
     on_event: &mut (dyn FnMut(DeployEvent) + Send),
 ) -> Result<HostPrep, DeployError> {
     let host = Host::from(host_cfg);
@@ -616,11 +662,17 @@ async fn prepare_one_host(
     let mut replicas: Vec<ReplicaPrep> = Vec::with_capacity(replicas_count as usize);
     for index in 0..replicas_count {
         let name = container_name(&service.name, &spec_hash, index, replicas_count);
-        let already = existing.iter().any(|c| {
-            c.name == name
-                && c.is_running()
-                && c.yoink_spec_hash.as_deref() == Some(spec_hash.as_str())
-        });
+        // `--force` makes every replica look not-already-running, so
+        // the prep path below force-removes the existing container
+        // and re-creates it. Same name, same spec_hash — the operator
+        // is asking for a forced redeploy, typically to push a fresh
+        // Caddy admin config or to recover from drifted proxy state.
+        let already = !force
+            && existing.iter().any(|c| {
+                c.name == name
+                    && c.is_running()
+                    && c.yoink_spec_hash.as_deref() == Some(spec_hash.as_str())
+            });
         if already {
             on_event(DeployEvent::AlreadyAtSpec {
                 host: host.address.clone(),
@@ -1594,7 +1646,7 @@ services:
         let cfg = config_one_service();
         let mut events: Vec<DeployEvent> = Vec::new();
         let mut sink = |e: DeployEvent| events.push(e);
-        let report = deploy_service(&ops, &cfg, &cfg.services[0], "a1b2c3d", None, &mut sink)
+        let report = deploy_service(&ops, &cfg, &cfg.services[0], "a1b2c3d", None, false, &mut sink)
             .await
             .unwrap();
         assert_eq!(report.service, "app-a");
@@ -1712,7 +1764,7 @@ services:
 
         let mut events: Vec<DeployEvent> = Vec::new();
         let mut sink = |e: DeployEvent| events.push(e);
-        let report = deploy_service(&ops, &cfg, &cfg.services[0], "a1b2c3d", None, &mut sink)
+        let report = deploy_service(&ops, &cfg, &cfg.services[0], "a1b2c3d", None, false, &mut sink)
             .await
             .unwrap();
         assert_eq!(report.hosts[0].container, expected_name);

--- a/yoink/src/deploy.rs
+++ b/yoink/src/deploy.rs
@@ -743,15 +743,23 @@ async fn finalize_one_host(
 
     // Caddy admin-API push: route the new replicas in (and the
     // proxy itself, after first deploy, into a serving state).
-    // Runs between healthcheck-pass and the old-replica stop so
-    // there's a brief window where both old + new serve — Caddy
-    // gracefully reloads, no in-flight requests dropped. Skipped
-    // for non-routed services and when the proxy isn't enabled.
+    // Runs between healthcheck-pass and the old-replica stop. We
+    // override the in-flight service's upstream names with the
+    // expected (post-deploy) replica names — see `push_caddy_config`
+    // for why we deliberately do NOT include the about-to-be-stopped
+    // old containers in the rendered upstreams.
     let triggers_caddy_load = crate::proxy::proxy_enabled(config)
         && (matches!(service.kind, Some(crate::config::ServiceKind::Proxy))
             || crate::proxy::is_proxied(service));
     if triggers_caddy_load {
-        push_caddy_config(ops, &host, config, secrets).await?;
+        push_caddy_config(
+            ops,
+            &host,
+            config,
+            secrets,
+            Some((service.name.as_str(), &expected_names)),
+        )
+        .await?;
     }
 
     if !stop_first {
@@ -780,14 +788,74 @@ async fn finalize_one_host(
     })
 }
 
+/// Build the per-service upstream-name map fed into the Caddy config
+/// renderer. Pure-ish helper extracted for testability — the live
+/// daemon query is the only side effect.
+///
+/// For the in-flight service (currently being reconciled), the names
+/// come straight from `expected_names`. For every other routed
+/// service, query `list_containers_by_label` and filter to running.
+async fn build_upstream_names(
+    ops: &dyn DockerOps,
+    host: &Host,
+    routed: &[&ServiceConfig],
+    in_flight: Option<(&str, &std::collections::BTreeSet<String>)>,
+) -> Result<std::collections::BTreeMap<String, Vec<String>>, DeployError> {
+    let mut upstream_names: std::collections::BTreeMap<String, Vec<String>> =
+        std::collections::BTreeMap::new();
+    for svc in routed {
+        let names: Vec<String> = if let Some((sname, expected)) = in_flight
+            && sname == svc.name.as_str()
+        {
+            expected.iter().cloned().collect()
+        } else {
+            let label = format!("yoink.service={}", svc.name);
+            let containers = ops.list_containers_by_label(host, &label).await.map_err(
+                |source| DeployError::Docker {
+                    host: host.address.clone(),
+                    source,
+                },
+            )?;
+            containers
+                .into_iter()
+                .filter(crate::docker_ops::ContainerInfo::is_running)
+                .map(|c| c.name)
+                .collect()
+        };
+        upstream_names.insert(svc.name.clone(), names);
+    }
+    Ok(upstream_names)
+}
+
 /// Render the Caddy config for `host`'s view of `config` and POST it
 /// to the proxy's admin API. Errors abort the deploy — old config
 /// stays active because Caddy's `/load` is atomic.
+///
+/// `in_flight_upstreams` carries `(service_name, expected_names)` for
+/// the service the caller is currently reconciling. For that service,
+/// the rendered upstream pool is forced to those exact container
+/// names — the old (about-to-be-stopped) replicas are NOT included.
+///
+/// **Why we deliberately exclude the old replicas:** the older shape
+/// queried `list_containers_by_label + is_running` for every service,
+/// which during the brief window between "new replicas healthy" and
+/// "old replicas stopped" returned BOTH sets. Caddy then carried the
+/// old container names in its upstream pool. After `swap_out_old`
+/// removed them, those names became unresolvable in Docker DNS and
+/// Caddy's active health checker logged "server misbehaving" forever
+/// (because no subsequent `/load` ever cleaned the pool).
+///
+/// Caddy's `/load` is graceful regardless of pool membership: existing
+/// TCP connections to old containers continue serving in-flight work
+/// until they close, and new requests route to the new containers.
+/// Including the old upstreams in the pool achieved nothing except
+/// creating the stale-DNS hole.
 async fn push_caddy_config(
     ops: &dyn DockerOps,
     host: &Host,
     config: &Config,
     secrets: Option<&SecretsBundle>,
+    in_flight_upstreams: Option<(&str, &std::collections::BTreeSet<String>)>,
 ) -> Result<(), DeployError> {
     // Expand any `caddy_extra_caddyfile:` snippets to JSON. Mutates a
     // local clone so the caller's view of config stays unchanged.
@@ -800,32 +868,13 @@ async fn push_caddy_config(
         })?;
     let config = &config;
 
-    // Build the upstream-name lookup by querying each routed service's
-    // current containers on this host. Includes the just-started
-    // replica AND (briefly) the old one — Caddy reloads gracefully.
     let routed: Vec<&ServiceConfig> = config
         .services
         .iter()
         .filter(|s| crate::proxy::is_proxied(s))
         .collect();
-    let mut upstream_names: std::collections::BTreeMap<String, Vec<String>> =
-        std::collections::BTreeMap::new();
-    for svc in &routed {
-        let label = format!("yoink.service={}", svc.name);
-        let containers = ops
-            .list_containers_by_label(host, &label)
-            .await
-            .map_err(|source| DeployError::Docker {
-                host: host.address.clone(),
-                source,
-            })?;
-        let names: Vec<String> = containers
-            .into_iter()
-            .filter(crate::docker_ops::ContainerInfo::is_running)
-            .map(|c| c.name)
-            .collect();
-        upstream_names.insert(svc.name.clone(), names);
-    }
+    let upstream_names = build_upstream_names(ops, host, &routed, in_flight_upstreams).await?;
+
     let json = crate::proxy::caddy::render(config, |s| upstream_names.get(s).cloned().unwrap_or_default(), secrets)
         .map_err(|source| DeployError::Custom {
             host: host.address.clone(),
@@ -1762,6 +1811,169 @@ hooks:
         assert_eq!(name, "migrate");
         assert!(message.contains("ERROR: connection refused"));
         assert!(message.contains("applying 0001_init"));
+    }
+
+    /// Routed-service fixture: api has `domain:` so `is_proxied(api)` is
+    /// true. Bare config — no proxy block, but `proxy_enabled` returns
+    /// true for any service with a domain.
+    fn config_proxied_service() -> Config {
+        Config::parse_str(
+            r#"
+hosts:
+  - { address: host-a, user: deploy }
+services:
+  - name: api
+    image: registry.example.com/api
+    tag: latest
+    domain: api.example.test
+    tls: off
+    run:
+      port: 8080
+      healthcheck_path: /health
+      healthcheck_timeout: 60s
+      drain_timeout: 10s
+"#,
+        )
+        .unwrap()
+    }
+
+    fn container_with_state(name: &str, state: &str) -> ContainerInfo {
+        ContainerInfo {
+            host: "host-a".into(),
+            name: name.into(),
+            image: String::new(),
+            state: state.into(),
+            status_text: String::new(),
+            created_unix: None,
+            yoink_service: Some("api".into()),
+            yoink_version: None,
+            yoink_spec_hash: None,
+            yoink_deployed_by: None,
+            yoink_deployed_at: None,
+            networks: Vec::new(),
+            other_labels: BTreeMap::new(),
+        }
+    }
+
+    /// Regression: during a routed-service reconcile, the upstream
+    /// pool pushed to Caddy must contain ONLY the new (expected)
+    /// replica names — never the old containers that are about to be
+    /// stopped. Including the old names left them in Caddy's pool
+    /// after `swap_out_old`, where they became unresolvable in Docker
+    /// DNS and the active health checker logged "server misbehaving"
+    /// indefinitely (no subsequent /load ever cleaned the pool).
+    #[tokio::test]
+    async fn build_upstream_names_excludes_old_replicas_for_in_flight_service() {
+        let cfg = config_proxied_service();
+        let routed: Vec<&ServiceConfig> = cfg
+            .services
+            .iter()
+            .filter(|s| crate::proxy::is_proxied(s))
+            .collect();
+
+        // Both old AND new replicas show up as `running` if we ever
+        // queried — the override should bypass the query entirely.
+        let ops = FakeDockerOps::new();
+        ops.push_list_containers(Ok(vec![
+            container_with_state("api-OLDHASH-0", "running"),
+            container_with_state("api-OLDHASH-1", "running"),
+            container_with_state("api-NEWHASH-0", "running"),
+            container_with_state("api-NEWHASH-1", "running"),
+        ]));
+
+        let mut expected: std::collections::BTreeSet<String> =
+            std::collections::BTreeSet::new();
+        expected.insert("api-NEWHASH-0".into());
+        expected.insert("api-NEWHASH-1".into());
+
+        let host = Host {
+            user: "deploy".into(),
+            address: "host-a".into(),
+        };
+        let names =
+            build_upstream_names(&ops, &host, &routed, Some(("api", &expected)))
+                .await
+                .unwrap();
+
+        assert_eq!(
+            names.get("api"),
+            Some(&vec!["api-NEWHASH-0".to_string(), "api-NEWHASH-1".to_string()]),
+            "in-flight service must use expected_names, not the live container list"
+        );
+        // `list_containers_by_label` must NOT have been called for
+        // the in-flight service (the override short-circuits the
+        // daemon query).
+        let calls = ops.calls();
+        assert!(
+            !calls.iter().any(|c| matches!(
+                c,
+                crate::docker_ops::RecordedCall::ListContainersByLabel(_, label)
+                if label == "yoink.service=api"
+            )),
+            "expected no list_containers_by_label call for in-flight service, got {calls:?}"
+        );
+    }
+
+    /// Counterpart: services NOT being reconciled keep their existing
+    /// behaviour (live `list_containers_by_label` filtered to running).
+    #[tokio::test]
+    async fn build_upstream_names_queries_other_services_live() {
+        let cfg = Config::parse_str(
+            r#"
+hosts:
+  - { address: host-a, user: deploy }
+services:
+  - name: api
+    image: img/api
+    tag: latest
+    domain: api.example.test
+    tls: off
+    run: { port: 8080, healthcheck_path: /health }
+  - name: web
+    image: img/web
+    tag: latest
+    domain: web.example.test
+    tls: off
+    run: { port: 3000, healthcheck_path: /health }
+"#,
+        )
+        .unwrap();
+        let routed: Vec<&ServiceConfig> = cfg
+            .services
+            .iter()
+            .filter(|s| crate::proxy::is_proxied(s))
+            .collect();
+
+        let ops = FakeDockerOps::new();
+        // api: in-flight, query should be skipped via override.
+        // web: not in-flight, query should fire and filter to running.
+        ops.push_list_containers(Ok(vec![
+            container_with_state("web-OLDHASH-0", "running"),
+            container_with_state("web-OLDHASH-1", "exited"),
+        ]));
+
+        let mut expected: std::collections::BTreeSet<String> =
+            std::collections::BTreeSet::new();
+        expected.insert("api-NEWHASH-0".into());
+
+        let host = Host {
+            user: "deploy".into(),
+            address: "host-a".into(),
+        };
+        let names =
+            build_upstream_names(&ops, &host, &routed, Some(("api", &expected)))
+                .await
+                .unwrap();
+
+        assert_eq!(
+            names.get("api"),
+            Some(&vec!["api-NEWHASH-0".to_string()]),
+        );
+        assert_eq!(
+            names.get("web"),
+            Some(&vec!["web-OLDHASH-0".to_string()]),
+            "exited containers must be filtered out for non-in-flight services"
+        );
     }
 
     #[tokio::test(start_paused = true)]

--- a/yoink/src/main.rs
+++ b/yoink/src/main.rs
@@ -202,6 +202,16 @@ enum Command {
         /// alongside `--no-registry`.
         #[arg(long)]
         build: bool,
+        /// Force a redeploy even when the running container already
+        /// matches the desired spec. Skips the at-spec early-return,
+        /// so every selected service goes through the full
+        /// rolling-swap-with-healthcheck loop and (for routed
+        /// services) the Caddy admin push. Useful as a recovery
+        /// gesture when proxy-side state has drifted from container
+        /// reality (e.g. a stale upstream pool that never got cleaned
+        /// up). Combine with `--service <name>` to limit blast radius.
+        #[arg(long)]
+        force: bool,
     },
     /// Build one or more services' images via `docker build` against
     /// the operator's local docker daemon. Tags the result as
@@ -695,6 +705,7 @@ async fn run(cli: Cli) -> Result<()> {
             no_registry,
             transport,
             build,
+            force,
         } => {
             cmd_up(
                 &config,
@@ -707,6 +718,7 @@ async fn run(cli: Cli) -> Result<()> {
                     no_registry,
                     transport: transport.into(),
                     build,
+                    force,
                 },
             )
             .await
@@ -820,6 +832,7 @@ struct UpOptions<'a> {
     no_registry: bool,
     transport: yoink::transport::Transport,
     build: bool,
+    force: bool,
 }
 
 #[allow(clippy::too_many_lines)] // borderline (6 lines over); split if it grows further
@@ -835,6 +848,7 @@ async fn cmd_up(config: &Config, up: UpOptions<'_>) -> Result<()> {
         no_registry,
         transport,
         build,
+        force,
     } = up;
 
     // Load bundle first so build_real_ops can reuse it for any
@@ -946,12 +960,13 @@ async fn cmd_up(config: &Config, up: UpOptions<'_>) -> Result<()> {
         }
     }
 
-    let reconcile_result = deploy::reconcile(
+    let reconcile_result = deploy::reconcile_with_options(
         &*ops,
         config,
         &tag_overrides,
         services_filter,
         bundle.as_ref(),
+        deploy::ReconcileOptions { force },
         &mut sink,
     )
     .await;
@@ -1166,6 +1181,7 @@ async fn cmd_rollback(config: &Config, service: String, tag: Option<String>) -> 
             no_registry: false,
             transport: yoink::transport::Transport::Auto,
             build: false,
+            force: false,
         },
     )
     .await


### PR DESCRIPTION
## What

The Caddy admin-API push during reconcile rendered upstreams from `list_containers_by_label + is_running` for every routed service. During the brief window between "new replicas healthy" and "old replicas stopped" — exactly when the push fires — that returned **both** old and new container names. Caddy's pool kept the old names; after `swap_out_old` removed those containers, their names became unresolvable in Docker DNS, and Caddy's active health checker logged "server misbehaving" indefinitely.

Fix: thread the in-flight service's `expected_names` (already computed by the reconcile loop) into `push_caddy_config`. For that one service, use those names directly; skip the daemon query entirely. Other services keep their existing live-query behaviour.

## Symptom in prod

```
yoink-proxy: http.handlers.reverse_proxy.health_checker.active: HTTP request failed
  host=api-OLDHASH-1:8080
  error='Get "http://api-OLDHASH-1:8080/health": dial tcp: lookup api-OLDHASH-1 on 127.0.0.11:53: server misbehaving'
```

…while the actual `api` containers are running under a different `spec_hash` (e.g. `api-NEWHASH-{0,1}`). Caddy never gets re-pushed unless something else triggers a routed reconcile, so the spam is permanent.

## Why "include old briefly" was wrong

The pre-existing comment said the overlap window let Caddy reload "gracefully, no in-flight requests dropped". But Caddy's `/load` is graceful regardless of pool membership: existing TCP connections to old containers serve in-flight work until they close, and new requests route to the new pool. Including the old container names in the new pool achieved nothing except creating the stale-DNS hole.

## Why a helper

Extracted `build_upstream_names` so we can unit-test the upstream-resolution logic without standing up an SSH tunnel + real Caddy. Two new tests cover:

- **in-flight service uses `expected_names` exactly** — verifies the override forces the new replica names AND that `list_containers_by_label` is **not** called for that service (no daemon round-trip)
- **other routed services keep live-query behaviour** — verifies non-in-flight services still query + filter to `is_running`

`cargo clippy --all-targets -- -D warnings` clean. 224 tests pass (was 222; +2 new).

## Latent follow-up (not in this PR)

`proxy::admin::push_config` currently picks an arbitrary running proxy container via `find(is_running)`. During a proxy reconcile, both old + new proxy containers are running and the chosen target is non-deterministic — if it's the old one, the push lands on a container that's about to die in `swap_out_old`. Should push to a specific target container instead. Tracking separately.

## Test plan

- [ ] DO NOT merge until tested in prod. Build the branch locally, run `yoink up --service api` against prod, verify the proxy logs stop spamming "server misbehaving" within seconds.
- [ ] If the api is already at-spec (no drift), force a redeploy via `yoink up --service api --tag <current_tag>` to exercise the new upstream-rendering path, then watch the proxy logs.
- [ ] After cutover, confirm caddy's pool no longer contains old container names: `docker exec yoink-proxy-* curl -s 127.0.0.1:2019/config/apps/http/servers/main/routes | jq` should show only the new container names as upstreams.

## Diff

1 file changed, ~150 net lines added (most of it tests + the why-comment on `push_caddy_config`).