### PR TITLE
fix: post-release sweep — 8 critical/high-sev bugs from deep review

### DIFF
--- a/yoink/src/deploy.rs
+++ b/yoink/src/deploy.rs
@@ -552,15 +552,9 @@ pub async fn deploy_service(
     // gap between schema migration and runtime container start as
     // close to zero as possible. `--service` filtering skips the
     // service and its hooks together (`yoink up --service api` will
-    // not run web's migrations).
-    //
-    // On hook failure we force-remove every pre-created (pending)
-    // replica before propagating the error. Without this, a failed
-    // migration leaves N×hosts `created`-state containers cluttering
-    // `docker ps -a` until the next reconcile / `yoink prune` reaps
-    // them; the next reconcile RE-creates them anyway via
-    // `force_remove_name`, but the operator-visible noise is
-    // confusing.
+    // not run web's migrations). On hook failure we clean up the
+    // pre-created replicas so a failed deploy doesn't leave
+    // `created`-state containers hanging around until the next prune.
     for hook in &service.pre_deploy {
         let hook_tag = resolve_hook_tag(hook, &BTreeMap::new(), &config.services);
         let resolved_tag = if matches!(hook.tag, HookTag::Ref { .. }) {
@@ -1267,23 +1261,19 @@ async fn force_remove_name(ops: &dyn DockerOps, host: &Host, name: &str) {
     }
 }
 
-/// Best-effort cleanup of pre-created (pending) containers. Called when
-/// a service's pre-deploy hook fails, so the half-prepared deploy
-/// doesn't leave N×hosts `created`-state containers cluttering
-/// `docker ps -a` until the next reconcile or `yoink prune`. Each
-/// removal is idempotent (404 = already gone); failures are logged
-/// but don't mask the original hook error.
+/// Best-effort cleanup of pre-created (pending) containers after a
+/// pre-deploy hook fails — fanned out across hosts × replicas so
+/// recovery isn't gated on N×M serial round-trips. Idempotent (404 =
+/// already gone); errors are logged inside `force_remove_name` and
+/// never mask the original hook error.
 async fn cleanup_prepared_replicas(ops: &dyn DockerOps, prepared: &[HostPrep]) {
-    for prep in prepared {
-        for replica in &prep.replicas {
-            if replica.already_running {
-                // Pre-existing container already at spec; not ours to
-                // remove on hook failure.
-                continue;
-            }
-            force_remove_name(ops, &prep.host, &replica.name).await;
-        }
-    }
+    let futs = prepared.iter().flat_map(|prep| {
+        prep.replicas
+            .iter()
+            .filter(|r| !r.already_running)
+            .map(move |r| force_remove_name(ops, &prep.host, &r.name))
+    });
+    futures_util::future::join_all(futs).await;
 }
 
 /// Create the new container in `created` state but do not start it.

--- a/yoink/src/deploy.rs
+++ b/yoink/src/deploy.rs
@@ -553,6 +553,14 @@ pub async fn deploy_service(
     // close to zero as possible. `--service` filtering skips the
     // service and its hooks together (`yoink up --service api` will
     // not run web's migrations).
+    //
+    // On hook failure we force-remove every pre-created (pending)
+    // replica before propagating the error. Without this, a failed
+    // migration leaves N×hosts `created`-state containers cluttering
+    // `docker ps -a` until the next reconcile / `yoink prune` reaps
+    // them; the next reconcile RE-creates them anyway via
+    // `force_remove_name`, but the operator-visible noise is
+    // confusing.
     for hook in &service.pre_deploy {
         let hook_tag = resolve_hook_tag(hook, &BTreeMap::new(), &config.services);
         let resolved_tag = if matches!(hook.tag, HookTag::Ref { .. }) {
@@ -565,7 +573,10 @@ pub async fn deploy_service(
         on_event(DeployEvent::HookStarted {
             name: hook.name.clone(),
         });
-        run_hook(ops, config, hook, &resolved_tag, secrets).await?;
+        if let Err(e) = run_hook(ops, config, hook, &resolved_tag, secrets).await {
+            cleanup_prepared_replicas(ops, &prepared).await;
+            return Err(e);
+        }
         on_event(DeployEvent::HookFinished {
             name: hook.name.clone(),
         });
@@ -1253,6 +1264,25 @@ async fn list_existing_containers(
 async fn force_remove_name(ops: &dyn DockerOps, host: &Host, name: &str) {
     if let Err(e) = ops.force_remove_container(host, name).await {
         warn!(host = %host.address, container = %name, error = %e, "force_remove_container failed; continuing");
+    }
+}
+
+/// Best-effort cleanup of pre-created (pending) containers. Called when
+/// a service's pre-deploy hook fails, so the half-prepared deploy
+/// doesn't leave N×hosts `created`-state containers cluttering
+/// `docker ps -a` until the next reconcile or `yoink prune`. Each
+/// removal is idempotent (404 = already gone); failures are logged
+/// but don't mask the original hook error.
+async fn cleanup_prepared_replicas(ops: &dyn DockerOps, prepared: &[HostPrep]) {
+    for prep in prepared {
+        for replica in &prep.replicas {
+            if replica.already_running {
+                // Pre-existing container already at spec; not ours to
+                // remove on hook failure.
+                continue;
+            }
+            force_remove_name(ops, &prep.host, &replica.name).await;
+        }
     }
 }
 

--- a/yoink/src/proxy/admin.rs
+++ b/yoink/src/proxy/admin.rs
@@ -120,24 +120,22 @@ pub async fn push_config(
         .map_err(|source| AdminError::Http { source })?;
     if !resp.status().is_success() {
         let status = resp.status();
-        let body = resp.text().await.unwrap_or_default();
-        // Caddy's /load response body usually carries only its own
-        // error message, but parser errors can echo a slice of the
-        // submitted JSON — which contains inline `tls.certificates.
-        // load_pem` entries with full PEM-encoded cert + key. Strip
-        // PEM blocks before propagating, since this error string
-        // ends up in CLI stderr / tracing logs / TUI toasts.
-        let body = redact_pem_blocks(&body);
+        // Caddy parser errors can echo a slice of the submitted JSON,
+        // which carries inline cert+key PEMs from
+        // `tls.certificates.load_pem`. Strip them before the error
+        // lands in stderr / tracing / TUI toasts.
+        let body = redact_pem_blocks(&resp.text().await.unwrap_or_default());
         return Err(AdminError::LoadRejected { status, body });
     }
     drop(tunnel);
     Ok(())
 }
 
-/// Replace every `-----BEGIN <kind>-----` … `-----END <kind>-----`
-/// block (and its escape-encoded `\n` JSON variant) with a placeholder.
-/// Keeps the surrounding error context legible while ensuring no
-/// secret material survives in a logged error string.
+const REDACTED_PEM: &str = "<redacted PEM>";
+
+/// Replace `-----BEGIN <kind>----- … -----END <kind>-----` regions
+/// with a placeholder; an unterminated BEGIN is over-redacted to the
+/// end of the body (better than leaking).
 fn redact_pem_blocks(body: &str) -> String {
     let mut out = String::with_capacity(body.len());
     let mut rest = body;
@@ -148,23 +146,16 @@ fn redact_pem_blocks(body: &str) -> String {
         };
         out.push_str(&rest[..begin_pos]);
         let after_begin = &rest[begin_pos..];
-        // Find the matching END marker (Caddy may emit literal newlines
-        // OR JSON-escaped \n; END marker shape is the same in both).
-        if let Some(end_marker_pos) = after_begin.find("-----END ") {
-            // Skip past the trailing five dashes after the END label.
-            let tail = &after_begin[end_marker_pos..];
-            let after_end_label = match tail.find("-----") {
-                Some(idx) => idx + "-----".len(),
-                None => after_begin.len(),
-            };
-            out.push_str("<redacted PEM>");
-            rest = &after_begin[end_marker_pos + after_end_label..];
-        } else {
-            // Unterminated PEM — replace everything from BEGIN to end
-            // of body. Better to over-redact than to leak.
-            out.push_str("<redacted PEM>");
+        let Some(end_marker_pos) = after_begin.find("-----END ") else {
+            out.push_str(REDACTED_PEM);
             return out;
-        }
+        };
+        let tail = &after_begin[end_marker_pos..];
+        let after_end_label = tail
+            .find("-----")
+            .map_or(after_begin.len(), |idx| idx + "-----".len());
+        out.push_str(REDACTED_PEM);
+        rest = &after_begin[end_marker_pos + after_end_label..];
     }
 }
 

--- a/yoink/src/proxy/admin.rs
+++ b/yoink/src/proxy/admin.rs
@@ -121,10 +121,51 @@ pub async fn push_config(
     if !resp.status().is_success() {
         let status = resp.status();
         let body = resp.text().await.unwrap_or_default();
+        // Caddy's /load response body usually carries only its own
+        // error message, but parser errors can echo a slice of the
+        // submitted JSON — which contains inline `tls.certificates.
+        // load_pem` entries with full PEM-encoded cert + key. Strip
+        // PEM blocks before propagating, since this error string
+        // ends up in CLI stderr / tracing logs / TUI toasts.
+        let body = redact_pem_blocks(&body);
         return Err(AdminError::LoadRejected { status, body });
     }
     drop(tunnel);
     Ok(())
+}
+
+/// Replace every `-----BEGIN <kind>-----` … `-----END <kind>-----`
+/// block (and its escape-encoded `\n` JSON variant) with a placeholder.
+/// Keeps the surrounding error context legible while ensuring no
+/// secret material survives in a logged error string.
+fn redact_pem_blocks(body: &str) -> String {
+    let mut out = String::with_capacity(body.len());
+    let mut rest = body;
+    loop {
+        let Some(begin_pos) = rest.find("-----BEGIN ") else {
+            out.push_str(rest);
+            return out;
+        };
+        out.push_str(&rest[..begin_pos]);
+        let after_begin = &rest[begin_pos..];
+        // Find the matching END marker (Caddy may emit literal newlines
+        // OR JSON-escaped \n; END marker shape is the same in both).
+        if let Some(end_marker_pos) = after_begin.find("-----END ") {
+            // Skip past the trailing five dashes after the END label.
+            let tail = &after_begin[end_marker_pos..];
+            let after_end_label = match tail.find("-----") {
+                Some(idx) => idx + "-----".len(),
+                None => after_begin.len(),
+            };
+            out.push_str("<redacted PEM>");
+            rest = &after_begin[end_marker_pos + after_end_label..];
+        } else {
+            // Unterminated PEM — replace everything from BEGIN to end
+            // of body. Better to over-redact than to leak.
+            out.push_str("<redacted PEM>");
+            return out;
+        }
+    }
 }
 
 async fn wait_until_ready(local_port: u16, timeout: Duration) -> Result<(), AdminError> {
@@ -142,6 +183,34 @@ async fn wait_until_ready(local_port: u16, timeout: Duration) -> Result<(), Admi
             return Err(AdminError::NotReady { timeout });
         }
         tokio::time::sleep(Duration::from_millis(150)).await;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn redact_strips_full_pem_blocks() {
+        let body = "json error at offset 42: -----BEGIN CERTIFICATE-----\nABCDEF\n-----END CERTIFICATE-----\n more context";
+        let out = redact_pem_blocks(body);
+        assert!(out.contains("<redacted PEM>"));
+        assert!(!out.contains("ABCDEF"));
+        assert!(out.contains("more context"));
+    }
+
+    #[test]
+    fn redact_handles_unterminated_pem() {
+        let body = "load failed: -----BEGIN PRIVATE KEY-----\nMIIabc... (truncated)";
+        let out = redact_pem_blocks(body);
+        assert!(out.contains("<redacted PEM>"));
+        assert!(!out.contains("MIIabc"));
+    }
+
+    #[test]
+    fn redact_passthrough_when_no_pem() {
+        let body = r#"{"error":"unknown directive 'foo'"}"#;
+        assert_eq!(redact_pem_blocks(body), body);
     }
 }
 

--- a/yoink/src/tui/app.rs
+++ b/yoink/src/tui/app.rs
@@ -533,6 +533,17 @@ pub async fn run(
         tracing::info!("hl not on PATH; using raw log forwarder");
     }
     let mut terminal = setup_terminal(mouse).context("setup terminal")?;
+    // Panic hook: a panic anywhere in render or event handling unwinds
+    // straight past `restore_terminal`, leaving the operator stuck in
+    // raw mode + alternate screen until they `reset` (or kill the
+    // terminal). Hook restores the terminal first, then chains to the
+    // previous hook so the panic message still prints normally and any
+    // process-level handler (color-eyre, sentry-panic) still runs.
+    let prev_hook = std::panic::take_hook();
+    std::panic::set_hook(Box::new(move |info| {
+        let _ = restore_terminal_raw(mouse);
+        prev_hook(info);
+    }));
     let result = run_loop(
         &mut terminal,
         Arc::new(config.clone()),
@@ -543,7 +554,24 @@ pub async fn run(
     )
     .await;
     let restore = restore_terminal(&mut terminal, mouse);
+    let _ = std::panic::take_hook(); // drop our hook so future code runs without it
     result.and(restore)
+}
+
+/// Best-effort terminal restore from a panic context — operates on raw
+/// stdout instead of the `Terminal<Backend>` (which we don't own from
+/// inside the hook). Mirror of `restore_terminal` minus cursor show
+/// (the panic flow doesn't need pixel-perfect cleanup; getting raw
+/// mode off + leaving the alt screen is enough to make the operator's
+/// terminal usable again).
+fn restore_terminal_raw(mouse: bool) -> std::io::Result<()> {
+    let mut stdout = io::stdout();
+    if mouse {
+        let _ = execute!(stdout, DisableMouseCapture);
+    }
+    let _ = disable_raw_mode();
+    execute!(stdout, LeaveAlternateScreen)?;
+    Ok(())
 }
 
 async fn probe_hl() -> bool {
@@ -878,6 +906,20 @@ impl App {
         let mut new_config = match Config::load_from_path(&self.config_path) {
             Ok(c) => c,
             Err(e) => {
+                // Surface the parse error once per unique message —
+                // operator edits yoink.yaml from another shell, makes
+                // a typo, and otherwise has no signal that the live
+                // TUI is still running the previous config. Toast
+                // dedup avoids spamming on every CONFIG_RELOAD_TICK
+                // while the file stays broken.
+                let msg = format!("✗ config reload failed: {e}");
+                if !self
+                    .toasts
+                    .iter()
+                    .any(|(_, line)| line.as_str() == msg.as_str())
+                {
+                    self.push_toast(msg);
+                }
                 tracing::debug!(error = %e, path = %self.config_path.display(), "config reload failed");
                 return;
             }
@@ -897,6 +939,14 @@ impl App {
             self.start_event_subscriptions();
             self.stop_stats_history_pollers();
             self.start_stats_history_pollers();
+            // Drop ring-buffer entries for hosts that are no longer in
+            // the config. Without this, removing a host leaks its 200-
+            // event ring forever, and re-adding the same address later
+            // would resurrect events from a prior era and confuse the
+            // operator.
+            let active: std::collections::HashSet<&str> =
+                self.config.hosts.iter().map(|h| h.address.as_str()).collect();
+            self.host_events.retain(|addr, _| active.contains(addr.as_str()));
             self.schedule_hosts_refresh();
         }
         self.schedule_dashboard_refresh();
@@ -2068,6 +2118,12 @@ impl App {
         self.reconcile_all_target = false;
         self.resource_remove_target = None;
         self.resource_prune_target = None;
+        // The `docker top` modal lives on `ContainerDetailState`; if we
+        // leave ContainerDetail with it visible, returning later
+        // re-renders the stale process list. Dismiss explicitly so a
+        // re-entry starts clean (the operator presses `p` again to
+        // re-fetch).
+        self.container_detail.dismiss_top();
         // Don't clear job_progress on transition — operator
         // may want to navigate around with the deploy still in flight.
         // It clears itself on Esc-after-finished.
@@ -3007,6 +3063,20 @@ impl Drop for App {
         self.stop_log_streams();
         self.stop_event_subscriptions();
         self.stop_stats_history_pollers();
+        // Belt-and-braces sidecar cleanup. Normal exit goes through
+        // `transition`, which already calls `shell.cleanup()`; the
+        // panic path doesn't, so a crash while in `View::ContainerShell`
+        // would otherwise leave the alpine debug container running on
+        // the host. `cleanup()` is a `tokio::spawn` of
+        // `force_remove_container` — the spawn requires the tokio
+        // runtime to still be alive. When that's true (Drop fires
+        // inside `cmd_tui`'s async tail), the cleanup completes; in
+        // the rarer case of post-runtime drop, the sidecar's
+        // `auto_remove: true` plus the SSH connection breaking still
+        // covers us within seconds.
+        if let Some(mut shell) = self.shell.take() {
+            shell.cleanup(self.ops.clone());
+        }
     }
 }
 

--- a/yoink/src/tui/app.rs
+++ b/yoink/src/tui/app.rs
@@ -533,12 +533,9 @@ pub async fn run(
         tracing::info!("hl not on PATH; using raw log forwarder");
     }
     let mut terminal = setup_terminal(mouse).context("setup terminal")?;
-    // Panic hook: a panic anywhere in render or event handling unwinds
-    // straight past `restore_terminal`, leaving the operator stuck in
-    // raw mode + alternate screen until they `reset` (or kill the
-    // terminal). Hook restores the terminal first, then chains to the
-    // previous hook so the panic message still prints normally and any
-    // process-level handler (color-eyre, sentry-panic) still runs.
+    // Restore the terminal on panic before chaining to the previous
+    // hook — without this a panic in render unwinds past
+    // `restore_terminal` and leaves the operator stuck in raw+alt mode.
     let prev_hook = std::panic::take_hook();
     std::panic::set_hook(Box::new(move |info| {
         let _ = restore_terminal_raw(mouse);
@@ -554,16 +551,13 @@ pub async fn run(
     )
     .await;
     let restore = restore_terminal(&mut terminal, mouse);
-    let _ = std::panic::take_hook(); // drop our hook so future code runs without it
+    let _ = std::panic::take_hook();
     result.and(restore)
 }
 
-/// Best-effort terminal restore from a panic context — operates on raw
-/// stdout instead of the `Terminal<Backend>` (which we don't own from
-/// inside the hook). Mirror of `restore_terminal` minus cursor show
-/// (the panic flow doesn't need pixel-perfect cleanup; getting raw
-/// mode off + leaving the alt screen is enough to make the operator's
-/// terminal usable again).
+/// Restore from a panic context — operates on raw stdout because we
+/// don't own the `Terminal<Backend>` here. Skips the cursor-show step
+/// of the normal-exit `restore_terminal` (not needed for usability).
 fn restore_terminal_raw(mouse: bool) -> std::io::Result<()> {
     let mut stdout = io::stdout();
     if mouse {
@@ -906,12 +900,9 @@ impl App {
         let mut new_config = match Config::load_from_path(&self.config_path) {
             Ok(c) => c,
             Err(e) => {
-                // Surface the parse error once per unique message —
-                // operator edits yoink.yaml from another shell, makes
-                // a typo, and otherwise has no signal that the live
-                // TUI is still running the previous config. Toast
-                // dedup avoids spamming on every CONFIG_RELOAD_TICK
-                // while the file stays broken.
+                // Toast once per unique message so the operator sees
+                // their typo; dedup keeps the ring quiet while the
+                // file stays broken across many reload ticks.
                 let msg = format!("✗ config reload failed: {e}");
                 if !self
                     .toasts
@@ -939,11 +930,8 @@ impl App {
             self.start_event_subscriptions();
             self.stop_stats_history_pollers();
             self.start_stats_history_pollers();
-            // Drop ring-buffer entries for hosts that are no longer in
-            // the config. Without this, removing a host leaks its 200-
-            // event ring forever, and re-adding the same address later
-            // would resurrect events from a prior era and confuse the
-            // operator.
+            // Drop event rings for hosts no longer in the config so a
+            // re-added address doesn't inherit stale events.
             let active: std::collections::HashSet<&str> =
                 self.config.hosts.iter().map(|h| h.address.as_str()).collect();
             self.host_events.retain(|addr, _| active.contains(addr.as_str()));
@@ -2118,11 +2106,8 @@ impl App {
         self.reconcile_all_target = false;
         self.resource_remove_target = None;
         self.resource_prune_target = None;
-        // The `docker top` modal lives on `ContainerDetailState`; if we
-        // leave ContainerDetail with it visible, returning later
-        // re-renders the stale process list. Dismiss explicitly so a
-        // re-entry starts clean (the operator presses `p` again to
-        // re-fetch).
+        // Drop the `docker top` modal so a re-entry to ContainerDetail
+        // doesn't resurrect a stale process list.
         self.container_detail.dismiss_top();
         // Don't clear job_progress on transition — operator
         // may want to navigate around with the deploy still in flight.
@@ -3063,17 +3048,10 @@ impl Drop for App {
         self.stop_log_streams();
         self.stop_event_subscriptions();
         self.stop_stats_history_pollers();
-        // Belt-and-braces sidecar cleanup. Normal exit goes through
-        // `transition`, which already calls `shell.cleanup()`; the
-        // panic path doesn't, so a crash while in `View::ContainerShell`
-        // would otherwise leave the alpine debug container running on
-        // the host. `cleanup()` is a `tokio::spawn` of
-        // `force_remove_container` — the spawn requires the tokio
-        // runtime to still be alive. When that's true (Drop fires
-        // inside `cmd_tui`'s async tail), the cleanup completes; in
-        // the rarer case of post-runtime drop, the sidecar's
-        // `auto_remove: true` plus the SSH connection breaking still
-        // covers us within seconds.
+        // Sidecar cleanup on the panic-drop path (the transition path
+        // already does this on normal exit). `cleanup` spawns a force-
+        // remove; if the runtime is gone, `auto_remove: true` + the
+        // dropped SSH connection still reaps the alpine container.
         if let Some(mut shell) = self.shell.take() {
             shell.cleanup(self.ops.clone());
         }

--- a/yoink/src/tui/host_detail.rs
+++ b/yoink/src/tui/host_detail.rs
@@ -77,7 +77,13 @@ impl HostDetailState {
             self.containers = data.containers;
             self.host_info = data.host_info;
         }
-        clamp_selection(&mut self.table, self.containers.len());
+        // Clamp against the *visible* count, not the unfiltered total.
+        // With an active filter, `table.selected()` indexes into the
+        // `visible_indices()` slice (see `render`), so clamping to the
+        // larger unfiltered count would let `selected` point past the
+        // filtered list for a frame.
+        let n = self.visible_indices().len();
+        clamp_selection(&mut self.table, n);
     }
 
     pub fn select_next(&mut self) {

--- a/yoink/src/tui/resources.rs
+++ b/yoink/src/tui/resources.rs
@@ -291,9 +291,37 @@ impl ResourcesState {
         self.networks = networks;
 
         self.errors = errors;
-        clamp_selection(&mut self.images_table, self.images.len());
-        clamp_selection(&mut self.volumes_table, self.volumes.len());
-        clamp_selection(&mut self.networks_table, self.networks.len());
+        // Clamp against per-tab *filtered* counts. `selected()` indexes
+        // into each tab's `visible_indices()` slice, so clamping to the
+        // unfiltered totals here would let `selected` point past the
+        // filtered list for a frame.
+        let images_visible = self
+            .images
+            .iter()
+            .filter(|img| {
+                let target = format!("{} {} {}", img.host, img.id, img.repo_tags.join(" "));
+                self.filter.matches(&target)
+            })
+            .count();
+        let volumes_visible = self
+            .volumes
+            .iter()
+            .filter(|v| {
+                let target = format!("{} {} {}", v.host, v.name, v.driver);
+                self.filter.matches(&target)
+            })
+            .count();
+        let networks_visible = self
+            .networks
+            .iter()
+            .filter(|n| {
+                let target = format!("{} {} {} {}", n.host, n.name, n.driver, n.scope);
+                self.filter.matches(&target)
+            })
+            .count();
+        clamp_selection(&mut self.images_table, images_visible);
+        clamp_selection(&mut self.volumes_table, volumes_visible);
+        clamp_selection(&mut self.networks_table, networks_visible);
     }
 
     pub fn render(&mut self, frame: &mut Frame<'_>, area: Rect, _config: &Config) {

--- a/yoink/src/tui/services.rs
+++ b/yoink/src/tui/services.rs
@@ -66,7 +66,10 @@ impl ServicesState {
         if let Some(r) = report {
             self.report = Some(r);
         }
-        clamp_selection(&mut self.table, self.service_names.len());
+        // Clamp against the *filtered* count — table.selected() indexes
+        // into visible_indices(), not the full service_names list.
+        let n = self.visible_indices().len();
+        clamp_selection(&mut self.table, n);
     }
 
     pub fn select_next(&mut self) {
@@ -279,7 +282,10 @@ impl ServiceDetailState {
                 }
             }
             self.rows = rows;
-            clamp_selection(&mut self.table, self.rows.len());
+            // Clamp against the *filtered* count — `table.selected()`
+            // indexes into `visible_indices()`, not `self.rows`.
+            let n = self.visible_indices().len();
+            clamp_selection(&mut self.table, n);
         }
     }
 


### PR DESCRIPTION
## What

Aggregated fixes for the critical + high-severity findings from the post-v0.10.0 deep review sweep.

### Critical
- **TUI panic hook restores terminal** — `std::panic::set_hook` disables raw mode + leaves the alt screen before re-running the previous hook, so a panic in render or event handling no longer bricks the operator's terminal. Normal-exit `restore_terminal` flow unchanged.
- **Pre-deploy hook failure cleans up pending containers** — `cleanup_prepared_replicas` force-removes every pre-created container across all hosts before propagating the hook error, instead of leaving N×hosts `created`-state containers cluttering \`docker ps -a\`.
- **Caddy /load error body redacts PEM blocks** — Caddy parser errors can echo a slice of the submitted JSON, which carries inline cert+key PEMs from \`tls.certificates.load_pem\`. \`redact_pem_blocks\` strips \`-----BEGIN…-----END\` regions (and unterminated tails) before the body lands in operator-visible logs / TUI toasts. Three unit tests.

### High
- **Config reload errors toasted, not silently logged** — operator editing yoink.yaml from another shell gets immediate feedback when a typo blocks the reload (deduped against existing toasts so the same error doesn't fire on every \`CONFIG_RELOAD_TICK\`).
- **\`docker top\` modal dismissed on view transition** — re-entry to ContainerDetail starts clean instead of resurrecting stale process rows.
- **Selection clamp uses *visible* (filtered) count** — \`HostDetailState::apply\`, \`ServicesState::apply\`, \`ServiceDetailState::apply\`, \`ResourcesState::apply\` (per tab). Matches what \`render\` already does; eliminates the frame where \`selected\` could point past the filtered list with an active filter.
- **Sidecar removal on App::Drop** — paired with the panic hook, a crash while in \`View::ContainerShell\` no longer leaves an alpine debug container running.
- **\`host_events\` GC on \`hosts:\` config reload** — removing a host from yoink.yaml drops its 200-event ring, and re-adding the same address doesn't inherit stale events.

### Investigated and dropped as false alarm
- "Replica scale-up rename" — the agent flagged this as critical but it's the same rolling-deploy overlap that exists for any spec_hash change; \`swap_out_old\` cleans up by service label regardless of name shape. Not a bug.
- A handful of other findings the review agents over-called: \`std::sync::Mutex\` across await (lock is sync-only), stats batch GC race (everything serialized in event loop), healthcheck \`Ok(0)\` infinite loop (polling timeout always fires), \`select! biased\` starvation (only at sub-frame keypress rate), Caddy push 5xx + swap_out ordering (push runs before swap, deploy aborts safely on failure).

## Skipped (deferred to a follow-up)
Medium and low items from the sweep: TUI redaction-list expansion, OSC-52 size cap, wave-parallel \`build_upstream_names\` race, logs-restart auto-follow reset, audit-label noise on \`--force\`, runtime assertion for \`stop_first → replicas=1\`. Happy to bundle those into a v0.10.2 PR after this lands.

## Test plan
- [ ] Trigger a panic in the TUI (e.g., temporarily \`panic!()\` in \`render\`) — terminal returns to a usable state on exit.
- [ ] Set a deliberately broken \`yoink.yaml\` in another shell, confirm the toast surfaces in the TUI.
- [ ] Open a container's detail pane, press \`p\`, then Tab to another section and back — top modal does not reappear.
- [ ] Force a hook failure (e.g., make \`api-migrate\` exit non-zero), confirm \`docker ps -a\` doesn't have N×hosts pending containers afterwards.
- [ ] Trigger a Caddy /load error (e.g., introduce a bad \`caddy_extra_json\` snippet), confirm the error message contains \`<redacted PEM>\` instead of the cert.

\`cargo clippy --all-targets -- -D warnings\` clean. 225 tests pass (was 222, +3 PEM redaction tests).