### PR TITLE
fix(docs): card links resolve baseURL path component

### DIFF
--- a/docs/layouts/_partials/shortcodes/card.html
+++ b/docs/layouts/_partials/shortcodes/card.html
@@ -19,14 +19,19 @@
 
 {{- $external := strings.HasPrefix $link "http" -}}
 {{/*
-  Override of Hextra's upstream `card.html`: use `absURL` instead of
-  `relURL` for absolute-path inputs. Hugo's `relURL "/docs/foo"`
-  strips the leading slash but does NOT prepend the baseURL's path
-  component — on a project page at `https://oddur.github.io/yoink/`
-  that yields `/docs/foo` (404) instead of `/yoink/docs/foo`.
-  `absURL` prepends the full baseURL (path component included).
+  Override of Hextra's upstream `card.html`. The upstream calls
+  `relURL "/docs/foo"`, but Hugo treats a leading slash as "from
+  origin" and skips the baseURL's path component — on a project page
+  at `https://oddur.github.io/yoink/` it yields `/docs/foo` (404)
+  instead of `/yoink/docs/foo`. The fix Hextra itself uses for
+  images is to trim the leading slash before `relURL`, which then
+  prepends the full baseURL path. Mirror that here.
 */}}
-{{- $href := cond (strings.HasPrefix $link "/") ($link | absURL) $link -}}
+{{- $href := cond
+    (strings.HasPrefix $link "/")
+    (relURL (strings.TrimPrefix "/" $link))
+    $link
+-}}
 
 
 <a


### PR DESCRIPTION
Front-page cards on https://oddur.github.io/yoink/ link to \`https://oddur.github.io/docs/...\` (404) instead of the correct \`https://oddur.github.io/yoink/docs/...\`. Previously attempted in #11; that fix didn't take because the new code path hit the same underlying Hugo behavior.

## Root cause

Hugo treats a leading slash in URL-helper input as "from origin" — both \`absURL\` and \`relURL\` skip the baseURL's path component for leading-slash inputs. The override in #11 swapped \`relURL\` for \`absURL\` thinking that would prepend the path, but it doesn't.

Hextra itself works around this for image inputs by trimming the leading slash *before* \`relURL\`, which then prepends the full baseURL path:

\`\`\`go-html-template
{{- $image = relURL (strings.TrimPrefix "/" $image) -}}
\`\`\`

This PR mirrors that pattern in the card-link override.

## Verified

Local build with \`--baseURL https://oddur.github.io/yoink/\` (matching CI):

\`\`\`
href=/yoink/docs/start/first-deploy
href=/yoink/docs/intro/compared
href=/yoink/docs/guide/deploy-modes
href=/yoink/docs/guide/security-defaults
href=/yoink/docs/recipes/ai-agents
href=/yoink/docs/recipes
href=/yoink/docs/reference
\`\`\`

Workflow file unchanged — \`actions/configure-pages\` was returning the right baseURL all along (you can see it in the menu links on the live site, which use \`pageRef\`-derived URLs and render correctly as \`/yoink/docs/intro\`). The bug was purely in the override.