### PR TITLE
feat: drift modal, --plan/--watch/--here, replica-aware shell + logs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3674,6 +3674,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "throbber-widgets-tui"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1e6941f74491a80911cb8821cb1f55f7e13bca867b28a2b14e5a1daaf691eb3"
+dependencies = [
+ "ratatui",
+]
+
+[[package]]
 name = "time"
 version = "0.3.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4822,6 +4831,7 @@ dependencies = [
  "tempfile",
  "testcontainers",
  "thiserror 2.0.18",
+ "throbber-widgets-tui",
  "tokio",
  "tokio-util",
  "tracing",

--- a/docs/content/docs/recipes/_index.md
+++ b/docs/content/docs/recipes/_index.md
@@ -20,4 +20,5 @@ Task-oriented how-tos. Each recipe stands alone — pick the one that matches wh
   {{< card link="/docs/recipes/secrets-external-cli" title="External secrets via CLI" subtitle="Per-tool wiring for Doppler, 1Password, Vault, AWS Secrets Manager, Infisical CLI, Bitwarden — anything that emits dotenv or JSON." icon="key" >}}
   {{< card link="/docs/recipes/pr-comment-dry-run" title="Pre-merge dry-run on every PR" subtitle="Sticky GitHub PR comment showing what `yoink up` would change before the merge." icon="annotation" >}}
   {{< card link="/docs/recipes/multi-host-distribution" title="Multi-host distribution" subtitle="`replicas` + `services[].hosts` patterns: scale-out, singletons, region-pinned, stateful + stateless." icon="server" >}}
+  {{< card link="/docs/recipes/watch-mode" title="Edit-save-deploy with --watch" subtitle="`yoink up --watch --build --no-registry` polls the config and redeploys on save. Hot-reload for prod-like dev without CI." icon="refresh" >}}
 {{< /cards >}}

--- a/docs/content/docs/recipes/watch-mode.md
+++ b/docs/content/docs/recipes/watch-mode.md
@@ -1,0 +1,60 @@
+---
+title: Edit-save-deploy with `--watch`
+weight: 5
+---
+
+`yoink up --watch` re-reconciles whenever the config file (or any include fragment) changes on disk. Combined with `--build --no-registry`, it gives you a hot-reload loop for prod-like development without CI, a registry, or a deploy command in your shell history.
+
+## The loop
+
+```sh
+yoink up --watch --build --no-registry --service my-tool
+```
+
+Then edit `yoink.yaml` (or the Dockerfile for `my-tool`). On save:
+
+1. Yoink polls every 2s and notices the config differs from the last reconcile.
+2. `--build` rebuilds `my-tool`'s image against your local docker daemon.
+3. `--no-registry` ships the new image directly to the host (unregistry transport by default — only the changed layers cross the wire).
+4. The reconcile loop swaps the running container with the standard healthcheck-gated rolling deploy.
+
+Ctrl-C exits the loop.
+
+## Why polling?
+
+Yoink's TUI uses the same 2 s tick to reload the config. Polling avoids a `notify`/`fsnotify`-style file-watcher dependency and is plenty fast for an operator typing in their editor — the reconcile latency itself dominates anything below ~500 ms.
+
+If the reload fails (yaml syntax error, missing required field), the watch loop prints the error and keeps polling. Fix the file and the next save tries again. There's no need to restart `yoink up`.
+
+## Common patterns
+
+**Iterating on a single service** — pin it with `--service` so unrelated services aren't redeployed on every save:
+
+```sh
+yoink up --watch --build --no-registry --service api
+```
+
+**Iterating on an include fragment** — the `include:` glob is re-resolved on every reload, so a fresh `services/new-thing.yaml` is picked up automatically:
+
+```yaml
+# yoink.yaml
+include:
+  - services/*.yaml
+```
+
+```sh
+yoink up --watch --build --no-registry        # all services, re-resolve includes on save
+```
+
+**Plan first, watch second** — `yoink up --plan` is a one-shot read-only view; `--watch` cannot be combined with `--plan` (the watch loop is for the apply path):
+
+```sh
+yoink up --plan                                # what would change?
+yoink up --watch --build --no-registry         # ok, ship it on every save
+```
+
+## Tradeoffs vs. an inotify-based watcher
+
+Polling means up to 2 s of latency between save and reconcile. For an editor flow that's typically below the threshold of "did I actually save?" — but if you're chaining `yoink up --watch` into a tighter feedback loop (test runner, screen recorder), be aware of the floor.
+
+The reconcile itself is cheap when nothing changed: `compute_spec_hash` short-circuits the no-op path before any image pull or container swap. So the cost of a fired but no-op reconcile is one round-trip per host.

--- a/docs/content/docs/reference/cli.md
+++ b/docs/content/docs/reference/cli.md
@@ -36,8 +36,17 @@ yoink up                                 reconcile every service to its desired 
   --service <NAME>                       restrict to a subset (repeatable)
   --tag <[name=]value>                   override a service's tag (repeatable; bare form
                                          applies to every selected service)
-  --dry-run                              print the planned actions and exit (read-only)
+  --here                                 use `git rev-parse --short HEAD` as the tag for
+                                         every selected service. Conflicts with --tag.
+  --plan                                 friendlier alias for --dry-run; mirrors
+                                         `terraform plan` (read-only)
+  --dry-run                              print the planned actions and exit (read-only).
+                                         Output shows per-service +/-/~ diffs of env keys
+                                         and label keys when --format text (default).
   --format <text|markdown|json>          dry-run output format
+  --watch                                re-reconcile whenever the config file (or include
+                                         fragment) changes on disk; polls every 2s. Ctrl-C
+                                         exits. Cannot combine with --plan/--dry-run.
   --no-registry                          stream local image to host (no docker pull);
                                          pair with --build for the indie one-shot
   --build                                docker build any service with a `build:` block first
@@ -72,12 +81,19 @@ yoink dump                               dense JSON of everything yoink can obse
                                          an LLM/agent for diagnosis. Secret-ish env values
                                          are redacted.
 
-yoink logs <SERVICE>                     stream or tail logs
+yoink logs <SERVICE>                     stream or tail logs. With multiple replicas and
+                                         no --host, multiplexes across all of them with
+                                         [host/container] line prefixes.
+  --host <ADDRESS>                       pin to a specific replica
   --follow                               keep streaming as new lines arrive
   --tail <N>                             show the last N lines
 
 yoink exec <SERVICE> -- <CMD> <ARGS>...  one-shot command inside a running container
-yoink shell <SERVICE>                    interactive PTY shell (`bash` if present, else `sh`)
+yoink shell <SERVICE>                    interactive PTY shell (`bash` if present, else
+                                         `sh`). With multiple replicas and no --host,
+                                         picks the first healthy one and prints which.
+                                         Aliased as `yoink ssh <SERVICE>`.
+yoink ssh <SERVICE>                      alias for `yoink shell`
 yoink debug <SERVICE>                    alpine debug sidecar in target's pid+net ns (for
                                          distroless / shell-less images)
 yoink restart <SERVICE>                  bounce the container without re-deploying
@@ -139,7 +155,11 @@ Services without an explicit tag (typical for `image: ghcr.io/you/api` where the
 ```sh
 yoink up --tag api=$(git rev-parse HEAD) --tag web=$(git rev-parse HEAD)
 yoink up --service api --tag $(git rev-parse HEAD)         # bare form, single service
+yoink up --here                                             # shorthand for "every service at HEAD"
+yoink up --service api --here                               # one service at HEAD
 ```
+
+`--here` resolves the current `git rev-parse --short HEAD` and applies it as a per-service override — equivalent to typing the SHA out for every service. Conflicts with `--tag` (use one or the other).
 
 ## Force redeploy (`--force`)
 
@@ -151,3 +171,73 @@ yoink up --service api --force                  # re-create + healthcheck all ap
 ```
 
 Tradeoff: for multi-replica services the prep phase removes the old replicas before finalize starts the new ones, so there's a brief service-level downtime window (≈ healthcheck timeout). Use sparingly. Routine deploys never need this — drift detection + the rolling-swap loop handle the normal case automatically.
+
+## Watch mode (`--watch`)
+
+`yoink up --watch` runs an initial reconcile, then keeps polling the config file every 2 seconds and re-reconciles on every change. Pairs with `--build --no-registry` for the edit-save-deploy inner loop:
+
+```sh
+yoink up --watch --build --no-registry --service my-tool
+# edit Dockerfile / yoink.yaml → save → yoink rebuilds and ships
+# Ctrl-C to exit
+```
+
+The 2 s cadence matches the TUI's reload tick. Reconcile errors are reported to stderr but don't abort the loop — fix the config and the next save kicks off another attempt.
+
+## Dynamic shell completion
+
+`yoink completions <shell>` emits static completions (subcommand names, flag names, value enums). For *dynamic* values — service names, host addresses, config file paths — yoink ships a hidden `__complete` helper that prints one value per line:
+
+| Subcommand | Source | Needs config loaded? |
+|---|---|---|
+| `yoink __complete services` | service names from the current config | yes |
+| `yoink __complete hosts` | host addresses from the current config | yes |
+| `yoink __complete configs` | `yoink.yaml` / `*.yoink.yaml` files anywhere under cwd, ranked newest-first | no |
+
+The walker behind `__complete configs` skips the usual noise directories (`.git`, `target`, `node_modules`, `.venv`, `dist`, `build`, …) and caps depth at 8, so a `<TAB>` press completes in well under 100 ms even on a large repo.
+
+Bash:
+
+```bash
+# ~/.bashrc (alongside `source <(yoink completions bash)`)
+_yoink_dynamic() {
+    local cur="${COMP_WORDS[COMP_CWORD]}"
+    local prev="${COMP_WORDS[COMP_CWORD-1]}"
+    # Forward any -c / --config that's already on the line so that
+    # `yoink -c staging.yoink.yaml shell <TAB>` lists *staging's*
+    # services, not the default config's.
+    local fwd=()
+    for ((i=1; i<COMP_CWORD; i++)); do
+        case "${COMP_WORDS[i]}" in
+            -c|--config)
+                fwd=(-c "${COMP_WORDS[i+1]}")
+                ;;
+        esac
+    done
+    case "$prev" in
+        -c|--config)
+            COMPREPLY=( $(compgen -W "$(yoink __complete configs 2>/dev/null)" -- "$cur") )
+            return 0
+            ;;
+        --service|-s|shell|ssh|exec|logs|restart|kill|debug|version|history|rollback|pull|diff)
+            COMPREPLY=( $(compgen -W "$(yoink "${fwd[@]}" __complete services 2>/dev/null)" -- "$cur") )
+            return 0
+            ;;
+        --host)
+            COMPREPLY=( $(compgen -W "$(yoink "${fwd[@]}" __complete hosts 2>/dev/null)" -- "$cur") )
+            return 0
+            ;;
+    esac
+}
+complete -F _yoink_dynamic -o default yoink
+```
+
+Zsh: drop the `compdef` snippet from `yoink completions zsh` into your `fpath`, then layer a wrapper that calls `yoink __complete <kind>` for the values you want described. The helper itself just prints `\n`-separated paths/names — wire it into whatever completion shape your shell prefers.
+
+After sourcing the snippet, every `<TAB>` works the way you'd hope:
+
+```sh
+yoink -c <TAB>                    # all yoink configs in this repo
+yoink shell <TAB>                 # services from the default config
+yoink -c staging.yoink.yaml shell <TAB>   # services from staging
+```

--- a/docs/content/docs/reference/tui.md
+++ b/docs/content/docs/reference/tui.md
@@ -56,6 +56,7 @@ Heavily inspired by [k9s](https://k9scli.io/) and [lazydocker](https://github.co
 | `!` | shell into container (`bash` then fallback to `sh`) |
 | `D` | debug sidecar (alpine in target's pid+net ns — for distroless / shell-less images) |
 | `H` | service deploy history; on a stopped row press `r` to roll back |
+| `~` | show drift detail for the focused service (image / tag / spec_hash / env keys / label keys) |
 | `x` | toggle eXited containers visible in the table |
 | `r` | refresh |
 | `/` | filter substring (Esc clears) |
@@ -89,6 +90,28 @@ Plus, at the bottom of the pane, a rolling tail of the container's logs.
 | `esc` | back to host detail |
 
 If your image is distroless or otherwise has no shell, `!` will fail. **Fall back to `D`** — the debug sidecar attaches an alpine container sharing the target's PID and network namespaces, so you can run `ps`, `ss`, `cat /proc/<pid>/...` against the target without modifying the production image. The sidecar auto-removes when you `exit` / Ctrl-D.
+
+## Drift detail (`~`)
+
+When the dashboard / host detail / service detail / container detail view shows ⚠ on a row, press **`~`** to open a modal that explains *what* drifted — the same per-field diff `yoink up --plan` produces on the CLI side:
+
+```
+ drift: api on host-a (esc to close) 
+   image  ghcr.io/me/api  (unchanged)
+   spec   a1b2c3d → e5f6a7b
+    tag   v1.2.4
+env:
+  + DATABASE_POOL_SIZE
+  ~ LOG_LEVEL
+labels:
+  - yoink.caddy.tls
+```
+
+Color-coded so the markers read at a glance: `+` green (added in desired), `-` red (removed from running), `~` yellow (changed). The hash and image columns highlight the running → desired transition in cyan when they differ; the line dims to `(unchanged)` when they match.
+
+The fetch reuses `diff::compute` under the hood, so the modal's content is identical to `yoink up --plan --service <name>` against the same host. For services without a `tag:` pinned in config (typical for `image: ghcr.io/you/api` where CI provides the tag), the modal falls back to the running replica's tag so the diff isolates the env/label change instead of erroring on a missing tag — useful for "what changed since deploy?" without leaving the TUI.
+
+`Esc` closes the modal. The underlying view stays put.
 
 ## Hosts pane (`h`)
 

--- a/yoink/Cargo.toml
+++ b/yoink/Cargo.toml
@@ -34,6 +34,7 @@ glob = "0.3"
 humantime-serde = "1"
 indicatif = "0.18"
 ratatui = "0.30"
+throbber-widgets-tui = "0.11"
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/yoink/src/completion.rs
+++ b/yoink/src/completion.rs
@@ -1,0 +1,176 @@
+//! Helpers behind the hidden `yoink __complete` subcommand —
+//! the dynamic-completion plumbing the bash/zsh snippets in
+//! `docs/content/docs/reference/cli.md` shell out to.
+//!
+//! Currently only the `configs` walker lives here; service / host
+//! listing is trivial enough to stay inline in `main.rs` next to
+//! the loaded `Config`.
+
+use std::path::{Path, PathBuf};
+use std::time::SystemTime;
+
+const MAX_DEPTH: usize = 8;
+
+/// Directories the walker prunes. These are the heavyweight noise
+/// dirs where a yoink config almost never lives — pruning them keeps
+/// even a deep monorepo scan well under 100 ms.
+const SKIP_DIRS: &[&str] = &[
+    ".git",
+    ".terraform",
+    ".cache",
+    ".next",
+    ".nuxt",
+    ".svelte-kit",
+    ".venv",
+    "venv",
+    "__pycache__",
+    "node_modules",
+    "target",
+    "dist",
+    "build",
+];
+
+/// Walk the cwd subtree and print one yoink config path per line.
+/// Bare paths so the bash `complete -F` snippet can pipe them
+/// straight through `compgen -W`.
+pub fn print_yoink_configs() {
+    let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
+    for path in find_yoink_configs(&cwd) {
+        println!("{}", path.display());
+    }
+}
+
+/// Names that mark a yoink config: the canonical `yoink.yaml`, plus
+/// the multi-environment convention `<env>.yoink.yaml` (e.g.
+/// `staging.yoink.yaml`). `services/*.yaml` fragments are *not*
+/// matched — they aren't valid `-c` targets on their own.
+#[must_use]
+pub fn is_yoink_config_name(name: &str) -> bool {
+    name == "yoink.yaml" || name.ends_with(".yoink.yaml")
+}
+
+/// Find every yoink config reachable from `root`, ranked by mtime
+/// (newest first — the file the operator just edited bubbles to the
+/// top of the completion list). Capped at [`MAX_DEPTH`] so a
+/// misconfigured symlink loop can't hang the shell on every `<TAB>`.
+#[must_use]
+pub fn find_yoink_configs(root: &Path) -> Vec<PathBuf> {
+    let mut hits: Vec<(PathBuf, SystemTime)> = Vec::new();
+    walk(root, root, &mut hits, 0);
+    // `Reverse` flips the natural ascending sort to descending.
+    hits.sort_by_key(|(_, mtime)| std::cmp::Reverse(*mtime));
+    hits.into_iter().map(|(p, _)| p).collect()
+}
+
+fn walk(root: &Path, dir: &Path, out: &mut Vec<(PathBuf, SystemTime)>, depth: usize) {
+    if depth > MAX_DEPTH {
+        return;
+    }
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let Ok(ft) = entry.file_type() else { continue };
+        let name = entry.file_name();
+        let name = name.to_string_lossy();
+        if ft.is_dir() {
+            if SKIP_DIRS.iter().any(|s| *s == name.as_ref()) {
+                continue;
+            }
+            walk(root, &entry.path(), out, depth + 1);
+        } else if ft.is_file() && is_yoink_config_name(&name) {
+            let path = entry.path();
+            let mtime = entry
+                .metadata()
+                .and_then(|m| m.modified())
+                .unwrap_or(SystemTime::UNIX_EPOCH);
+            // Print paths relative to the walk root so completions
+            // render cleanly (`./staging/yoink.yaml` not the full
+            // absolute path).
+            let rel = path.strip_prefix(root).unwrap_or(&path).to_path_buf();
+            out.push((rel, mtime));
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    #[test]
+    fn config_name_recognises_canonical_and_multi_env() {
+        assert!(is_yoink_config_name("yoink.yaml"));
+        assert!(is_yoink_config_name("staging.yoink.yaml"));
+        assert!(is_yoink_config_name("prod.yoink.yaml"));
+    }
+
+    #[test]
+    fn config_name_rejects_fragments_and_unrelated_yaml() {
+        assert!(!is_yoink_config_name("api.yaml"));
+        assert!(!is_yoink_config_name("docker-compose.yaml"));
+        assert!(!is_yoink_config_name("yoink.yml"));
+    }
+
+    #[test]
+    fn walker_finds_configs_skipping_noise_dirs_and_fragments() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+
+        fs::write(root.join("yoink.yaml"), "hosts: []\nservices: []\n").unwrap();
+        fs::create_dir_all(root.join("staging")).unwrap();
+        fs::write(
+            root.join("staging").join("yoink.yaml"),
+            "hosts: []\nservices: []\n",
+        )
+        .unwrap();
+        fs::write(
+            root.join("prod.yoink.yaml"),
+            "hosts: []\nservices: []\n",
+        )
+        .unwrap();
+
+        // Fragment under `services/` — should NOT be picked up.
+        fs::create_dir_all(root.join("services")).unwrap();
+        fs::write(root.join("services").join("api.yaml"), "name: api\n").unwrap();
+
+        // Noise dirs that should be skipped entirely.
+        for noise in [".git", "target", "node_modules"] {
+            fs::create_dir_all(root.join(noise)).unwrap();
+            fs::write(root.join(noise).join("yoink.yaml"), "ignored\n").unwrap();
+        }
+
+        let mut found: Vec<String> = find_yoink_configs(root)
+            .into_iter()
+            .map(|p| p.to_string_lossy().into_owned())
+            .collect();
+        found.sort();
+        assert_eq!(
+            found,
+            vec![
+                "prod.yoink.yaml".to_string(),
+                "staging/yoink.yaml".to_string(),
+                "yoink.yaml".to_string(),
+            ],
+        );
+    }
+
+    #[test]
+    fn walker_ranks_by_modification_time_newest_first() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        fs::write(root.join("yoink.yaml"), "hosts: []\n").unwrap();
+        // Make the second file's mtime strictly newer.
+        std::thread::sleep(std::time::Duration::from_millis(20));
+        fs::write(root.join("staging.yoink.yaml"), "hosts: []\n").unwrap();
+
+        let found: Vec<String> = find_yoink_configs(root)
+            .into_iter()
+            .map(|p| p.to_string_lossy().into_owned())
+            .collect();
+        // Newest (staging) bubbles up first — the file the operator
+        // most recently edited is almost always the one they want.
+        assert_eq!(found.first().map(String::as_str), Some("staging.yoink.yaml"));
+        assert_eq!(found.get(1).map(String::as_str), Some("yoink.yaml"));
+    }
+}

--- a/yoink/src/config.rs
+++ b/yoink/src/config.rs
@@ -40,6 +40,13 @@ pub enum ConfigError {
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct Config {
+    /// Optional banner text rendered in the TUI's top chrome on every
+    /// view. Use it to mark a config — typically `"PRODUCTION — TREAD
+    /// CAREFULLY"` — so an operator can't miss what they're pointed at.
+    /// Free-form: anything goes, but keep it short (the chrome reserves
+    /// a single line).
+    #[serde(default)]
+    pub slug: Option<String>,
     #[serde(default)]
     pub deploy: DeployDefaults,
     #[serde(default)]
@@ -429,6 +436,12 @@ pub enum TlsMode {
 pub struct ServiceConfig {
     pub name: String,
     pub image: String,
+    /// Human-readable summary of what this service does. Written to every
+    /// container as `org.opencontainers.image.description` (the OCI standard
+    /// label key) so the TUI can surface it for both yoink-deployed and
+    /// 3rd-party OCI-compliant containers via a single label lookup.
+    #[serde(default)]
+    pub description: Option<String>,
     /// Special-purpose service marker. Set automatically on the
     /// implicit `_proxy` service; users do not write this.
     #[serde(default)]

--- a/yoink/src/deploy.rs
+++ b/yoink/src/deploy.rs
@@ -164,6 +164,18 @@ pub fn build_labels(
     spec_hash: &str,
 ) -> BTreeMap<String, String> {
     let mut labels: BTreeMap<String, String> = service.labels.clone();
+    // Use the OCI standard key so the TUI's single lookup works for
+    // both yoink-deployed and 3rd-party OCI containers.
+    if let Some(desc) = service
+        .description
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+    {
+        labels
+            .entry("org.opencontainers.image.description".into())
+            .or_insert_with(|| desc.to_string());
+    }
     labels.insert("yoink.managed".into(), "true".into());
     labels.insert("yoink.service".into(), service.name.clone());
     labels.insert("yoink.version".into(), tag.into());
@@ -1600,6 +1612,44 @@ services:
         assert_eq!(
             labels.get("yoink.spec_hash"),
             Some(&"0123456789abcdef".into())
+        );
+    }
+
+    #[test]
+    fn build_labels_emits_oci_description_when_set() {
+        let mut cfg = config_one_service();
+        cfg.services[0].description = Some("API gateway".into());
+        let labels = build_labels(&cfg.services[0], "abc1234", "0123456789abcdef");
+        assert_eq!(
+            labels.get("org.opencontainers.image.description"),
+            Some(&"API gateway".into())
+        );
+    }
+
+    #[test]
+    fn build_labels_omits_oci_description_when_unset_or_blank() {
+        let cfg = config_one_service();
+        let labels = build_labels(&cfg.services[0], "abc1234", "0123456789abcdef");
+        assert!(!labels.contains_key("org.opencontainers.image.description"));
+
+        let mut blank = config_one_service();
+        blank.services[0].description = Some("   ".into());
+        let labels = build_labels(&blank.services[0], "abc1234", "0123456789abcdef");
+        assert!(!labels.contains_key("org.opencontainers.image.description"));
+    }
+
+    #[test]
+    fn build_labels_user_override_wins_over_description_field() {
+        let mut cfg = config_one_service();
+        cfg.services[0].description = Some("from convenience field".into());
+        cfg.services[0].labels.insert(
+            "org.opencontainers.image.description".into(),
+            "explicit user override".into(),
+        );
+        let labels = build_labels(&cfg.services[0], "abc1234", "0123456789abcdef");
+        assert_eq!(
+            labels.get("org.opencontainers.image.description"),
+            Some(&"explicit user override".into())
         );
     }
 

--- a/yoink/src/diff.rs
+++ b/yoink/src/diff.rs
@@ -297,42 +297,75 @@ async fn inspect_field_diff(
     secrets: Option<&SecretsBundle>,
 ) -> Result<FieldDiff, DockerError> {
     let detail = ops.inspect_container(host, container).await?;
-    let current_env = detail.env_map();
     let desired_env = deploy::build_env(service, secrets);
-    let (env_added, env_removed, env_changed) = diff_kv(&current_env, &desired_env);
-
     let desired_labels = deploy::build_labels(service, tag, desired_hash);
-    let (mut labels_added, mut labels_removed, mut labels_changed) =
-        diff_kv(&detail.labels, &desired_labels);
-    // Suppress the labels yoink itself manages so the operator doesn't
-    // see them in every diff:
-    //   - `yoink.version` / `yoink.spec_hash` are already shown via the
-    //     dedicated tag/spec_hash diff lines.
-    //   - `yoink.deployed-*` are audit labels written at deploy time
-    //     (see `deploy::audit_labels`), kept out of `build_labels` so
-    //     the spec_hash isn't poisoned. Without this filter every
-    //     Update would report them as `removed` since they're in the
-    //     running container but not in `desired_labels`.
-    labels_added.retain(|k| !is_yoink_managed_label(k));
-    labels_removed.retain(|k| !is_yoink_managed_label(k));
-    labels_changed.retain(|k| !is_yoink_managed_label(k));
+    Ok(field_diff_scoped(
+        service,
+        &detail.env_map(),
+        &detail.labels,
+        &desired_env,
+        &desired_labels,
+    ))
+}
 
-    Ok(FieldDiff {
+/// Pure-function part of `inspect_field_diff`: given current vs desired
+/// env+labels (already loaded), produce the operator-facing field diff,
+/// filtered down to keys yoink would actually set.
+///
+/// The scoping matters because the running container's env always
+/// carries image-inherited entries (`PATH`, `SSL_CERT_FILE`, locale
+/// vars, …) and the running container's labels carry image-baked OCI
+/// annotations (`LABEL service=foo` from a Dockerfile, `org.openconta-
+/// iners.image.*`). yoink doesn't manage any of those, so they
+/// shouldn't show as drift — they'd flood the modal with permanent
+/// red `-` lines. The contract is "yoink reports drift on what it
+/// sets": for env that's `service.env` + declared `secrets:` + LHS
+/// of `env_from_secrets:`; for labels that's anything starting with
+/// `yoink.` or anything the operator declared in `service.labels`.
+fn field_diff_scoped(
+    service: &crate::config::ServiceConfig,
+    current_env: &BTreeMap<String, String>,
+    current_labels: &BTreeMap<String, String>,
+    desired_env: &BTreeMap<String, String>,
+    desired_labels: &BTreeMap<String, String>,
+) -> FieldDiff {
+    let managed_env: BTreeSet<String> = service
+        .env
+        .keys()
+        .cloned()
+        .chain(service.secrets.iter().cloned())
+        .chain(service.env_from_secrets.keys().cloned())
+        .collect();
+    let (mut env_added, mut env_removed, mut env_changed) = diff_kv(current_env, desired_env);
+    env_added.retain(|k| managed_env.contains(k));
+    env_removed.retain(|k| managed_env.contains(k));
+    env_changed.retain(|k| managed_env.contains(k));
+
+    let user_labels: BTreeSet<String> = service.labels.keys().cloned().collect();
+    let label_in_scope =
+        |k: &String| (k.starts_with("yoink.") || user_labels.contains(k)) && !is_yoink_internal_label(k);
+    let (mut labels_added, mut labels_removed, mut labels_changed) =
+        diff_kv(current_labels, desired_labels);
+    labels_added.retain(&label_in_scope);
+    labels_removed.retain(&label_in_scope);
+    labels_changed.retain(&label_in_scope);
+
+    FieldDiff {
         env_added,
         env_removed,
         env_changed,
         labels_added,
         labels_removed,
         labels_changed,
-    })
+    }
 }
 
-/// Labels yoink manages on its own and that the field-diff suppresses
-/// from added/removed/changed lists. These are either represented by
-/// other parts of the diff (`yoink.version`, `yoink.spec_hash` ↔ the
-/// tag and `spec_hash` columns) or by design absent from `build_labels`
-/// (`yoink.deployed-*` audit labels — see `deploy::audit_labels`).
-fn is_yoink_managed_label(k: &str) -> bool {
+/// Yoink-internal labels suppressed from the field diff. These are
+/// either represented by other parts of the diff (`yoink.version`,
+/// `yoink.spec_hash` ↔ the tag and `spec_hash` columns) or by design
+/// absent from `build_labels` (`yoink.deployed-*` audit labels — see
+/// `deploy::audit_labels`).
+fn is_yoink_internal_label(k: &str) -> bool {
     matches!(k, "yoink.version" | "yoink.spec_hash") || k.starts_with("yoink.deployed-")
 }
 
@@ -712,16 +745,148 @@ mod tests {
     }
 
     #[test]
-    fn is_yoink_managed_label_recognises_audit_and_spec_keys() {
-        assert!(is_yoink_managed_label("yoink.version"));
-        assert!(is_yoink_managed_label("yoink.spec_hash"));
-        assert!(is_yoink_managed_label("yoink.deployed-by"));
-        assert!(is_yoink_managed_label("yoink.deployed-at"));
+    fn is_yoink_internal_label_recognises_audit_and_spec_keys() {
+        assert!(is_yoink_internal_label("yoink.version"));
+        assert!(is_yoink_internal_label("yoink.spec_hash"));
+        assert!(is_yoink_internal_label("yoink.deployed-by"));
+        assert!(is_yoink_internal_label("yoink.deployed-at"));
         // Other yoink labels (caddy, custom user labels under yoink.*)
         // remain visible in the diff.
-        assert!(!is_yoink_managed_label("yoink.caddy.domain"));
-        assert!(!is_yoink_managed_label("yoink.service"));
-        assert!(!is_yoink_managed_label("org.opencontainers.image.description"));
+        assert!(!is_yoink_internal_label("yoink.caddy.domain"));
+        assert!(!is_yoink_internal_label("yoink.service"));
+        assert!(!is_yoink_internal_label("org.opencontainers.image.description"));
+    }
+
+    fn service_with_managed_keys() -> crate::config::ServiceConfig {
+        let cfg = crate::config::Config::parse_str(
+            r#"
+hosts:
+  - { address: host-a, user: deploy }
+services:
+  - name: api
+    image: registry.example.com/bt-api
+    tag: latest
+    env:
+      LOG_LEVEL: info
+      PORT: "8080"
+    secrets:
+      - DATABASE_URL
+    env_from_secrets:
+      OTEL_HEADERS: GRAFANA_AUTH
+    labels:
+      ops.team: platform
+    run:
+      port: 8080
+      healthcheck_path: /health
+      healthcheck_timeout: 60s
+      drain_timeout: 10s
+      options: { memory: 256Mi }
+"#,
+        )
+        .unwrap();
+        cfg.services[0].clone()
+    }
+
+    #[test]
+    fn field_diff_ignores_image_inherited_env() {
+        // Container has image-baked vars (PATH, SSL_CERT_FILE, NODE_ENV)
+        // alongside the ones yoink set. Desired only carries the
+        // yoink-set ones. The image-inherited shouldn't show as
+        // env_removed.
+        let svc = service_with_managed_keys();
+        let mut current_env = BTreeMap::new();
+        current_env.insert("PATH".into(), "/usr/local/bin:/usr/bin".into());
+        current_env.insert("SSL_CERT_FILE".into(), "/etc/ssl/cert.pem".into());
+        current_env.insert("NODE_ENV".into(), "production".into());
+        current_env.insert("LOG_LEVEL".into(), "info".into());
+        current_env.insert("PORT".into(), "8080".into());
+        current_env.insert("DATABASE_URL".into(), "postgres://…".into());
+        current_env.insert("OTEL_HEADERS".into(), "Bearer …".into());
+        let mut desired_env = current_env.clone();
+        desired_env.remove("PATH");
+        desired_env.remove("SSL_CERT_FILE");
+        desired_env.remove("NODE_ENV");
+        let diff = field_diff_scoped(
+            &svc,
+            &current_env,
+            &BTreeMap::new(),
+            &desired_env,
+            &BTreeMap::new(),
+        );
+        assert!(diff.env_removed.is_empty(), "got: {:?}", diff.env_removed);
+    }
+
+    #[test]
+    fn field_diff_still_reports_dropped_managed_env() {
+        // Operator removes a key from service.env: that IS drift —
+        // make sure the scoping doesn't over-filter and silently
+        // hide it.
+        let svc = service_with_managed_keys();
+        let mut current_env = BTreeMap::new();
+        current_env.insert("LOG_LEVEL".into(), "info".into());
+        current_env.insert("PORT".into(), "8080".into()); // gone in desired
+        current_env.insert("PATH".into(), "/usr/bin".into()); // image, ignored
+        let mut desired_env = BTreeMap::new();
+        desired_env.insert("LOG_LEVEL".into(), "info".into());
+        let diff = field_diff_scoped(
+            &svc,
+            &current_env,
+            &BTreeMap::new(),
+            &desired_env,
+            &BTreeMap::new(),
+        );
+        assert_eq!(diff.env_removed, vec!["PORT".to_string()]);
+    }
+
+    #[test]
+    fn field_diff_ignores_image_baked_labels() {
+        // bt-api's Dockerfile carries `LABEL service=backtrack` plus
+        // OCI image annotations. Those shouldn't show as drift;
+        // operator can't act on them.
+        let svc = service_with_managed_keys();
+        let mut current_labels = BTreeMap::new();
+        current_labels.insert("service".into(), "backtrack".into());
+        current_labels.insert(
+            "org.opencontainers.image.source".into(),
+            "https://example.com".into(),
+        );
+        current_labels.insert("yoink.managed".into(), "true".into());
+        current_labels.insert("yoink.service".into(), "api".into());
+        current_labels.insert("ops.team".into(), "platform".into());
+        let mut desired_labels = current_labels.clone();
+        desired_labels.remove("service");
+        desired_labels.remove("org.opencontainers.image.source");
+        let diff = field_diff_scoped(
+            &svc,
+            &BTreeMap::new(),
+            &current_labels,
+            &BTreeMap::new(),
+            &desired_labels,
+        );
+        assert!(
+            diff.labels_removed.is_empty(),
+            "got: {:?}",
+            diff.labels_removed
+        );
+    }
+
+    #[test]
+    fn field_diff_reports_user_label_change() {
+        // A label declared in service.labels is yoink-managed; an
+        // operator-side change should still show as drift.
+        let svc = service_with_managed_keys();
+        let mut current_labels = BTreeMap::new();
+        current_labels.insert("ops.team".into(), "platform".into());
+        let mut desired_labels = BTreeMap::new();
+        desired_labels.insert("ops.team".into(), "infra".into());
+        let diff = field_diff_scoped(
+            &svc,
+            &BTreeMap::new(),
+            &current_labels,
+            &BTreeMap::new(),
+            &desired_labels,
+        );
+        assert_eq!(diff.labels_changed, vec!["ops.team".to_string()]);
     }
 
     #[test]

--- a/yoink/src/diff.rs
+++ b/yoink/src/diff.rs
@@ -14,7 +14,7 @@ use serde::Serialize;
 use thiserror::Error;
 
 use crate::config::Config;
-use crate::deploy::{DeployError, build_desired_spec, container_name};
+use crate::deploy::{self, DeployError, build_desired_spec, container_name};
 use crate::docker;
 use crate::docker_ops::{ContainerInfo, DockerError, DockerOps, Host};
 use crate::secrets::SecretsBundle;
@@ -55,14 +55,45 @@ pub enum ChangeKind {
     /// No matching container with the same `yoink.service` label.
     Create { desired_image: String },
     /// Existing container has the service label but a different
-    /// `spec_hash`.
+    /// `spec_hash`. `fields` is empty when we couldn't inspect the
+    /// running container (transient docker error) — the hash drift
+    /// is still authoritative; only the per-field breakdown is
+    /// best-effort.
     Update {
         current_hash: String,
         current_image: String,
         desired_image: String,
+        #[serde(default, skip_serializing_if = "FieldDiff::is_empty")]
+        fields: FieldDiff,
     },
     /// Spec hash matches — nothing for `yoink up` to do.
     NoOp { current_hash: String },
+}
+
+/// Per-field diff between a running container and its desired spec.
+/// Keys only — values may carry secret material in env, and hashes
+/// hide it for labels too. Operators get "what changed" without
+/// risking a sealed secret leaking into a PR comment.
+#[derive(Debug, Clone, Default, Serialize)]
+pub struct FieldDiff {
+    pub env_added: Vec<String>,
+    pub env_removed: Vec<String>,
+    pub env_changed: Vec<String>,
+    pub labels_added: Vec<String>,
+    pub labels_removed: Vec<String>,
+    pub labels_changed: Vec<String>,
+}
+
+impl FieldDiff {
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.env_added.is_empty()
+            && self.env_removed.is_empty()
+            && self.env_changed.is_empty()
+            && self.labels_added.is_empty()
+            && self.labels_removed.is_empty()
+            && self.labels_changed.is_empty()
+    }
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -112,6 +143,7 @@ impl DiffReport {
     }
 }
 
+#[allow(clippy::too_many_lines)] // single-pass diff over services × hosts; splitting hides the data flow
 pub async fn compute(
     ops: &dyn DockerOps,
     config: &Config,
@@ -119,20 +151,28 @@ pub async fn compute(
     services_filter: Option<&[String]>,
     secrets: Option<&SecretsBundle>,
 ) -> Result<DiffReport, DiffError> {
-    // Snapshot every host's yoink-managed containers, exactly like
-    // `deploy::reconcile` does in its pre-flight pass.
-    let mut snapshot: BTreeMap<String, Vec<ContainerInfo>> = BTreeMap::new();
-    for host_cfg in &config.hosts {
-        let host = Host::from(host_cfg);
-        let containers = ops
-            .list_containers_by_label(&host, "yoink.managed=true")
-            .await
-            .map_err(|source| DiffError::Docker {
-                host: host.address.clone(),
-                source,
-            })?;
-        snapshot.insert(host.address.clone(), containers);
-    }
+    // Snapshot every host's yoink-managed containers in parallel —
+    // for an N-host fleet this is one round-trip instead of N. Same
+    // fan-out shape `deploy::reconcile` and the prune path use.
+    let snapshot: BTreeMap<String, Vec<ContainerInfo>> = {
+        let futs = config.hosts.iter().map(|host_cfg| {
+            let host = Host::from(host_cfg);
+            async move {
+                let containers = ops
+                    .list_containers_by_label(&host, "yoink.managed=true")
+                    .await
+                    .map_err(|source| DiffError::Docker {
+                        host: host.address.clone(),
+                        source,
+                    })?;
+                Ok::<_, DiffError>((host.address, containers))
+            }
+        });
+        futures_util::future::try_join_all(futs)
+            .await?
+            .into_iter()
+            .collect()
+    };
 
     let selected: BTreeSet<&str> = match services_filter {
         Some(f) => f.iter().map(String::as_str).collect(),
@@ -197,10 +237,22 @@ pub async fn compute(
                     },
                     Some(c) => {
                         owned.insert((host.clone(), c.name.clone()));
+                        let fields = inspect_field_diff(
+                            ops,
+                            &Host::from(host_cfg),
+                            &c.name,
+                            svc,
+                            &tag,
+                            &desired_hash,
+                            secrets,
+                        )
+                        .await
+                        .unwrap_or_default();
                         ChangeKind::Update {
                             current_hash: c.yoink_spec_hash.clone().unwrap_or_default(),
                             current_image: c.image.clone(),
                             desired_image: desired_image.clone(),
+                            fields,
                         }
                     }
                 }
@@ -229,6 +281,80 @@ pub async fn compute(
     }
 
     Ok(DiffReport { services, orphans })
+}
+
+/// Inspect the running container, parse its env into a key/value map,
+/// and return a key-only diff against the desired env+labels. Errors
+/// are swallowed (`Default::default()` returned) — the dry-run is
+/// informational and the hash drift is still authoritative.
+async fn inspect_field_diff(
+    ops: &dyn DockerOps,
+    host: &Host,
+    container: &str,
+    service: &crate::config::ServiceConfig,
+    tag: &str,
+    desired_hash: &str,
+    secrets: Option<&SecretsBundle>,
+) -> Result<FieldDiff, DockerError> {
+    let detail = ops.inspect_container(host, container).await?;
+    let current_env = detail.env_map();
+    let desired_env = deploy::build_env(service, secrets);
+    let (env_added, env_removed, env_changed) = diff_kv(&current_env, &desired_env);
+
+    let desired_labels = deploy::build_labels(service, tag, desired_hash);
+    let (mut labels_added, mut labels_removed, mut labels_changed) =
+        diff_kv(&detail.labels, &desired_labels);
+    // Suppress the labels yoink itself manages so the operator doesn't
+    // see them in every diff:
+    //   - `yoink.version` / `yoink.spec_hash` are already shown via the
+    //     dedicated tag/spec_hash diff lines.
+    //   - `yoink.deployed-*` are audit labels written at deploy time
+    //     (see `deploy::audit_labels`), kept out of `build_labels` so
+    //     the spec_hash isn't poisoned. Without this filter every
+    //     Update would report them as `removed` since they're in the
+    //     running container but not in `desired_labels`.
+    labels_added.retain(|k| !is_yoink_managed_label(k));
+    labels_removed.retain(|k| !is_yoink_managed_label(k));
+    labels_changed.retain(|k| !is_yoink_managed_label(k));
+
+    Ok(FieldDiff {
+        env_added,
+        env_removed,
+        env_changed,
+        labels_added,
+        labels_removed,
+        labels_changed,
+    })
+}
+
+/// Labels yoink manages on its own and that the field-diff suppresses
+/// from added/removed/changed lists. These are either represented by
+/// other parts of the diff (`yoink.version`, `yoink.spec_hash` ↔ the
+/// tag and `spec_hash` columns) or by design absent from `build_labels`
+/// (`yoink.deployed-*` audit labels — see `deploy::audit_labels`).
+fn is_yoink_managed_label(k: &str) -> bool {
+    matches!(k, "yoink.version" | "yoink.spec_hash") || k.starts_with("yoink.deployed-")
+}
+
+fn diff_kv(
+    current: &BTreeMap<String, String>,
+    desired: &BTreeMap<String, String>,
+) -> (Vec<String>, Vec<String>, Vec<String>) {
+    let mut added = Vec::new();
+    let mut changed = Vec::new();
+    for (k, v) in desired {
+        match current.get(k) {
+            None => added.push(k.clone()),
+            Some(cv) if cv != v => changed.push(k.clone()),
+            _ => {}
+        }
+    }
+    let removed: Vec<String> = current
+        .keys()
+        .filter(|k| !desired.contains_key(*k))
+        .cloned()
+        .collect();
+    (added, removed, changed)
 }
 
 // ---------------------------------------------------------------------
@@ -360,18 +486,65 @@ fn text_row(d: &ServiceDiff) -> String {
             current_hash,
             current_image,
             desired_image,
-        } => format!(
-            "~ {:18} {} → {}    {current_image} → {desired_image}",
-            d.service,
-            short(current_hash),
-            short(&d.desired_hash),
-        ),
+            fields,
+        } => {
+            let head = format!(
+                "~ {:18} {} → {}    {current_image} → {desired_image}",
+                d.service,
+                short(current_hash),
+                short(&d.desired_hash),
+            );
+            let detail = field_diff_lines(fields, "      ");
+            if detail.is_empty() {
+                head
+            } else {
+                format!("{head}\n{detail}")
+            }
+        }
         ChangeKind::NoOp { current_hash } => format!(
             "= {:18} {}              (no change)",
             d.service,
             short(current_hash)
         ),
     }
+}
+
+/// Render a `FieldDiff` as `+`/`-`/`~` lines, indented by `indent`.
+/// Empty when nothing changed at the env/label level.
+fn field_diff_lines(fields: &FieldDiff, indent: &str) -> String {
+    if fields.is_empty() {
+        return String::new();
+    }
+    let mut lines = Vec::new();
+    let mut group = |label: &str, added: &[String], removed: &[String], changed: &[String]| {
+        if added.is_empty() && removed.is_empty() && changed.is_empty() {
+            return;
+        }
+        let mut parts = Vec::new();
+        for k in added {
+            parts.push(format!("+ {k}"));
+        }
+        for k in removed {
+            parts.push(format!("- {k}"));
+        }
+        for k in changed {
+            parts.push(format!("~ {k}"));
+        }
+        lines.push(format!("{indent}{label}: {}", parts.join(", ")));
+    };
+    group(
+        "env",
+        &fields.env_added,
+        &fields.env_removed,
+        &fields.env_changed,
+    );
+    group(
+        "labels",
+        &fields.labels_added,
+        &fields.labels_removed,
+        &fields.labels_changed,
+    );
+    lines.join("\n")
 }
 
 fn markdown_cells(d: &ServiceDiff) -> (&'static str, String, String) {
@@ -383,6 +556,7 @@ fn markdown_cells(d: &ServiceDiff) -> (&'static str, String, String) {
             current_hash,
             current_image,
             desired_image,
+            fields: _,
         } => (
             "🟡",
             format!("`{}` → `{}`", short(current_hash), short(&d.desired_hash)),
@@ -427,6 +601,7 @@ mod tests {
                 current_hash: "0123456789".into(),
                 current_image: "img:v1".into(),
                 desired_image: "img:v2".into(),
+                fields: FieldDiff::default(),
             },
         }
     }
@@ -521,5 +696,47 @@ mod tests {
         let r = diff_with(vec![noop("a", "h1")], vec![]);
         let m = r.render(Format::Markdown);
         assert!(m.contains("_No changes._"));
+    }
+
+    #[test]
+    fn text_render_shows_field_diff_under_update() {
+        let mut row = update("api", "h1");
+        if let ChangeKind::Update { ref mut fields, .. } = row.change {
+            fields.env_added = vec!["DATABASE_POOL_SIZE".into()];
+            fields.env_changed = vec!["LOG_LEVEL".into()];
+            fields.labels_removed = vec!["yoink.caddy.tls".into()];
+        }
+        let t = diff_with(vec![row], vec![]).render(Format::Text);
+        assert!(t.contains("env: + DATABASE_POOL_SIZE, ~ LOG_LEVEL"));
+        assert!(t.contains("labels: - yoink.caddy.tls"));
+    }
+
+    #[test]
+    fn is_yoink_managed_label_recognises_audit_and_spec_keys() {
+        assert!(is_yoink_managed_label("yoink.version"));
+        assert!(is_yoink_managed_label("yoink.spec_hash"));
+        assert!(is_yoink_managed_label("yoink.deployed-by"));
+        assert!(is_yoink_managed_label("yoink.deployed-at"));
+        // Other yoink labels (caddy, custom user labels under yoink.*)
+        // remain visible in the diff.
+        assert!(!is_yoink_managed_label("yoink.caddy.domain"));
+        assert!(!is_yoink_managed_label("yoink.service"));
+        assert!(!is_yoink_managed_label("org.opencontainers.image.description"));
+    }
+
+    #[test]
+    fn diff_kv_classifies_added_removed_changed() {
+        let mut current = BTreeMap::new();
+        current.insert("KEEP".into(), "same".into());
+        current.insert("CHANGE".into(), "old".into());
+        current.insert("REMOVE".into(), "gone".into());
+        let mut desired = BTreeMap::new();
+        desired.insert("KEEP".into(), "same".into());
+        desired.insert("CHANGE".into(), "new".into());
+        desired.insert("ADD".into(), "fresh".into());
+        let (added, removed, changed) = diff_kv(&current, &desired);
+        assert_eq!(added, vec!["ADD"]);
+        assert_eq!(removed, vec!["REMOVE"]);
+        assert_eq!(changed, vec!["CHANGE"]);
     }
 }

--- a/yoink/src/docker_ops.rs
+++ b/yoink/src/docker_ops.rs
@@ -369,6 +369,21 @@ pub struct ContainerDetail {
     pub read_only: bool,
 }
 
+impl ContainerDetail {
+    /// Parse `env: Vec<"KEY=VALUE">` into a key/value map. Lines
+    /// without `=` (rare but legal in docker) are dropped — the
+    /// callers (TUI redaction, dry-run diff) only care about keyed
+    /// values. Cheap; recompute at call sites rather than caching.
+    #[must_use]
+    pub fn env_map(&self) -> BTreeMap<String, String> {
+        self.env
+            .iter()
+            .filter_map(|kv| kv.split_once('='))
+            .map(|(k, v)| (k.to_string(), v.to_string()))
+            .collect()
+    }
+}
+
 /// One docker network as the dashboard / `yoink networks` show it.
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
 pub struct NetworkInfo {

--- a/yoink/src/lib.rs
+++ b/yoink/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod build;
+pub mod completion;
 pub mod config;
 pub mod deploy;
 pub mod diff;

--- a/yoink/src/main.rs
+++ b/yoink/src/main.rs
@@ -212,6 +212,24 @@ enum Command {
         /// up). Combine with `--service <name>` to limit blast radius.
         #[arg(long)]
         force: bool,
+        /// Use `git rev-parse --short HEAD` as the tag for every
+        /// selected service (or every service when `--service` is
+        /// omitted). Equivalent to `--service x --tag $(git rev-parse
+        /// --short HEAD)` per service. Conflicts with bare `--tag`.
+        #[arg(long, conflicts_with = "tag")]
+        here: bool,
+        /// Friendlier alias for `--dry-run`. Mirrors `terraform plan`:
+        /// print what would change and exit without mutating. With
+        /// the default `--format text`, output reads as a per-service
+        /// summary; `--format markdown` is suitable for PR comments.
+        #[arg(long, conflicts_with = "watch")]
+        plan: bool,
+        /// Re-reconcile whenever the config changes on disk. Polls
+        /// every 2s — same cadence as the TUI's reload tick. Pairs
+        /// with `--build --no-registry --service <name>` for the
+        /// edit-save-deploy inner loop. Ctrl-C exits.
+        #[arg(long)]
+        watch: bool,
     },
     /// Build one or more services' images via `docker build` against
     /// the operator's local docker daemon. Tags the result as
@@ -305,7 +323,11 @@ enum Command {
     Version { service: String },
     /// Drop into an interactive PTY shell inside a service's container
     /// (k9s-style, terminal-side). Picks `bash` when present, falls
-    /// back to `sh`. Exit with `exit` or Ctrl-D.
+    /// back to `sh`. With multiple replicas and no `--host`, picks the
+    /// first healthy replica. Exit with `exit` or Ctrl-D.
+    ///
+    /// Aliased as `ssh` for muscle memory.
+    #[command(alias = "ssh")]
     Shell {
         /// Service name as declared in the config.
         service: String,
@@ -453,11 +475,32 @@ enum Command {
         #[arg(value_enum)]
         shell: clap_complete::Shell,
     },
+    /// Internal: print field values for shell completion. Hidden
+    /// because it's plumbing for the bash/zsh snippet documented in
+    /// the CLI reference; operators don't invoke it directly.
+    #[command(name = "__complete", hide = true)]
+    Complete {
+        #[arg(value_enum)]
+        what: CompleteKind,
+    },
     /// Manage `age`-sealed secrets (the batteries-included default).
     Secrets {
         #[command(subcommand)]
         action: SecretsAction,
     },
+}
+
+/// What `yoink __complete` lists. Drives the dynamic-completion
+/// snippets in the CLI reference docs — extend as new shell-completion
+/// needs surface.
+#[derive(Debug, Clone, Copy, clap::ValueEnum)]
+enum CompleteKind {
+    Services,
+    Hosts,
+    /// Yoink config files reachable from the current working
+    /// directory. Walked depth-first, ranked by recency. Powers
+    /// `yoink -c <TAB>`.
+    Configs,
 }
 
 /// Subcommands for `yoink secrets`.
@@ -725,6 +768,9 @@ async fn run(cli: Cli) -> Result<()> {
             transport,
             build,
             force,
+            here,
+            plan,
+            watch,
         } => {
             cmd_up(
                 &config,
@@ -738,6 +784,10 @@ async fn run(cli: Cli) -> Result<()> {
                     transport: transport.into(),
                     build,
                     force,
+                    here,
+                    plan,
+                    watch,
+                    config_path: &cli.config,
                 },
             )
             .await
@@ -806,6 +856,10 @@ async fn run(cli: Cli) -> Result<()> {
             cmd_completions(shell);
             Ok(())
         }
+        Command::Complete { what } => {
+            cmd_complete(&config, what);
+            Ok(())
+        }
         Command::Secrets { action } => cmd_secrets(&config, action),
         Command::Tui { mode, mouse } => cmd_tui(&config, cli.config.clone(), mode, mouse).await,
         Command::Init { .. } => unreachable!("init handled by run_bootstrap"),
@@ -838,9 +892,8 @@ async fn cmd_preflight(config: &Config) -> Result<()> {
     Ok(())
 }
 
-// `UpOptions` mirrors the `up` subcommand's flags 1:1. The bool count
-// is the actual CLI surface; rolling them into an enum would just hide
-// the same surface area at higher cognitive cost.
+// Each bool is a discrete CLI flag; collapsing them would just hide
+// the same surface area behind an enum.
 #[allow(clippy::struct_excessive_bools)]
 struct UpOptions<'a> {
     services: &'a [String],
@@ -852,22 +905,105 @@ struct UpOptions<'a> {
     transport: yoink::transport::Transport,
     build: bool,
     force: bool,
+    /// Pin every selected service to the current git short SHA.
+    here: bool,
+    /// Friendlier alias for `dry_run` — same machinery, different name.
+    plan: bool,
+    /// Re-reconcile on config-file change. Drives the watch loop in
+    /// `cmd_up` after the initial run completes.
+    watch: bool,
+    /// Source path for the watch loop's `Config::load_from_path` polling.
+    /// Always set when `watch` is true; ignored otherwise.
+    config_path: &'a std::path::Path,
 }
 
-#[allow(clippy::too_many_lines)] // borderline (6 lines over); split if it grows further
 async fn cmd_up(config: &Config, up: UpOptions<'_>) -> Result<()> {
+    let dry_run = up.dry_run || up.plan;
+
+    do_up_once(config, &up, dry_run).await?;
+    if !up.watch {
+        return Ok(());
+    }
+    if dry_run {
+        // The watch loop only makes sense when we're actually
+        // mutating — otherwise it would re-print the same diff every
+        // 2s. Reject rather than silently spin.
+        anyhow::bail!("--watch and --plan/--dry-run are mutually exclusive");
+    }
+
+    eprintln!("● watching {} for changes (Ctrl-C to exit)", up.config_path.display());
+    let mut last_config = config.clone();
+    let mut last_error: Option<String> = None;
+    let mut tick = tokio::time::interval(WATCH_TICK);
+    tick.tick().await; // burn the immediate first fire
+    let ctrlc = tokio::signal::ctrl_c();
+    tokio::pin!(ctrlc);
+    loop {
+        tokio::select! {
+            _ = &mut ctrlc => {
+                eprintln!("\n✗ watch interrupted");
+                break;
+            }
+            _ = tick.tick() => {
+                let next = match Config::load_from_path(up.config_path) {
+                    Ok(c) => {
+                        // Surface the recovery once so the operator
+                        // knows yoink is happy again.
+                        if last_error.is_some() {
+                            eprintln!("● config OK — resuming");
+                            last_error = None;
+                        }
+                        c
+                    }
+                    Err(e) => {
+                        // Print the parse error once per *unique*
+                        // message — a half-saved edit shouldn't fill
+                        // the terminal with the same error every 2s.
+                        let msg = format!("✗ config reload failed: {e}");
+                        if last_error.as_deref() != Some(msg.as_str()) {
+                            eprintln!("{msg}");
+                            last_error = Some(msg);
+                        }
+                        continue;
+                    }
+                };
+                if next == last_config {
+                    continue;
+                }
+                eprintln!("● config changed — reconciling");
+                if let Err(e) = do_up_once(&next, &up, dry_run).await {
+                    eprintln!("✗ reconcile failed: {e:#}");
+                }
+                last_config = next;
+            }
+        }
+    }
+    Ok(())
+}
+
+const WATCH_TICK: std::time::Duration = std::time::Duration::from_secs(2);
+
+#[allow(clippy::too_many_lines)]
+async fn do_up_once(config: &Config, up: &UpOptions<'_>, dry_run: bool) -> Result<()> {
     use yoink::docker_ops::Host;
     use yoink::lock::HostLock;
-    let UpOptions {
+    let &UpOptions {
         services,
         tag_args,
         allow_dirty,
-        dry_run,
         format,
         no_registry,
         transport,
         build,
         force,
+        here,
+        // `dry_run` arrives as a separate parameter (collapsed with
+        // `plan` upstream); `plan`, `watch`, `config_path` are
+        // handled by the caller.
+        dry_run: _,
+        plan: _,
+        watch: _,
+        config_path: _,
     } = up;
 
     // Load bundle first so build_real_ops can reuse it for any
@@ -877,7 +1013,25 @@ async fn cmd_up(config: &Config, up: UpOptions<'_>) -> Result<()> {
     // their own clone for the duration of the deploy.
     let ops: std::sync::Arc<dyn DockerOps> =
         std::sync::Arc::new(build_real_ops(config, bundle.as_ref()).await?);
-    let tag_overrides = parse_tag_overrides(tag_args, services, allow_dirty)?;
+    // `--here`: resolve current git short SHA and inject as per-service
+    // `name=tag` overrides so the rest of the pipeline treats it like
+    // any other explicit tag — and `parse_tag_overrides`'s bare-tag-
+    // without-service guard doesn't fire.
+    let here_overrides: Vec<String> = if here {
+        let cwd = std::env::current_dir().context("--here: read current directory")?;
+        let sha = git::current_short_sha(&cwd)
+            .context("--here: resolve git short SHA from current directory")?;
+        let names: Vec<&str> = if services.is_empty() {
+            config.services.iter().map(|s| s.name.as_str()).collect()
+        } else {
+            services.iter().map(String::as_str).collect()
+        };
+        names.iter().map(|n| format!("{n}={sha}")).collect()
+    } else {
+        Vec::new()
+    };
+    let tag_args: Vec<String> = tag_args.iter().chain(here_overrides.iter()).cloned().collect();
+    let tag_overrides = parse_tag_overrides(&tag_args, services, allow_dirty)?;
 
     let services_filter = services_filter(services);
 
@@ -1201,6 +1355,10 @@ async fn cmd_rollback(config: &Config, service: String, tag: Option<String>) -> 
             transport: yoink::transport::Transport::Auto,
             build: false,
             force: false,
+            here: false,
+            plan: false,
+            watch: false,
+            config_path: std::path::Path::new(""),
         },
     )
     .await
@@ -1274,44 +1432,67 @@ async fn build_real_ops(
 /// via the `yoink.service=<name>` label. Errors with the candidate set
 /// when the user doesn't pin a host on a multi-replica service, so an
 /// `exec` or `logs` command can't accidentally hit the wrong replica.
+/// Every running replica of `service` (optionally filtered to a host).
+/// Used by both the strict `resolve_running_container` (errors on >1)
+/// and the replica-aware shell/logs paths (auto-pick / multiplex).
+/// Per-host listings run in parallel — for a fleet of N hosts this is
+/// one round-trip instead of N. Same fan-out shape used elsewhere in
+/// the CLI (deploy.rs, prune, prefetch).
+async fn list_running_replicas(
+    ops: &dyn DockerOps,
+    config: &Config,
+    service: &str,
+    host_filter: Option<&str>,
+) -> Result<Vec<(yoink::docker_ops::Host, yoink::docker_ops::ContainerInfo)>> {
+    use yoink::docker_ops::Host;
+    let label = format!("yoink.service={service}");
+    let futs = config
+        .hosts
+        .iter()
+        .filter(|h| host_filter.is_none_or(|f| f == h.address))
+        .map(|host_cfg| {
+            let host = Host::from(host_cfg);
+            let label = &label;
+            async move {
+                let containers = ops
+                    .list_containers_by_label(&host, label)
+                    .await
+                    .with_context(|| format!("list containers on {}", host.address))?;
+                anyhow::Ok((host, containers))
+            }
+        });
+    let per_host = futures_util::future::try_join_all(futs).await?;
+    let mut candidates = Vec::new();
+    for (host, containers) in per_host {
+        for c in containers {
+            if c.is_running() {
+                candidates.push((host.clone(), c));
+            }
+        }
+    }
+    Ok(candidates)
+}
+
+/// Strict resolver — errors on zero or many candidates. Used by gestures
+/// that target *one* container (`exec`, `restart`, `version`, `logs`
+/// without multiplexing).
 async fn resolve_running_container(
     ops: &dyn DockerOps,
     config: &Config,
     service: &str,
     host_filter: Option<&str>,
 ) -> Result<(yoink::docker_ops::Host, String)> {
-    use yoink::docker_ops::Host;
-    let label = format!("yoink.service={service}");
-    let mut candidates: Vec<(Host, String)> = Vec::new();
-    for host_cfg in &config.hosts {
-        if let Some(filter) = host_filter
-            && filter != host_cfg.address
-        {
-            continue;
-        }
-        let host = Host::from(host_cfg);
-        let containers = ops
-            .list_containers_by_label(&host, &label)
-            .await
-            .with_context(|| format!("list containers on {}", host.address))?;
-        for c in containers {
-            if c.is_running() {
-                candidates.push((host.clone(), c.name));
-            }
-        }
-    }
+    let candidates = list_running_replicas(ops, config, service, host_filter).await?;
     match candidates.len() {
-        0 => anyhow::bail!(
-            "no running container with yoink.service={service}{}",
-            host_filter
-                .map(|h| format!(" on host {h}"))
-                .unwrap_or_default()
-        ),
-        1 => Ok(candidates.into_iter().next().expect("len == 1")),
+        0 => Err(no_replicas_err(service, host_filter)),
+        1 => {
+            let (h, c) = candidates.into_iter().next().expect("len == 1");
+            Ok((h, c.name))
+        }
         _ => {
             let listing = candidates
                 .iter()
-                .map(|(h, n)| format!("  {} → {}", h.address, n))
+                .map(|(h, c)| format!("  {} → {}", h.address, c.name))
                 .collect::<Vec<_>>()
                 .join("\n");
             anyhow::bail!(
@@ -1319,6 +1500,33 @@ async fn resolve_running_container(
             )
         }
     }
+}
+
+/// Standard "no running replicas" error, shared by every gesture
+/// that targets a service by name (`shell`, `logs`, `exec`, …).
+fn no_replicas_err(service: &str, host_filter: Option<&str>) -> anyhow::Error {
+    anyhow::anyhow!(
+        "no running container with yoink.service={service}{}",
+        host_filter
+            .map(|h| format!(" on host {h}"))
+            .unwrap_or_default()
+    )
+}
+
+/// Replica-aware picker: prefer the first explicitly healthy replica;
+/// fall back to the first running. The fall-back covers services with
+/// no `healthcheck_path:` (where `health_hint()` is always `None`) so
+/// `yoink shell <svc>` still works on them.
+fn pick_healthy_replica(
+    candidates: Vec<(yoink::docker_ops::Host, yoink::docker_ops::ContainerInfo)>,
+) -> Option<(yoink::docker_ops::Host, yoink::docker_ops::ContainerInfo)> {
+    if let Some(idx) = candidates
+        .iter()
+        .position(|(_, c)| c.health_hint() == Some("healthy"))
+    {
+        return candidates.into_iter().nth(idx);
+    }
+    candidates.into_iter().next()
 }
 
 async fn cmd_exec(
@@ -1352,32 +1560,103 @@ async fn cmd_logs(
     follow: bool,
     tail: u32,
 ) -> Result<()> {
-    let ops = build_real_ops(config, None).await?;
-    let (host, container) = resolve_running_container(&ops, config, service, host_filter).await?;
+    let ops: std::sync::Arc<dyn DockerOps> =
+        std::sync::Arc::new(build_real_ops(config, None).await?);
+    let candidates = list_running_replicas(ops.as_ref(), config, service, host_filter).await?;
+    if candidates.is_empty() {
+        return Err(no_replicas_err(service, host_filter));
+    }
     if follow {
-        let mut rx = ops
-            .open_log_stream(&host, &container, tail)
-            .await
-            .with_context(|| format!("open log stream {}@{container}", host.address))?;
-        // Honor SIGINT cleanly so Ctrl-C doesn't dump a panic.
-        let ctrlc = tokio::signal::ctrl_c();
-        tokio::pin!(ctrlc);
-        loop {
-            tokio::select! {
-                line = rx.recv() => match line {
-                    Some(l) => println!("{}", l.message),
-                    None => break,
-                },
-                _ = &mut ctrlc => break,
-            }
-        }
+        cmd_logs_follow(ops, candidates, tail).await
     } else {
+        cmd_logs_tail(&*ops, candidates, tail).await
+    }
+}
+
+/// `[host/container] ` prefix, or empty when there's only one replica
+/// (preserved so shell pipelines piping `yoink logs` into `grep` keep
+/// working unchanged for the single-replica case).
+fn replica_prefix(host: &yoink::docker_ops::Host, info: &yoink::docker_ops::ContainerInfo, multi: bool) -> String {
+    if multi {
+        format!("[{}/{}] ", host.address, info.name)
+    } else {
+        String::new()
+    }
+}
+
+/// Multiplexed `--follow` path: one stream task per replica fanned
+/// into a shared mpsc. `drop(tx)` after the spawn loop closes the
+/// channel once every per-replica task exits.
+async fn cmd_logs_follow(
+    ops: std::sync::Arc<dyn DockerOps>,
+    candidates: Vec<(yoink::docker_ops::Host, yoink::docker_ops::ContainerInfo)>,
+    tail: u32,
+) -> Result<()> {
+    let multi = candidates.len() > 1;
+    let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel::<String>();
+    for (host, info) in candidates {
+        let ops = ops.clone();
+        let tx = tx.clone();
+        let prefix = replica_prefix(&host, &info, multi);
+        tokio::spawn(async move {
+            let mut stream = match ops.open_log_stream(&host, &info.name, tail).await {
+                Ok(rx) => rx,
+                Err(e) => {
+                    let _ = tx.send(format!("{prefix}log stream failed: {e}"));
+                    return;
+                }
+            };
+            while let Some(line) = stream.recv().await {
+                let formatted = if prefix.is_empty() {
+                    line.message
+                } else {
+                    format!("{prefix}{}", line.message)
+                };
+                if tx.send(formatted).is_err() {
+                    return;
+                }
+            }
+        });
+    }
+    drop(tx);
+    let ctrlc = tokio::signal::ctrl_c();
+    tokio::pin!(ctrlc);
+    loop {
+        tokio::select! {
+            line = rx.recv() => match line {
+                Some(s) => println!("{s}"),
+                None => break,
+            },
+            _ = &mut ctrlc => break,
+        }
+    }
+    Ok(())
+}
+
+/// One-shot tail path: fetch each replica's recent log buffer and
+/// print, prefixing per-line when there's >1 replica. `fetch_recent_logs`
+/// returns lines with trailing newlines preserved, so prefixes are
+/// inserted before each `\n`-delimited segment.
+async fn cmd_logs_tail(
+    ops: &dyn DockerOps,
+    candidates: Vec<(yoink::docker_ops::Host, yoink::docker_ops::ContainerInfo)>,
+    tail: u32,
+) -> Result<()> {
+    let multi = candidates.len() > 1;
+    for (host, info) in candidates {
         let lines = ops
-            .fetch_recent_logs(&host, &container, tail)
+            .fetch_recent_logs(&host, &info.name, tail)
             .await
-            .with_context(|| format!("fetch logs {}@{container}", host.address))?;
+            .with_context(|| format!("fetch logs {}@{}", host.address, info.name))?;
+        let prefix = replica_prefix(&host, &info, multi);
         for l in lines {
-            print!("{l}");
+            if prefix.is_empty() {
+                print!("{l}");
+            } else {
+                for raw in l.split_inclusive('\n') {
+                    print!("{prefix}{raw}");
+                }
+            }
         }
     }
     Ok(())
@@ -1422,8 +1701,25 @@ async fn cmd_pty(
     use crossterm::terminal::{disable_raw_mode, enable_raw_mode, size};
 
     let ops: std::sync::Arc<dyn DockerOps> = std::sync::Arc::new(build_real_ops(config, None).await?);
-    let (host, container) =
-        resolve_running_container(ops.as_ref(), config, service, host_filter).await?;
+    // For shell, we don't need a single-replica guarantee — pick a
+    // healthy replica (or the first running one) and tell the operator
+    // which one we landed on.
+    let candidates = list_running_replicas(ops.as_ref(), config, service, host_filter).await?;
+    if candidates.is_empty() {
+        return Err(no_replicas_err(service, host_filter));
+    }
+    let multi = candidates.len() > 1;
+    let (host, info) =
+        pick_healthy_replica(candidates).expect("non-empty checked above");
+    let container = info.name.clone();
+    if multi {
+        eprintln!(
+            "→ {}/{} ({})",
+            host.address,
+            container,
+            info.health_hint().unwrap_or("running"),
+        );
+    }
 
     let (cols, rows) = size().context("query terminal size")?;
 
@@ -2539,6 +2835,30 @@ fn cmd_completions(shell: clap_complete::Shell) {
     clap_complete::generate(shell, &mut cmd, bin_name, &mut io::stdout());
 }
 
+/// Print one value per line. Output is consumed by the bash/zsh
+/// snippet in the CLI reference; stays terse on purpose. `Configs`
+/// is handled in `run_bootstrap` because completing config paths is
+/// the one case that *must* work without a config already loaded.
+fn cmd_complete(config: &Config, what: CompleteKind) {
+    match what {
+        CompleteKind::Services => {
+            for svc in &config.services {
+                println!("{}", svc.name);
+            }
+        }
+        CompleteKind::Hosts => {
+            for host in &config.hosts {
+                println!("{}", host.address);
+            }
+        }
+        CompleteKind::Configs => {
+            // Bootstrap should have caught this; render anyway in
+            // case someone calls through `run()` directly.
+            yoink::completion::print_yoink_configs();
+        }
+    }
+}
+
 /// Subcommands that don't need a `yoink.yaml`. Returns `Some(result)`
 /// to short-circuit `run`'s config-load step, or `None` to fall
 /// through.
@@ -2546,6 +2866,15 @@ fn run_bootstrap(command: &Command) -> Option<Result<()>> {
     match command {
         Command::Completions { shell } => {
             cmd_completions(*shell);
+            Some(Ok(()))
+        }
+        Command::Complete {
+            what: CompleteKind::Configs,
+        } => {
+            // Configs completion *cannot* depend on a config already
+            // existing — the whole point is to find one to use. Run
+            // before the load step in `run()`.
+            yoink::completion::print_yoink_configs();
             Some(Ok(()))
         }
         Command::Secrets {
@@ -2943,3 +3272,4 @@ fn chrono_like_now() -> String {
         .unwrap_or_default();
     format!("unix={secs}")
 }
+

--- a/yoink/src/proxy/mod.rs
+++ b/yoink/src/proxy/mod.rs
@@ -216,6 +216,7 @@ fn synthesized_proxy_service(p: &ProxyConfig) -> ServiceConfig {
     ServiceConfig {
         name: PROXY_SERVICE_NAME.to_string(),
         image,
+        description: None,
         kind: Some(ServiceKind::Proxy),
         build: None,
         tag,

--- a/yoink/src/tui/app.rs
+++ b/yoink/src/tui/app.rs
@@ -2814,7 +2814,27 @@ impl App {
         let secrets = self.secrets.clone();
         let tx = self.update_tx.clone();
         tokio::spawn(async move {
-            let bundle = secrets.read().await.clone();
+            // Fresh bundle per modal open. The cached one is loaded
+            // ONCE at startup (spawn_secrets_loader); a long-running
+            // TUI that outlives an Infisical edit / rotation would
+            // otherwise compute desired_hash from stale env and show
+            // bogus drift forever. On refresh failure, fall back to
+            // the cached bundle so the modal still renders something
+            // and surface the staleness via a toast.
+            let bundle = match crate::secrets::load_bundle(&config).await {
+                Ok(Some(fresh)) => {
+                    let arc = std::sync::Arc::new(fresh);
+                    *secrets.write().await = Some(arc.clone());
+                    Some(arc)
+                }
+                Ok(None) => None,
+                Err(e) => {
+                    let _ = tx.send(Update::Toast(format!(
+                        "✗ secrets refresh failed: {e} (drift may use stale values)"
+                    )));
+                    secrets.read().await.clone()
+                }
+            };
             let mut overrides = std::collections::BTreeMap::new();
             // For services with no `tag:` in config, fall back to the
             // running replica's tag so the diff isolates the env/label

--- a/yoink/src/tui/app.rs
+++ b/yoink/src/tui/app.rs
@@ -161,6 +161,8 @@ impl View {
             "  q / Ctrl-C    quit yoink",
             "  d h s l       dashboard / hosts / services / logs",
             "  R e           resources / encrypted-secrets",
+            "  E             edit config in $EDITOR (jumps to focused service/host)",
+            "  ~             show drift detail for the focused service",
             "  Tab / S-Tab   cycle modes forward / backward",
             "  ?             toggle this help overlay",
             "",
@@ -401,6 +403,13 @@ enum Update {
         container: String,
         result: Result<crate::docker_ops::ProcessTable, String>,
     },
+    /// Result of a drift-modal fetch — the matching `ServiceDiff`
+    /// for `(host, service)` produced by `diff::compute`.
+    Drift {
+        host: Host,
+        service: String,
+        result: super::drift::DriftRefresh,
+    },
     /// Batch of `(host_address, container_name, stats)` samples produced
     /// by the always-on background stats poller. Each sample is folded
     /// into the per-container `StatsHistory` so that opening a
@@ -548,6 +557,7 @@ pub async fn run(
         ops,
         mode,
         hl_available,
+        mouse,
     )
     .await;
     let restore = restore_terminal(&mut terminal, mouse);
@@ -608,6 +618,7 @@ async fn run_loop(
     ops: Arc<dyn DockerOps>,
     mode: Mode,
     hl_available: bool,
+    mouse: bool,
 ) -> Result<()> {
     let mut app = App::new(config, config_path, ops, View::from(mode), hl_available);
     // Schedule the first round of background fetches so each pane has data
@@ -630,11 +641,15 @@ async fn run_loop(
     // matters when the shell view is up and `inner` is None; the
     // branch is gated so it's a no-op otherwise.
     let mut shell_spin_tick = interval(Duration::from_millis(125));
+    // 10fps spinner animation; cheap because ratatui's diff renderer
+    // only writes changed cells, but the redraw rate is the floor.
+    let mut throbber_tick = interval(Duration::from_millis(100));
     fast_tick.tick().await;
     hosts_tick.tick().await;
     resources_tick.tick().await;
     config_tick.tick().await;
     shell_spin_tick.tick().await;
+    throbber_tick.tick().await;
 
     loop {
         terminal.draw(|f| app.render(f))?;
@@ -645,6 +660,27 @@ async fn run_loop(
                     Some(Ok(Event::Key(key))) => {
                         if app.on_key(key).await {
                             return Ok(());
+                        }
+                        if let Some(target) = app.take_pending_editor() {
+                            // Run the editor synchronously — the operator
+                            // is *editing*; nothing else should fire while
+                            // the alt-screen is torn down.
+                            restore_terminal(terminal, mouse)
+                                .context("restore terminal for $EDITOR")?;
+                            let status = super::editor::run_editor(&target);
+                            *terminal = setup_terminal(mouse)
+                                .context("re-setup terminal after $EDITOR")?;
+                            terminal.clear().context("clear terminal after $EDITOR")?;
+                            match status {
+                                Ok(s) if !s.success() => app.push_toast(format!(
+                                    "✗ editor exited with status {s}"
+                                )),
+                                Err(e) => app.push_toast(format!("✗ editor failed: {e}")),
+                                _ => {}
+                            }
+                            // Pick up edits immediately rather than
+                            // waiting for the next reload tick.
+                            app.maybe_reload_config();
                         }
                     }
                     Some(Ok(Event::Mouse(m))) => app.on_mouse(m),
@@ -675,6 +711,9 @@ async fn run_loop(
             }
             _ = config_tick.tick() => {
                 app.maybe_reload_config();
+            }
+            _ = throbber_tick.tick() => {
+                app.tick_throbber();
             }
             Some(update) = app.update_rx.recv() => {
                 app.apply_update(update);
@@ -734,6 +773,11 @@ pub struct App {
     /// current view. The user confirms with `y` (or Enter) and
     /// cancels with anything else. Cleared on transition.
     kill_target: Option<(Host, String)>,
+    /// Drift inspection modal — populated by pressing `~` on a
+    /// drifted row. The fetch runs in the background and lands via
+    /// `Update::Drift`; the modal is rendered on top of whatever
+    /// view was active.
+    drift: super::drift::DriftState,
     /// `Some((service, tag))` while a reconcile-confirmation modal
     /// is open. `y` / Enter confirms; anything else cancels.
     reconcile_target: Option<(String, String)>,
@@ -822,6 +866,18 @@ pub struct App {
     /// Path to the root `yoink.yaml`. Re-read every `CONFIG_RELOAD_TICK`
     /// so on-disk edits flow into the running TUI.
     config_path: std::path::PathBuf,
+    /// Cached source-of-truth label for the chrome (e.g. "yoink(*)") —
+    /// shell-outs to `git` happen on the config-reload tick, not every
+    /// render. `None` = not in a git repo, or git isn't installed.
+    config_source: Option<String>,
+    /// Set when the operator pressed `E` to edit the config in
+    /// `$EDITOR`. Drained by `run_loop`, which suspends the alt-
+    /// screen, runs the editor synchronously, and re-enters the TUI.
+    pending_editor: Option<super::editor::EditorTarget>,
+    /// Drives the spinner glyph in `loading…` rows. Advanced on a
+    /// dedicated 100 ms tick so the animation looks alive even when
+    /// the slower data ticks aren't firing.
+    throbber_state: throbber_widgets_tui::ThrobberState,
     hl_available: bool,
 }
 
@@ -857,6 +913,7 @@ impl App {
             error_modal: None,
             shown_errors: std::collections::HashSet::new(),
             kill_target: None,
+            drift: super::drift::DriftState::default(),
             reconcile_target: None,
             prune_target: false,
             reconcile_all_target: false,
@@ -886,8 +943,95 @@ impl App {
             log_tx,
             log_rx,
             event_tasks: Vec::new(),
+            config_source: super::chrome::config_source(&config_path),
             config_path,
+            pending_editor: None,
+            throbber_state: throbber_widgets_tui::ThrobberState::default(),
             hl_available,
+        }
+    }
+
+    /// Drained by `run_loop` after each key event. When `Some`, the
+    /// outer loop suspends the TUI, runs `$EDITOR` on the target,
+    /// and re-enters the alt-screen + raw mode.
+    pub fn take_pending_editor(&mut self) -> Option<super::editor::EditorTarget> {
+        self.pending_editor.take()
+    }
+
+    /// Advance the loading-spinner glyph one frame.
+    pub fn tick_throbber(&mut self) {
+        self.throbber_state.calc_next();
+    }
+
+    /// Build the editor jump target for the current view. Falls back
+    /// to "open at line 1" when the focused object isn't a service or
+    /// host (e.g. the dashboard or the secrets pane), or when the
+    /// matching block can't be located in the root config file.
+    fn editor_target_for_current_view(&self) -> super::editor::EditorTarget {
+        let yaml = std::fs::read_to_string(&self.config_path).unwrap_or_default();
+        let line = match &self.view {
+            View::ServiceDetail(name) | View::ServiceHistory(name) => {
+                super::editor::find_service_line(&yaml, name)
+            }
+            View::HostDetail(host) => super::editor::find_host_line(&yaml, &host.address),
+            View::ContainerDetail { container, .. } | View::ContainerLogs { container, .. } => {
+                // Look up the service this container belongs to: try
+                // each declared service name as a `<name>-` prefix and
+                // pick the longest match. Service names in the same
+                // file are unique, so there's at most one valid hit.
+                self.config
+                    .services
+                    .iter()
+                    .filter(|s| {
+                        container == s.name.as_str()
+                            || container.starts_with(&format!("{}-", s.name))
+                    })
+                    .max_by_key(|s| s.name.len())
+                    .and_then(|s| super::editor::find_service_line(&yaml, &s.name))
+            }
+            _ => None,
+        };
+        super::editor::EditorTarget {
+            path: self.config_path.clone(),
+            line,
+        }
+    }
+
+    /// Resolve the focused `(host, service)` pair for the drift
+    /// modal. Each list view exposes its selected row; the container
+    /// detail view falls back to the inspected container's
+    /// `yoink.service` label. `None` when the current view has no
+    /// notion of a focused row (Logs / Resources / Secrets).
+    fn drift_focus(&self) -> Option<(Host, String)> {
+        let host_for = |addr: &str| -> Option<Host> {
+            self.config
+                .hosts
+                .iter()
+                .find(|h| h.address == addr)
+                .map(Host::from)
+        };
+        match &self.view {
+            View::Dashboard => {
+                let row = self.dashboard.selected()?;
+                let service = row.service?;
+                host_for(&row.host).map(|h| (h, service))
+            }
+            View::HostDetail(host) => self
+                .host_detail
+                .selected_service()
+                .map(|s| (host.clone(), s)),
+            View::ServiceDetail(svc) => {
+                let row = self.service_detail.selected_row()?;
+                Some((row.host, svc.clone()))
+            }
+            View::ContainerDetail { host, .. } => {
+                let labels = &self.container_detail.inspect()?.labels;
+                labels
+                    .get("yoink.service")
+                    .cloned()
+                    .map(|s| (host.clone(), s))
+            }
+            _ => None,
         }
     }
 
@@ -895,8 +1039,11 @@ impl App {
     /// actually changed. Silent no-op on parse errors so a half-saved
     /// edit doesn't blank the dashboard; the next tick will catch the
     /// finished edit. If `hosts:` changed we tear down and respawn the
-    /// docker-events subscriptions.
+    /// docker-events subscriptions. Also refreshes the chrome's git
+    /// "from <repo>(*)" label, which piggybacks on this slow tick so
+    /// `git status` doesn't run at render rate.
     fn maybe_reload_config(&mut self) {
+        self.config_source = super::chrome::config_source(&self.config_path);
         let mut new_config = match Config::load_from_path(&self.config_path) {
             Ok(c) => c,
             Err(e) => {
@@ -1390,6 +1537,14 @@ impl App {
             return false;
         }
 
+        // Drift modal: Esc dismisses, anything else falls through so
+        // the operator can keep typing into the underlying view (e.g.
+        // press `~` again on a different focus, or navigate away).
+        if self.drift.is_visible() && matches!(key.code, KeyCode::Esc) {
+            self.drift.clear();
+            return false;
+        }
+
         // Kill-confirmation modal: `y` / Enter confirms, anything else
         // dismisses. Captured before view-specific keys so a stray `j`
         // can't both dismiss and select-next.
@@ -1578,6 +1733,23 @@ impl App {
                 // already used for refresh; the per-view handler can
                 // map capital R to other things if needed).
                 self.transition(View::Resources).await;
+                return false;
+            }
+            // Capital `E` jumps into `$EDITOR` at the focused service /
+            // host's line in the config (lowercase `e` is taken by
+            // Secrets). The actual suspend + resume happens in
+            // `run_loop` so the alt-screen plumbing stays in one place.
+            KeyCode::Char('E') => {
+                self.pending_editor = Some(self.editor_target_for_current_view());
+                return false;
+            }
+            // `~` opens the drift modal for the focused (host, service).
+            // Shows the same `+`/`-`/`~` per-field diff `yoink up --plan`
+            // produces — without leaving the TUI. Esc closes.
+            KeyCode::Char('~') => {
+                if let Some((host, service)) = self.drift_focus() {
+                    self.open_drift(host, service);
+                }
                 return false;
             }
             // Tab / Shift-Tab cycle through the top-level modes
@@ -2617,7 +2789,70 @@ impl App {
                     self.push_toast(format!("✗ docker top {container}: {e}"));
                 }
             },
+            Update::Drift {
+                host,
+                service,
+                result,
+            } => {
+                self.drift.apply(&host, &service, result);
+            }
         }
+    }
+
+    /// Open the drift modal for `(host, service)` and spawn the
+    /// background fetch. The fetch reuses `diff::compute` so the
+    /// modal shows exactly what `yoink up --plan --service <name>`
+    /// would print on the CLI side. Tag overrides default to the
+    /// running container's `yoink.version` for git-versioned
+    /// services where `service.tag` is absent — otherwise
+    /// `compute` would error with `TagMissing`, which is correct
+    /// for `yoink up` but useless for "what changed".
+    fn open_drift(&mut self, host: Host, service: String) {
+        self.drift.set_target(host.clone(), service.clone());
+        let ops = self.ops.clone();
+        let config = self.config.clone();
+        let secrets = self.secrets.clone();
+        let tx = self.update_tx.clone();
+        tokio::spawn(async move {
+            let bundle = secrets.read().await.clone();
+            let mut overrides = std::collections::BTreeMap::new();
+            // For services with no `tag:` in config, fall back to the
+            // running replica's tag so the diff isolates the env/label
+            // change instead of erroring on a missing tag.
+            if let Some(svc) = config.services.iter().find(|s| s.name == service)
+                && svc.tag.is_none()
+                && let Ok(containers) = ops
+                    .list_containers_by_label(&host, &format!("yoink.service={service}"))
+                    .await
+                && let Some(running) = containers
+                    .iter()
+                    .find(|c| c.is_running())
+                    .and_then(|c| c.yoink_version.clone())
+            {
+                overrides.insert(service.clone(), running);
+            }
+            let services_filter = std::slice::from_ref(&service);
+            let result = match crate::diff::compute(
+                ops.as_ref(),
+                &config,
+                &overrides,
+                Some(services_filter),
+                bundle.as_deref(),
+            )
+            .await
+            {
+                Ok(report) => Ok(report
+                    .services
+                    .into_iter()
+                    .find(|d| d.host == host.address && d.service == service)),
+                Err(e) => Err(format!("{e}")),
+            };
+            let _ = tx.send(Update::Drift {
+                host,
+                service,
+                result,
+            });
+        });
     }
 
     /// React to a `docker events` push by refreshing whichever pane is
@@ -2771,7 +3006,16 @@ impl App {
             "Secrets",
         ];
         let selected_tab = Some(self.view.top_section());
-        super::ui::render_header(frame, header_area, &tabs, selected_tab, &crumbs, &right);
+        super::ui::render_header(
+            frame,
+            header_area,
+            &tabs,
+            selected_tab,
+            &crumbs,
+            &right,
+            self.config.slug.as_deref(),
+            self.config_source.as_deref(),
+        );
 
         let secrets = self.secrets.try_read().ok().and_then(|g| g.clone());
         match &self.view {
@@ -2782,9 +3026,12 @@ impl App {
                     &self.config,
                     secrets.as_deref(),
                     &self.container_history,
+                    &self.throbber_state,
                 );
             }
-            View::Hosts => self.hosts.render(frame, pane_area, &self.config),
+            View::Hosts => self
+                .hosts
+                .render(frame, pane_area, &self.config, &self.throbber_state),
             View::HostDetail(host) => {
                 let events: Vec<String> = self
                     .host_events
@@ -2798,6 +3045,7 @@ impl App {
                     secrets.as_deref(),
                     &events,
                     &self.container_history,
+                    &self.throbber_state,
                 );
             }
             View::ContainerDetail { host, container } => {
@@ -2812,16 +3060,28 @@ impl App {
                 let history: Option<&StatsHistory> = self
                     .container_history
                     .get(&(host.address.clone(), container.clone()));
-                self.container_detail.render(frame, split[0], history);
+                self.container_detail
+                    .render(frame, split[0], history, &self.throbber_state);
                 self.logs.render(frame, split[1], &self.config);
             }
-            View::Services => self.services.render(frame, pane_area, &self.config),
+            View::Services => self.services.render(
+                frame,
+                pane_area,
+                &self.config,
+                &self.throbber_state,
+            ),
             View::ServiceDetail(_) => {
-                self.service_detail
-                    .render(frame, pane_area, &self.config, secrets.as_deref());
+                self.service_detail.render(
+                    frame,
+                    pane_area,
+                    &self.config,
+                    secrets.as_deref(),
+                    &self.throbber_state,
+                );
             }
             View::ServiceHistory(_) => {
-                self.history.render(frame, pane_area);
+                self.history
+                    .render(frame, pane_area, &self.throbber_state);
             }
             View::Logs | View::ContainerLogs { .. } => {
                 self.logs.render(frame, pane_area, &self.config);
@@ -2840,10 +3100,12 @@ impl App {
             }
             View::Secrets => {
                 self.secrets_state.ensure_loaded(&self.config, false);
-                self.secrets_state.render(frame, pane_area);
+                self.secrets_state
+                    .render(frame, pane_area, &self.throbber_state);
             }
             View::Resources => {
-                self.resources.render(frame, pane_area, &self.config);
+                self.resources
+                    .render(frame, pane_area, &self.config, &self.throbber_state);
             }
         }
 
@@ -3001,15 +3263,19 @@ impl App {
                 JobKind::Prune => "prune".to_string(),
             };
             let title = format!(
-                " {header}{} ",
+                "{header}{}",
                 match &progress.finished {
-                    None => " (running…)".to_string(),
-                    Some(Ok(_)) => " (done — esc to close)".to_string(),
-                    Some(Err(_)) => " (failed — esc to close)".to_string(),
+                    None => " · running",
+                    Some(Ok(_)) => " · done — esc to close",
+                    Some(Err(_)) => " · failed — esc to close",
                 },
             );
             let success = matches!(progress.finished, Some(Ok(_)));
             let failure = matches!(progress.finished, Some(Err(_)));
+            let running_throbber = progress
+                .finished
+                .is_none()
+                .then_some(&self.throbber_state);
             // ReconcileAll gets a status table on top of the scrolling
             // log so concurrent waves don't make the operator hunt for
             // "where is service X right now?".
@@ -3025,10 +3291,22 @@ impl App {
                     &lines,
                     success,
                     failure,
+                    running_throbber,
                 );
             } else {
-                super::ui::render_log_modal(frame, &title, &lines, success, failure);
+                super::ui::render_log_modal(
+                    frame,
+                    &title,
+                    &lines,
+                    success,
+                    failure,
+                    running_throbber,
+                );
             }
+        }
+
+        if self.drift.is_visible() {
+            super::drift::render_modal(frame, &self.drift, &self.throbber_state);
         }
 
         // Render last so it sits on top of everything else when a

--- a/yoink/src/tui/chrome.rs
+++ b/yoink/src/tui/chrome.rs
@@ -1,0 +1,50 @@
+//! Helpers for the TUI top chrome: detect when the loaded config
+//! lives in a git repo and whether it's dirty, so the header can
+//! show "<repo>" / "<repo>(*)" — answering "which version of the
+//! config am I looking at" without leaving the TUI.
+
+use std::ffi::OsStr;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// Display name for the git repo containing the config file (when one
+/// exists), with `(*)` appended if the config file has uncommitted
+/// edits relative to HEAD. `None` when the file isn't in a git
+/// working tree, or `git` isn't on PATH.
+#[must_use]
+pub fn config_source(config_path: &Path) -> Option<String> {
+    let workdir = config_path.parent()?;
+    let repo_root_raw = run_git(workdir, &["rev-parse", "--show-toplevel"])?;
+    let repo_root = PathBuf::from(repo_root_raw.trim());
+    let name = repo_root
+        .file_name()
+        .map_or_else(|| "git".into(), |s| s.to_string_lossy().into_owned());
+    // Limit the dirty check to the config file itself — operators
+    // almost always have unrelated work-in-progress in the same repo
+    // and we only care whether *this config* differs from HEAD.
+    let status = run_git(
+        &repo_root,
+        &[OsStr::new("status"), OsStr::new("--porcelain"), OsStr::new("--"), config_path.as_os_str()],
+    );
+    if status
+        .as_deref()
+        .is_some_and(crate::git::is_dirty_from_status)
+    {
+        Some(format!("{name}(*)"))
+    } else {
+        Some(name)
+    }
+}
+
+fn run_git<S: AsRef<OsStr>>(workdir: &Path, args: &[S]) -> Option<String> {
+    let out = Command::new("git")
+        .arg("-C")
+        .arg(workdir)
+        .args(args)
+        .output()
+        .ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    String::from_utf8(out.stdout).ok()
+}

--- a/yoink/src/tui/container_detail.rs
+++ b/yoink/src/tui/container_detail.rs
@@ -238,6 +238,13 @@ impl ContainerDetailState {
         self.top_loading || self.top.is_some()
     }
 
+    /// Last-known inspect for the focused container, if loaded.
+    /// Used by `App::drift_focus` to resolve the service name from
+    /// the running container's `yoink.service` label.
+    pub fn inspect(&self) -> Option<&ContainerDetail> {
+        self.inspect.as_ref()
+    }
+
     pub fn target(&self) -> Option<&(Host, String)> {
         self.target.as_ref()
     }
@@ -258,7 +265,13 @@ impl ContainerDetailState {
         }
     }
 
-    pub fn render(&mut self, frame: &mut Frame<'_>, area: Rect, history: Option<&StatsHistory>) {
+    pub fn render(
+        &mut self,
+        frame: &mut Frame<'_>,
+        area: Rect,
+        history: Option<&StatsHistory>,
+        throbber: &throbber_widgets_tui::ThrobberState,
+    ) {
         if let Some(err) = &self.last_error {
             let block = Block::default().borders(Borders::ALL).title(" container ");
             frame.render_widget(
@@ -271,17 +284,20 @@ impl ContainerDetailState {
         }
 
         let Some(inspect) = &self.inspect else {
-            let msg = if self.loaded {
-                "(container not found — may have been removed)"
+            let block = Block::default().borders(Borders::ALL).title(" container ");
+            if self.loaded {
+                frame.render_widget(
+                    Paragraph::new("(container not found — may have been removed)")
+                        .style(Style::default().fg(Color::DarkGray))
+                        .block(block),
+                    area,
+                );
             } else {
-                "(loading…)"
-            };
-            frame.render_widget(
-                Paragraph::new(msg)
-                    .style(Style::default().fg(Color::DarkGray))
-                    .block(Block::default().borders(Borders::ALL).title(" container ")),
-                area,
-            );
+                frame.render_widget(
+                    Paragraph::new(super::ui::loading_line(throbber)).block(block),
+                    area,
+                );
+            }
             return;
         };
 
@@ -307,7 +323,7 @@ impl ContainerDetailState {
         Self::render_env_labels(frame, cols[1], inspect);
 
         if self.top_visible() {
-            self.render_top_modal(frame);
+            self.render_top_modal(frame, throbber);
         }
     }
 
@@ -526,7 +542,11 @@ impl ContainerDetailState {
 
     /// Centre-modal overlay listing `docker top` rows. Same dimensions
     /// as the help/error modals so the visual language stays consistent.
-    fn render_top_modal(&self, frame: &mut Frame<'_>) {
+    fn render_top_modal(
+        &self,
+        frame: &mut Frame<'_>,
+        throbber: &throbber_widgets_tui::ThrobberState,
+    ) {
         use ratatui::widgets::Clear;
         let area = frame.area();
         let modal_width = (area.width.saturating_sub(4)).clamp(60, 140);
@@ -546,9 +566,7 @@ impl ContainerDetailState {
         frame.render_widget(Clear, modal_area);
 
         if self.top_loading && self.top.is_none() {
-            let body = Paragraph::new("(loading…)")
-                .style(Style::default().fg(Color::DarkGray))
-                .block(block);
+            let body = Paragraph::new(super::ui::loading_line(throbber)).block(block);
             frame.render_widget(body, modal_area);
             return;
         }
@@ -635,6 +653,14 @@ impl ContainerDetailState {
         if let Some(h) = health {
             left_lines.push(kv_styled("health", h, health_style(h)));
         }
+        if let Some(desc) = inspect
+            .labels
+            .get("org.opencontainers.image.description")
+            .map(|s| s.trim())
+            .filter(|s| !s.is_empty())
+        {
+            left_lines.push(kv("description", desc));
+        }
         if let Some(cmd) = &inspect.command {
             left_lines.push(kv("command", cmd));
         }
@@ -716,20 +742,102 @@ impl ContainerDetailState {
     }
 
     fn render_runtime(frame: &mut Frame<'_>, area: Rect, inspect: &ContainerDetail) {
-        let chunks = Layout::default()
-            .direction(Direction::Vertical)
-            .constraints([
-                Constraint::Percentage(20), // ports
-                Constraint::Percentage(30), // mounts
-                Constraint::Percentage(20), // networks
-                Constraint::Percentage(30), // security & limits
-            ])
-            .split(area);
+        // Skip the proxy section for non-routed containers (3rd-party
+        // images, or services without `domain:`) so their layout stays
+        // 4-section.
+        let has_proxy = inspect.labels.contains_key("yoink.caddy.domain");
+        let chunks = if has_proxy {
+            Layout::default()
+                .direction(Direction::Vertical)
+                .constraints([
+                    Constraint::Percentage(18), // proxy
+                    Constraint::Percentage(15), // ports
+                    Constraint::Percentage(25), // mounts
+                    Constraint::Percentage(15), // networks
+                    Constraint::Percentage(27), // security & limits
+                ])
+                .split(area)
+        } else {
+            Layout::default()
+                .direction(Direction::Vertical)
+                .constraints([
+                    Constraint::Percentage(20), // ports
+                    Constraint::Percentage(30), // mounts
+                    Constraint::Percentage(20), // networks
+                    Constraint::Percentage(30), // security & limits
+                ])
+                .split(area)
+        };
 
-        Self::render_list(frame, chunks[0], " ports ", &inspect.ports);
-        Self::render_list(frame, chunks[1], " mounts ", &inspect.mounts);
-        Self::render_list(frame, chunks[2], " networks ", &inspect.networks);
-        Self::render_security(frame, chunks[3], inspect);
+        let mut idx = 0;
+        if has_proxy {
+            Self::render_proxy(frame, chunks[idx], inspect);
+            idx += 1;
+        }
+        Self::render_list(frame, chunks[idx], " ports ", &inspect.ports);
+        Self::render_list(frame, chunks[idx + 1], " mounts ", &inspect.mounts);
+        Self::render_list(frame, chunks[idx + 2], " networks ", &inspect.networks);
+        Self::render_security(frame, chunks[idx + 3], inspect);
+    }
+
+    /// Public URL + TLS + extra-rules indicator, sourced from
+    /// `yoink.caddy.*` labels written by `deploy::build_labels`.
+    /// The labels are the source of truth here — they flow through
+    /// the `spec_hash` so any routing change has already been
+    /// redeployed by the time this renders.
+    fn render_proxy(frame: &mut Frame<'_>, area: Rect, inspect: &ContainerDetail) {
+        let block = Block::default().borders(Borders::ALL).title(" proxy ");
+        let inner = block.inner(area);
+        frame.render_widget(block, area);
+
+        let Some(domain_csv) = inspect.labels.get("yoink.caddy.domain") else {
+            return;
+        };
+        let domains: Vec<&str> = domain_csv
+            .split(',')
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .collect();
+        let primary = domains.first().copied().unwrap_or("?");
+        let extra_count = domains.len().saturating_sub(1);
+
+        let tls = inspect
+            .labels
+            .get("yoink.caddy.tls")
+            .map_or("auto", String::as_str);
+        let scheme = if tls == "off" { "http" } else { "https" };
+        let url = format!("{scheme}://{primary}");
+
+        let tls_text = match tls {
+            "off" => "off (HTTP only)".to_string(),
+            "cert" => {
+                let secret = inspect
+                    .labels
+                    .get("yoink.caddy.cert_secret")
+                    .map_or("?", String::as_str);
+                format!("custom cert ({secret})")
+            }
+            _ => "auto (Let's Encrypt)".to_string(),
+        };
+
+        let dim = Style::default().fg(Color::DarkGray);
+        let mut url_spans = vec![
+            Span::styled("url ", dim),
+            Span::styled(url, Style::default().fg(Color::Cyan)),
+        ];
+        if extra_count > 0 {
+            url_spans.push(Span::styled(format!("  (+{extra_count} more)"), dim));
+        }
+        let mut lines: Vec<Line<'static>> = vec![Line::from(url_spans), kv("tls", &tls_text)];
+
+        if extra_count > 0 {
+            lines.push(kv("aliases", &domains[1..].join(", ")));
+        }
+        if let Some(hash) = inspect.labels.get("yoink.caddy.extra_hash") {
+            lines.push(kv("extra rules", &format!("present ({hash})")));
+        }
+
+        frame.render_widget(Paragraph::new(lines).wrap(Wrap { trim: false }), inner);
     }
 
     /// Surface the secure-by-default profile + any override the

--- a/yoink/src/tui/dashboard.rs
+++ b/yoink/src/tui/dashboard.rs
@@ -183,6 +183,7 @@ impl DashboardState {
         config: &Config,
         secrets: Option<&SecretsBundle>,
         history: &HashMap<(String, String), StatsHistory>,
+        throbber: &throbber_widgets_tui::ThrobberState,
     ) {
         let layout = pane_layout(area);
 
@@ -196,7 +197,7 @@ impl DashboardState {
             Paragraph::new(format!("yoink dashboard · services: {services}")).style(bold());
         frame.render_widget(header, layout[0]);
 
-        let rows = self.build_rows(config, secrets, history);
+        let rows = self.build_rows(config, secrets, history, throbber);
         let widths = [
             Constraint::Length(18), // host
             Constraint::Length(14), // service
@@ -252,17 +253,16 @@ impl DashboardState {
         config: &Config,
         secrets: Option<&SecretsBundle>,
         history: &HashMap<(String, String), StatsHistory>,
+        throbber: &throbber_widgets_tui::ThrobberState,
     ) -> Vec<Row<'static>> {
         let Some(report) = &self.report else {
             // No cached report. If the first fetch already finished
             // and errored (loaded=true), don't pretend we're still
             // loading — the error footer carries the detail.
-            let cell = if self.loaded {
-                "(no data — see error in footer)"
-            } else {
-                "(loading…)"
-            };
-            return vec![Row::new(vec![Cell::from(cell)])];
+            if self.loaded {
+                return vec![Row::new(vec![Cell::from("(no data — see error in footer)")])];
+            }
+            return vec![Row::new(vec![Cell::from(super::ui::loading_line(throbber))])];
         };
         let mut rows: Vec<Row<'_>> = Vec::new();
         for host in &report.hosts {

--- a/yoink/src/tui/drift.rs
+++ b/yoink/src/tui/drift.rs
@@ -1,0 +1,261 @@
+//! Drift inspection modal — answers "what about this service drifted?"
+//! without leaving the TUI.
+//!
+//! The data shown is the same `FieldDiff` `yoink up --plan` prints
+//! (image, tag, `spec_hash`, env keys, label keys). The modal opens
+//! on `~` from any view that has a focused (host, service) — list
+//! views resolve the focused row, the container detail view derives
+//! it from the inspected container.
+
+use ratatui::Frame;
+use ratatui::layout::Rect;
+use ratatui::style::{Color, Modifier, Style};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Block, Borders, Clear, Paragraph, Wrap};
+
+use crate::diff::{ChangeKind, FieldDiff, ServiceDiff};
+use crate::docker_ops::Host;
+
+/// Outcome of a drift fetch — either the matching `ServiceDiff` for
+/// the focused (host, service) pair, or `None` when the host yielded
+/// no row (rare: a service mid-removal). Errors flow back as `Err`.
+pub type DriftRefresh = Result<Option<ServiceDiff>, String>;
+
+#[derive(Default)]
+pub struct DriftState {
+    target: Option<(Host, String)>,
+    loading: bool,
+    diff: Option<ServiceDiff>,
+    error: Option<String>,
+}
+
+impl DriftState {
+    #[must_use]
+    pub fn is_visible(&self) -> bool {
+        self.target.is_some()
+    }
+
+    /// Begin a fetch for `(host, service)`. Subsequent `apply` for a
+    /// different target is dropped — the user re-pressed `~` on a
+    /// different row before the previous fetch landed.
+    pub fn set_target(&mut self, host: Host, service: String) {
+        self.target = Some((host, service));
+        self.loading = true;
+        self.diff = None;
+        self.error = None;
+    }
+
+    pub fn apply(&mut self, host: &Host, service: &str, result: DriftRefresh) {
+        if self
+            .target
+            .as_ref()
+            .is_none_or(|(h, s)| h != host || s != service)
+        {
+            return;
+        }
+        self.loading = false;
+        match result {
+            Ok(Some(diff)) => self.diff = Some(diff),
+            Ok(None) => self.error = Some("no drift data for this host".into()),
+            Err(e) => self.error = Some(e),
+        }
+    }
+
+    pub fn clear(&mut self) {
+        self.target = None;
+        self.loading = false;
+        self.diff = None;
+        self.error = None;
+    }
+}
+
+/// Center-of-screen modal mirroring the help/log modal sizing.
+/// Header strip carries `Esc` close hint; body shows the diff with
+/// `+`/`-`/`~` color coding (green/red/yellow) — same legend the
+/// CLI's terraform-style text format uses.
+pub fn render_modal(
+    frame: &mut Frame<'_>,
+    state: &DriftState,
+    throbber: &throbber_widgets_tui::ThrobberState,
+) {
+    let Some((host, service)) = state.target.as_ref() else {
+        return;
+    };
+    let area = frame.area();
+    let modal_width = (area.width.saturating_sub(4)).clamp(50, 100);
+    let modal_height = (area.height.saturating_sub(4)).clamp(10, 30);
+    let x = (area.width.saturating_sub(modal_width)) / 2;
+    let y = (area.height.saturating_sub(modal_height)) / 2;
+    let rect = Rect {
+        x,
+        y,
+        width: modal_width,
+        height: modal_height,
+    };
+
+    let title = format!(" drift: {service} on {} (esc to close) ", host.address);
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(Color::Cyan))
+        .title(title);
+
+    let lines = if state.loading {
+        vec![super::ui::loading_line(throbber)]
+    } else if let Some(err) = state.error.as_deref() {
+        vec![
+            Line::from(Span::styled(
+                format!("✗ {err}"),
+                Style::default().fg(Color::Red),
+            )),
+            Line::from(""),
+            Line::from(Span::styled(
+                "(running `yoink up --plan --service <name>` from the CLI",
+                Style::default().fg(Color::DarkGray),
+            )),
+            Line::from(Span::styled(
+                "may surface a richer error message)",
+                Style::default().fg(Color::DarkGray),
+            )),
+        ]
+    } else if let Some(diff) = state.diff.as_ref() {
+        body_lines(diff)
+    } else {
+        vec![Line::from("(no data)")]
+    };
+
+    frame.render_widget(Clear, rect);
+    frame.render_widget(
+        Paragraph::new(lines).wrap(Wrap { trim: false }).block(block),
+        rect,
+    );
+}
+
+fn body_lines(diff: &ServiceDiff) -> Vec<Line<'static>> {
+    match &diff.change {
+        ChangeKind::NoOp { current_hash } => vec![Line::from(vec![
+            Span::styled(
+                "= no drift",
+                Style::default()
+                    .fg(Color::Green)
+                    .add_modifier(Modifier::BOLD),
+            ),
+            Span::raw(format!(" (spec_hash {})", short(current_hash))),
+        ])],
+        ChangeKind::Create { desired_image } => vec![
+            Line::from(vec![
+                Span::styled(
+                    "+ would create",
+                    Style::default()
+                        .fg(Color::Green)
+                        .add_modifier(Modifier::BOLD),
+                ),
+                Span::raw(format!("  {desired_image}")),
+            ]),
+            Line::from(""),
+            Line::from(Span::styled(
+                "no running replica on this host yet — nothing to diff against.",
+                Style::default().fg(Color::DarkGray),
+            )),
+        ],
+        ChangeKind::Update {
+            current_hash,
+            current_image,
+            desired_image,
+            fields,
+        } => update_body(current_hash, current_image, desired_image, &diff.tag, &diff.desired_hash, fields),
+    }
+}
+
+fn update_body(
+    current_hash: &str,
+    current_image: &str,
+    desired_image: &str,
+    desired_tag: &str,
+    desired_hash: &str,
+    fields: &FieldDiff,
+) -> Vec<Line<'static>> {
+    let mut out = Vec::new();
+    out.push(kv_diff_line("image", current_image, desired_image));
+    out.push(kv_diff_line("spec", &short(current_hash), &short(desired_hash)));
+    out.push(Line::from(vec![
+        Span::styled("    tag  ", Style::default().fg(Color::DarkGray)),
+        Span::styled(
+            desired_tag.to_string(),
+            Style::default().fg(Color::Cyan).add_modifier(Modifier::BOLD),
+        ),
+    ]));
+    if !fields.is_empty() {
+        out.push(Line::from(""));
+        push_kv_group(&mut out, "env", &fields.env_added, &fields.env_removed, &fields.env_changed);
+        push_kv_group(
+            &mut out,
+            "labels",
+            &fields.labels_added,
+            &fields.labels_removed,
+            &fields.labels_changed,
+        );
+    }
+    out
+}
+
+fn kv_diff_line(label: &str, current: &str, desired: &str) -> Line<'static> {
+    if current == desired {
+        Line::from(vec![
+            Span::styled(format!("{label:>8}  "), Style::default().fg(Color::DarkGray)),
+            Span::raw(current.to_string()),
+            Span::styled(
+                "  (unchanged)".to_string(),
+                Style::default().fg(Color::DarkGray),
+            ),
+        ])
+    } else {
+        Line::from(vec![
+            Span::styled(format!("{label:>8}  "), Style::default().fg(Color::DarkGray)),
+            Span::styled(current.to_string(), Style::default().fg(Color::Yellow)),
+            Span::styled(" → ".to_string(), Style::default().fg(Color::DarkGray)),
+            Span::styled(
+                desired.to_string(),
+                Style::default().fg(Color::Cyan).add_modifier(Modifier::BOLD),
+            ),
+        ])
+    }
+}
+
+fn push_kv_group(
+    out: &mut Vec<Line<'static>>,
+    label: &str,
+    added: &[String],
+    removed: &[String],
+    changed: &[String],
+) {
+    if added.is_empty() && removed.is_empty() && changed.is_empty() {
+        return;
+    }
+    out.push(Line::from(Span::styled(
+        format!("{label}:"),
+        Style::default().fg(Color::Cyan).add_modifier(Modifier::BOLD),
+    )));
+    for k in added {
+        out.push(prefixed("  + ", k, Color::Green));
+    }
+    for k in removed {
+        out.push(prefixed("  - ", k, Color::Red));
+    }
+    for k in changed {
+        out.push(prefixed("  ~ ", k, Color::Yellow));
+    }
+}
+
+fn prefixed(marker: &str, key: &str, color: Color) -> Line<'static> {
+    Line::from(vec![
+        Span::styled(
+            marker.to_string(),
+            Style::default().fg(color).add_modifier(Modifier::BOLD),
+        ),
+        Span::raw(key.to_string()),
+    ])
+}
+
+fn short(h: &str) -> String {
+    h[..h.len().min(7)].to_string()
+}

--- a/yoink/src/tui/editor.rs
+++ b/yoink/src/tui/editor.rs
@@ -1,0 +1,141 @@
+//! Suspend the TUI and jump into `$EDITOR` at the YAML line of the
+//! object the operator is currently looking at. Returning from the
+//! editor restores the alt-screen and triggers the next config
+//! reload tick — the existing reload path picks up edits without
+//! any new plumbing.
+//!
+//! Line-finding is intentionally a dumb line scanner, not a YAML
+//! parser, so it can point at the *exact* `name:` / `address:` line
+//! the user typed (a re-serialized AST would lose comments and
+//! ordering). The yoink config file is line-oriented yaml with no
+//! flow-style maps in the wild, so this is fine in practice.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+/// Where to drop the operator on `$EDITOR` resume.
+#[derive(Debug, Clone)]
+pub struct EditorTarget {
+    pub path: PathBuf,
+    /// 1-indexed line, or `None` to open at the top of the file.
+    pub line: Option<usize>,
+}
+
+/// 1-indexed line of the `name: <service>` block in the yaml text.
+/// Matches any indentation and a leading `- ` (yaml list syntax).
+/// Strips matching quotes around the value so `name: "api"` and
+/// `name: api` both match.
+#[must_use]
+pub fn find_service_line(yaml: &str, service_name: &str) -> Option<usize> {
+    find_kv_line(yaml, "name", service_name)
+}
+
+/// Same idea as [`find_service_line`] but scans for `address:`.
+#[must_use]
+pub fn find_host_line(yaml: &str, address: &str) -> Option<usize> {
+    find_kv_line(yaml, "address", address)
+}
+
+fn find_kv_line(yaml: &str, key: &str, value: &str) -> Option<usize> {
+    let needle = format!("{key}:");
+    for (idx, line) in yaml.lines().enumerate() {
+        let trimmed = line.trim_start();
+        let after_dash = trimmed.strip_prefix("- ").unwrap_or(trimmed);
+        let Some(rest) = after_dash.strip_prefix(&needle) else {
+            continue;
+        };
+        let candidate = rest
+            .trim()
+            // Drop a trailing inline comment if any.
+            .split('#')
+            .next()
+            .unwrap_or("")
+            .trim()
+            .trim_matches(|c| c == '"' || c == '\'');
+        if candidate == value {
+            return Some(idx + 1);
+        }
+    }
+    None
+}
+
+/// Suspend the TUI, run the operator's editor on `target`, return
+/// when they exit. The caller is responsible for tearing down the
+/// terminal (alt-screen + raw mode) before this and re-entering
+/// after — we don't touch the terminal here so the call site can
+/// keep its existing setup/restore helpers.
+///
+/// `$EDITOR` (then `$VISUAL`, then `vi`) decides which editor to
+/// run. We pass `+<line>` as the first argument when a line is
+/// known — every popular terminal editor (`vi`/`vim`/`nvim`,
+/// `nano`, `emacs -nw`, `helix`, `kakoune`, `micro`) treats `+N`
+/// as "open at line N". Editors that don't (`code`, `subl`) are
+/// the GUI ones an operator is unlikely to set as `$EDITOR` in a
+/// terminal session anyway.
+pub fn run_editor(target: &EditorTarget) -> std::io::Result<std::process::ExitStatus> {
+    let editor = std::env::var("EDITOR")
+        .ok()
+        .or_else(|| std::env::var("VISUAL").ok())
+        .filter(|s| !s.trim().is_empty())
+        .unwrap_or_else(|| "vi".into());
+    // Allow `EDITOR="code -w"` etc. — split on whitespace so the
+    // shell-style "command + flags" form works.
+    let mut parts = editor.split_whitespace();
+    let prog = parts.next().unwrap_or("vi");
+    let mut cmd = Command::new(prog);
+    for arg in parts {
+        cmd.arg(arg);
+    }
+    if let Some(line) = target.line {
+        cmd.arg(format!("+{line}"));
+    }
+    cmd.arg(&target.path);
+    cmd.status()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const SAMPLE: &str = "\
+hosts:
+  - address: host-a
+    user: deploy
+  - address: host-b
+    user: deploy
+services:
+  - name: api
+    image: ghcr.io/example/api
+  - name: \"web\"
+    image: ghcr.io/example/web
+  - name: app-a
+    image: ghcr.io/example/app-a
+";
+
+    #[test]
+    fn finds_service_by_name() {
+        assert_eq!(find_service_line(SAMPLE, "api"), Some(7));
+    }
+
+    #[test]
+    fn finds_service_with_quoted_name() {
+        assert_eq!(find_service_line(SAMPLE, "web"), Some(9));
+    }
+
+    #[test]
+    fn finds_service_with_dash_in_name() {
+        assert_eq!(find_service_line(SAMPLE, "app-a"), Some(11));
+    }
+
+    #[test]
+    fn finds_host_by_address() {
+        assert_eq!(find_host_line(SAMPLE, "host-a"), Some(2));
+        assert_eq!(find_host_line(SAMPLE, "host-b"), Some(4));
+    }
+
+    #[test]
+    fn missing_target_returns_none() {
+        assert_eq!(find_service_line(SAMPLE, "ghost"), None);
+        assert_eq!(find_host_line(SAMPLE, "nope"), None);
+    }
+}

--- a/yoink/src/tui/history.rs
+++ b/yoink/src/tui/history.rs
@@ -140,7 +140,12 @@ impl HistoryState {
         Some((svc.clone(), row.version.clone()))
     }
 
-    pub fn render(&mut self, frame: &mut Frame<'_>, area: Rect) {
+    pub fn render(
+        &mut self,
+        frame: &mut Frame<'_>,
+        area: Rect,
+        throbber: &throbber_widgets_tui::ThrobberState,
+    ) {
         let layout = pane_layout(area);
         let title = match &self.service {
             Some(svc) => format!("yoink history · {svc} · ↑↓ select · r rollback · esc back"),
@@ -158,7 +163,7 @@ impl HistoryState {
             Constraint::Min(12),    // deployed-by
         ];
         let rows: Vec<Row<'_>> = if !self.loaded {
-            vec![Row::new(vec![Cell::from("(loading…)")])]
+            vec![Row::new(vec![Cell::from(super::ui::loading_line(throbber))])]
         } else if self.rows.is_empty() && !self.errors.is_empty() {
             // All hosts errored — make that obvious instead of
             // implying the service has no history.

--- a/yoink/src/tui/host_detail.rs
+++ b/yoink/src/tui/host_detail.rs
@@ -148,7 +148,7 @@ impl HostDetailState {
         self.host.as_ref()
     }
 
-    #[allow(clippy::too_many_lines)]
+    #[allow(clippy::too_many_lines, clippy::too_many_arguments)]
     pub fn render(
         &mut self,
         frame: &mut Frame<'_>,
@@ -157,6 +157,7 @@ impl HostDetailState {
         secrets: Option<&SecretsBundle>,
         events: &[String],
         history: &HashMap<(String, String), StatsHistory>,
+        throbber: &throbber_widgets_tui::ThrobberState,
     ) {
         // 5-section layout: header · summary · containers (Min) · events (Length 8 when present) · footer.
         // The event panel collapses to 0 when no events are recorded yet.
@@ -187,7 +188,7 @@ impl HostDetailState {
         let header = Paragraph::new(header_text).style(bold());
         frame.render_widget(header, header_area);
 
-        self.render_summary(frame, summary_area, history);
+        self.render_summary(frame, summary_area, history, throbber);
 
         let widths = [
             Constraint::Length(14), // service
@@ -204,7 +205,7 @@ impl HostDetailState {
         let visible = self.visible_indices();
         clamp_selection(&mut self.table, visible.len());
         let rows: Vec<Row<'_>> = if !self.loaded && self.last_error.is_none() {
-            vec![Row::new(vec![Cell::from("(loading…)")])]
+            vec![Row::new(vec![Cell::from(super::ui::loading_line(throbber))])]
         } else if visible.is_empty() && !self.containers.is_empty() {
             vec![Row::new(vec![Cell::from("(no containers match filter)")])]
         } else if self.containers.is_empty() {
@@ -320,6 +321,7 @@ impl HostDetailState {
         frame: &mut Frame<'_>,
         area: ratatui::layout::Rect,
         history: &HashMap<(String, String), StatsHistory>,
+        throbber: &throbber_widgets_tui::ThrobberState,
     ) {
         let block = Block::default()
             .borders(Borders::ALL)
@@ -396,21 +398,28 @@ impl HostDetailState {
 
         // Third row: kernel + OS + container counts. Dim so it sits
         // quietly under the gauges.
-        let info_text = match &self.host_info {
+        match &self.host_info {
             Some(i) => {
                 let os = i.operating_system.as_deref().unwrap_or("?");
                 let kernel = i.kernel.as_deref().unwrap_or("?");
                 let running = i.containers_running.unwrap_or(0);
                 let total = i.containers.unwrap_or(0);
                 let images = i.images.unwrap_or(0);
-                format!("{os} · {kernel} · {running}/{total} containers · {images} images")
+                let info_text = format!(
+                    "{os} · {kernel} · {running}/{total} containers · {images} images"
+                );
+                frame.render_widget(
+                    Paragraph::new(info_text).style(Style::default().fg(Color::DarkGray)),
+                    chunks[2],
+                );
             }
-            None => "(host info loading…)".into(),
-        };
-        frame.render_widget(
-            Paragraph::new(info_text).style(Style::default().fg(Color::DarkGray)),
-            chunks[2],
-        );
+            None => {
+                frame.render_widget(
+                    Paragraph::new(super::ui::throbber_with_label(throbber, " host info…")),
+                    chunks[2],
+                );
+            }
+        }
     }
 }
 

--- a/yoink/src/tui/hosts.rs
+++ b/yoink/src/tui/hosts.rs
@@ -117,7 +117,13 @@ impl HostsState {
             .collect()
     }
 
-    pub fn render(&mut self, frame: &mut Frame<'_>, area: ratatui::layout::Rect, _config: &Config) {
+    pub fn render(
+        &mut self,
+        frame: &mut Frame<'_>,
+        area: ratatui::layout::Rect,
+        _config: &Config,
+        throbber: &throbber_widgets_tui::ThrobberState,
+    ) {
         let layout = pane_layout(area);
 
         let header = Paragraph::new("yoink hosts · ↑↓ select · enter for detail").style(bold());
@@ -126,7 +132,7 @@ impl HostsState {
         let visible = self.visible_indices();
         clamp_selection(&mut self.table, visible.len());
         let rows: Vec<Row<'_>> = if !self.loaded {
-            vec![Row::new(vec![Cell::from("(loading…)")])]
+            vec![Row::new(vec![Cell::from(super::ui::loading_line(throbber))])]
         } else if visible.is_empty() && !self.rows.is_empty() {
             vec![Row::new(vec![Cell::from("(no hosts match filter)")])]
         } else if self.rows.is_empty() {

--- a/yoink/src/tui/mod.rs
+++ b/yoink/src/tui/mod.rs
@@ -2,8 +2,11 @@
 //! rendering.
 
 mod app;
+mod chrome;
 mod container_detail;
 mod dashboard;
+mod drift;
+mod editor;
 mod history;
 mod host_detail;
 mod hosts;

--- a/yoink/src/tui/resources.rs
+++ b/yoink/src/tui/resources.rs
@@ -324,7 +324,13 @@ impl ResourcesState {
         clamp_selection(&mut self.networks_table, networks_visible);
     }
 
-    pub fn render(&mut self, frame: &mut Frame<'_>, area: Rect, _config: &Config) {
+    pub fn render(
+        &mut self,
+        frame: &mut Frame<'_>,
+        area: Rect,
+        _config: &Config,
+        throbber: &throbber_widgets_tui::ThrobberState,
+    ) {
         let layout = pane_layout(area);
         let header = layout[0];
         let body = layout[1];
@@ -349,9 +355,9 @@ impl ResourcesState {
         frame.render_widget(tabs, header);
 
         match self.current_tab() {
-            ResourceTab::Images => self.render_images(frame, body),
-            ResourceTab::Volumes => self.render_volumes(frame, body),
-            ResourceTab::Networks => self.render_networks(frame, body),
+            ResourceTab::Images => self.render_images(frame, body, throbber),
+            ResourceTab::Volumes => self.render_volumes(frame, body, throbber),
+            ResourceTab::Networks => self.render_networks(frame, body, throbber),
         }
 
         // Footer: filter line + per-tab help on the right.
@@ -383,7 +389,12 @@ impl ResourcesState {
         }
     }
 
-    fn render_images(&mut self, frame: &mut Frame<'_>, area: Rect) {
+    fn render_images(
+        &mut self,
+        frame: &mut Frame<'_>,
+        area: Rect,
+        throbber: &throbber_widgets_tui::ThrobberState,
+    ) {
         let widths = [
             Constraint::Length(16), // host
             Constraint::Length(14), // id
@@ -398,7 +409,7 @@ impl ResourcesState {
         let dangling_count = self.images.iter().filter(|i| i.dangling).count();
 
         let rows: Vec<Row<'_>> = if !self.loaded {
-            vec![Row::new(vec![Cell::from("(loading…)")])]
+            vec![Row::new(vec![Cell::from(super::ui::loading_line(throbber))])]
         } else if self.images.is_empty() {
             vec![Row::new(vec![Cell::from("(no images cached on any host)")])]
         } else if visible.is_empty() {
@@ -457,7 +468,12 @@ impl ResourcesState {
         frame.render_stateful_widget(table, area, &mut self.images_table);
     }
 
-    fn render_volumes(&mut self, frame: &mut Frame<'_>, area: Rect) {
+    fn render_volumes(
+        &mut self,
+        frame: &mut Frame<'_>,
+        area: Rect,
+        throbber: &throbber_widgets_tui::ThrobberState,
+    ) {
         let widths = [
             Constraint::Length(16), // host
             Constraint::Length(28), // name
@@ -468,7 +484,7 @@ impl ResourcesState {
         clamp_selection(&mut self.volumes_table, visible.len());
 
         let rows: Vec<Row<'_>> = if !self.loaded {
-            vec![Row::new(vec![Cell::from("(loading…)")])]
+            vec![Row::new(vec![Cell::from(super::ui::loading_line(throbber))])]
         } else if self.volumes.is_empty() {
             vec![Row::new(vec![Cell::from("(no volumes on any host)")])]
         } else if visible.is_empty() {
@@ -504,7 +520,12 @@ impl ResourcesState {
         frame.render_stateful_widget(table, area, &mut self.volumes_table);
     }
 
-    fn render_networks(&mut self, frame: &mut Frame<'_>, area: Rect) {
+    fn render_networks(
+        &mut self,
+        frame: &mut Frame<'_>,
+        area: Rect,
+        throbber: &throbber_widgets_tui::ThrobberState,
+    ) {
         let widths = [
             Constraint::Length(16), // host
             Constraint::Length(28), // name
@@ -516,7 +537,7 @@ impl ResourcesState {
         clamp_selection(&mut self.networks_table, visible.len());
 
         let rows: Vec<Row<'_>> = if !self.loaded {
-            vec![Row::new(vec![Cell::from("(loading…)")])]
+            vec![Row::new(vec![Cell::from(super::ui::loading_line(throbber))])]
         } else if self.networks.is_empty() {
             vec![Row::new(vec![Cell::from("(no networks)")])]
         } else if visible.is_empty() {

--- a/yoink/src/tui/secrets.rs
+++ b/yoink/src/tui/secrets.rs
@@ -368,15 +368,20 @@ impl SecretsState {
         self.flash = Some((Instant::now(), msg.into()));
     }
 
-    pub fn render(&mut self, frame: &mut Frame<'_>, area: Rect) {
+    pub fn render(
+        &mut self,
+        frame: &mut Frame<'_>,
+        area: Rect,
+        throbber: &throbber_widgets_tui::ThrobberState,
+    ) {
         let layout = pane_layout(area);
 
-        let header = Paragraph::new(self.header_text()).style(bold());
+        let header = Paragraph::new(self.header_text(throbber)).style(bold());
         frame.render_widget(header, layout[0]);
 
         match &self.bundle {
             LoadStatus::NotLoaded => {
-                let p = Paragraph::new("(loading…)")
+                let p = Paragraph::new(super::ui::loading_line(throbber))
                     .block(Block::default().borders(Borders::ALL).title("secrets"));
                 frame.render_widget(p, layout[1]);
             }
@@ -422,9 +427,9 @@ impl SecretsState {
         parts.join(" · ")
     }
 
-    fn header_text(&self) -> String {
+    fn header_text(&self, _throbber: &throbber_widgets_tui::ThrobberState) -> String {
         match &self.bundle {
-            LoadStatus::NotLoaded => "yoink secrets · (loading…)".into(),
+            LoadStatus::NotLoaded => "yoink secrets · loading…".into(),
             LoadStatus::Failed(_) => "yoink secrets · (error)".into(),
             LoadStatus::Loaded(b) => {
                 let n = b.values.len();

--- a/yoink/src/tui/services.rs
+++ b/yoink/src/tui/services.rs
@@ -106,7 +106,13 @@ impl ServicesState {
             .collect()
     }
 
-    pub fn render(&mut self, frame: &mut Frame<'_>, area: ratatui::layout::Rect, config: &Config) {
+    pub fn render(
+        &mut self,
+        frame: &mut Frame<'_>,
+        area: ratatui::layout::Rect,
+        config: &Config,
+        throbber: &throbber_widgets_tui::ThrobberState,
+    ) {
         let layout = pane_layout(area);
         let header = Paragraph::new(format!(
             "yoink services · {} declared · ↑↓ select · enter for instances",
@@ -125,7 +131,7 @@ impl ServicesState {
         let visible = self.visible_indices();
         clamp_selection(&mut self.table, visible.len());
         let rows: Vec<Row<'_>> = if !self.loaded {
-            vec![Row::new(vec![Cell::from("(loading…)")])]
+            vec![Row::new(vec![Cell::from(super::ui::loading_line(throbber))])]
         } else if visible.is_empty() && !self.service_names.is_empty() {
             vec![Row::new(vec![Cell::from("(no services match filter)")])]
         } else {
@@ -359,6 +365,7 @@ impl ServiceDetailState {
         area: ratatui::layout::Rect,
         config: &Config,
         secrets: Option<&SecretsBundle>,
+        throbber: &throbber_widgets_tui::ThrobberState,
     ) {
         let layout = pane_layout(area);
         let header_text = match &self.service {
@@ -383,7 +390,7 @@ impl ServiceDetailState {
         let visible = self.visible_indices();
         clamp_selection(&mut self.table, visible.len());
         let rows: Vec<Row<'_>> = if !self.loaded {
-            vec![Row::new(vec![Cell::from("(loading…)")])]
+            vec![Row::new(vec![Cell::from(super::ui::loading_line(throbber))])]
         } else if self.rows.is_empty() {
             vec![Row::new(vec![Cell::from("(no instances)")])]
         } else if visible.is_empty() {

--- a/yoink/src/tui/ui.rs
+++ b/yoink/src/tui/ui.rs
@@ -5,6 +5,7 @@ use ratatui::layout::{Constraint, Direction, Layout, Rect};
 use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span};
 use ratatui::widgets::{Block, Borders, Cell, Clear, Paragraph, TableState};
+use throbber_widgets_tui::{Throbber, ThrobberState};
 
 use crate::config::Config;
 use crate::deploy;
@@ -16,6 +17,62 @@ use crate::secrets::SecretsBundle;
 #[must_use]
 pub fn bold() -> Style {
     Style::default().add_modifier(Modifier::BOLD)
+}
+
+fn throbber_glyph_style() -> Style {
+    Style::default()
+        .fg(Color::Cyan)
+        .add_modifier(Modifier::BOLD)
+}
+
+/// Animated "loading…" line, shared by every pane that drops a
+/// placeholder row while a docker fetch is in flight. Drives off the
+/// `throbber-widgets-tui` crate so the spinner glyph rotates with the
+/// app's `ThrobberState` (advanced once per fast UI tick) — clearly
+/// distinguishing "still working" from "stuck on an old result".
+#[must_use]
+pub fn loading_line(state: &ThrobberState) -> Line<'static> {
+    throbber_with_label(state, " loading…")
+}
+
+/// Same as [`loading_line`] but with a caller-supplied label.
+/// Use it when "loading" is the wrong word (e.g. " running…",
+/// " pulling…") so the spinner reads naturally for the action
+/// it's animating.
+#[must_use]
+pub fn throbber_with_label(state: &ThrobberState, label: &'static str) -> Line<'static> {
+    Throbber::default()
+        .label(label)
+        .style(Style::default().fg(Color::DarkGray))
+        .throbber_style(throbber_glyph_style())
+        .to_line(state)
+}
+
+/// Just the rotating throbber glyph — useful when you need to embed
+/// the spinner inside a richer line (a modal title, a status table
+/// row) where the surrounding spans already carry their own styling.
+#[must_use]
+pub fn throbber_span(state: &ThrobberState) -> Span<'static> {
+    Throbber::default()
+        .throbber_style(throbber_glyph_style())
+        .to_symbol_span(state)
+}
+
+/// Compose a modal title `Line`. When `throbber` is `Some` (job is
+/// still in flight) a rotating glyph is prepended so the operator
+/// has a visible "still working" cue independent of the streaming
+/// log — a streaming log that has stalled for 30 seconds looks the
+/// same as a finished one until the spinner stops moving.
+#[must_use]
+fn modal_title(title: &str, throbber: Option<&ThrobberState>) -> Line<'static> {
+    let mut spans: Vec<Span<'static>> = Vec::new();
+    spans.push(Span::raw(" "));
+    if let Some(state) = throbber {
+        spans.push(throbber_span(state));
+    }
+    spans.push(Span::raw(title.to_string()));
+    spans.push(Span::raw(" "));
+    Line::from(spans)
 }
 
 /// Drift cell shared by every list view (dashboard, host detail,
@@ -162,6 +219,13 @@ pub fn split_with_header(area: Rect) -> (Rect, Rect) {
 /// top-level section labels; `selected_tab` is the currently active
 /// index (or `None` to dim the whole bar — used inside drill-down
 /// views that don't map cleanly to a single top-level tab).
+///
+/// `slug` is rendered centered in the top border in bold red — a
+/// loud, always-visible reminder that the operator opted into
+/// (e.g. "PRODUCTION — TREAD CAREFULLY") for configs where typing
+/// `up` should give pause. `source` shows where the config came from
+/// (typically "<git-repo>" or "<git-repo>(*)" when dirty), aligned
+/// right in the top border.
 #[allow(clippy::too_many_arguments)]
 pub fn render_header(
     frame: &mut Frame<'_>,
@@ -170,10 +234,12 @@ pub fn render_header(
     selected_tab: Option<usize>,
     crumbs: &[String],
     right: &str,
+    slug: Option<&str>,
+    source: Option<&str>,
 ) {
     use ratatui::widgets::Tabs;
 
-    let block = Block::default()
+    let mut block = Block::default()
         .borders(Borders::ALL)
         .border_style(Style::default().fg(Color::Gray))
         .title(Line::from(Span::styled(
@@ -182,6 +248,26 @@ pub fn render_header(
                 .fg(Color::Cyan)
                 .add_modifier(Modifier::BOLD),
         )));
+    if let Some(text) = slug.map(str::trim).filter(|s| !s.is_empty()) {
+        block = block.title(
+            Line::from(Span::styled(
+                format!(" {text} "),
+                Style::default()
+                    .fg(Color::Red)
+                    .add_modifier(Modifier::BOLD),
+            ))
+            .centered(),
+        );
+    }
+    if let Some(text) = source.map(str::trim).filter(|s| !s.is_empty()) {
+        block = block.title(
+            Line::from(Span::styled(
+                format!(" {text} "),
+                Style::default().fg(Color::DarkGray),
+            ))
+            .right_aligned(),
+        );
+    }
     let inner = block.inner(area);
     frame.render_widget(block, area);
 
@@ -463,13 +549,16 @@ pub fn render_vertical_scrollbar(
 /// Big centered modal that displays a streaming log, auto-scrolled
 /// so the newest line is always visible. `success` / `failure` tint
 /// the border (green / red) once the producing task is done — both
-/// false means "still running".
+/// false means "still running". When `throbber` is `Some` the title
+/// gets a leading spinner glyph so the operator can distinguish
+/// "still working" from "frozen".
 pub fn render_log_modal(
     frame: &mut Frame<'_>,
     title: &str,
     lines: &[String],
     success: bool,
     failure: bool,
+    throbber: Option<&ThrobberState>,
 ) {
     let area = frame.area();
     // 90% of the available area, capped at 120×40 so the modal feels
@@ -495,7 +584,7 @@ pub fn render_log_modal(
     let block = Block::default()
         .borders(Borders::ALL)
         .border_style(Style::default().fg(border_color))
-        .title(title.to_string());
+        .title(modal_title(title, throbber));
 
     // Auto-scroll: keep the newest line glued to the bottom.
     let inner_height = modal_area.height.saturating_sub(2) as usize;
@@ -516,6 +605,7 @@ pub fn render_log_modal(
 /// scrolling event log below. Used for `JobKind::ReconcileAll` so
 /// concurrent waves are legible at a glance — the status table is the
 /// "where is everyone right now?" overview, the log is the detail.
+#[allow(clippy::too_many_arguments)]
 pub fn render_status_log_modal(
     frame: &mut Frame<'_>,
     title: &str,
@@ -523,6 +613,7 @@ pub fn render_status_log_modal(
     lines: &[String],
     success: bool,
     failure: bool,
+    throbber: Option<&ThrobberState>,
 ) {
     let area = frame.area();
     let modal_width = (area.width.saturating_sub(4)).clamp(40, 120);
@@ -546,7 +637,7 @@ pub fn render_status_log_modal(
     let outer = Block::default()
         .borders(Borders::ALL)
         .border_style(Style::default().fg(border_color))
-        .title(title.to_string());
+        .title(modal_title(title, throbber));
     frame.render_widget(Clear, modal_area);
     frame.render_widget(&outer, modal_area);
 


### PR DESCRIPTION
## Summary

A round of TUI inspection + CLI ergonomics polish on top of v0.11.0.

**TUI**
- **Drift modal (`~`)** — press `~` on any drifted row (dashboard / host detail / service detail / container detail) to see *what* drifted: image, spec_hash, env keys, label keys with terraform-style ± coloring. Reuses `diff::compute` so the modal content matches `yoink up --plan --service <name>` byte-for-byte. For git-versioned services the fetch falls back to the running replica's tag, so the diff isolates env/label changes instead of erroring on a missing tag.
- **Service description** (`services[].description`) writes the OCI standard `org.opencontainers.image.description` label and surfaces in the container detail card. Single lookup also picks up the same key from 3rd-party OCI-compliant images.
- **Proxy section** in container detail: public URL (https/http based on `yoink.caddy.tls`), TLS mode (auto/cert/off), domain aliases, and a hash for any `caddy_extra_json`. Hidden for non-routed containers.
- **Slug banner** (`Config.slug`) — operator-defined warning text rendered centered in the header in bold red ("PRODUCTION — TREAD CAREFULLY").
- **Git source chrome** auto-detects the loaded config's git repo + dirty state and shows `<repo>(*)` in the header right.
- **`E`** suspends the alt-screen, opens `$EDITOR` at the focused service/host's line in the config, reloads on exit.
- **Throbber animations** (throbber-widgets-tui) replace static `(loading…)` text in dashboard/hosts/host detail/services/service detail/history/resources/secrets/container detail and the reconcile modal title.

**CLI**
- **`yoink up --plan`** — alias for `--dry-run` with a terraform-style per-field diff (image, tag, spec_hash, env keys, label keys ± / ~). `--format markdown|json` unchanged so CI consumers keep working.
- **`yoink up --watch`** — poll-based redeploy on `yoink.yaml` change, matching the TUI's 2 s tick. Pairs with `--build --no-registry` for the edit-save-deploy inner loop. Reload errors deduped.
- **`yoink up --here`** — shorthand for `--tag $(git rev-parse --short HEAD)` applied to every (or every `--service`-selected) service.
- **`yoink shell|ssh <service>`** — auto-picks the first healthy replica when `--host` is omitted; `ssh` registered as a hidden alias.
- **`yoink logs <service>`** — multiplexes across replicas with `[host/container]` line prefixes when `--host` is omitted; single-replica path stays prefix-free for shell pipelines.
- **`yoink __complete services|hosts|configs`** — dynamic shell completion helper. `configs` walks cwd for `yoink.yaml` / `*.yoink.yaml`, skips noise dirs (`.git`, `target`, `node_modules`, …), ranks by mtime so the just-edited file bubbles to the top of `-c <TAB>`.
- Parallelized `list_running_replicas` and `diff::compute` snapshot via `try_join_all` — flat scaling with host count for `shell`/`logs`/`exec`/`--plan`.

**Bug fixes from the post-feature sweep**
- Audit labels (`yoink.deployed-by`/`-at`) no longer falsely show as "removed" in every Update diff (they're added in `audit_labels`, not `build_labels`, by design — now suppressed from the diff too).
- Watch loop dedupes config-reload errors instead of spamming the same parse error every 2 s while the file is broken.

**Docs**
- `docs/content/docs/reference/cli.md` — new flags, replica-aware shell/logs, dynamic completion snippet (forwards in-line `-c`).
- `docs/content/docs/reference/tui.md` — drift modal section with legend, `~` binding in the dashboard cheat sheet.
- `docs/content/docs/recipes/watch-mode.md` — new recipe.

## Test plan
- [x] `cargo test --workspace` — 253 passed (was 240 before the rebase on v0.11.0; gained 13 from upstream)
- [x] `cargo clippy --workspace --all-targets` — clean (the 50+ `large_futures` warnings exist on `origin/main` and aren't introduced here)
- [ ] Manual: `yoink up --plan --service <name>` against a drifted service shows ± env/label keys
- [ ] Manual: edit `yoink.yaml`, `yoink up --watch --build --no-registry --service <name>` redeploys on save
- [ ] Manual: `yoink shell <service>` with multiple replicas auto-picks healthy + prints which
- [ ] Manual: `yoink logs <service> -f` with multiple replicas interleaves prefixed lines
- [ ] Manual: `yoink -c <TAB>` lists discovered configs newest-first
- [ ] Manual: in TUI, `~` on drifted row opens modal with field-level ± diff