### PR TITLE
feat(proxy): emit Docker HEALTHCHECK on the synthesized yoink-proxy

### DIFF
--- a/yoink/src/deploy.rs
+++ b/yoink/src/deploy.rs
@@ -1028,7 +1028,48 @@ fn build_run_spec(
         publish: service.run.publish.clone(),
         binds,
         volumes: service.run.volumes.clone(),
+        docker_healthcheck: docker_healthcheck_for(service),
     }
+}
+
+/// Pick a docker-native HEALTHCHECK directive for a service.
+///
+/// Today this only lights up for the synthesized `yoink-proxy`:
+/// the bundled image is `caddy:2`, which doesn't ship a HEALTHCHECK
+/// of its own, and the proxy is the one container yoink puts on
+/// every host whether the operator wrote a yaml entry for it or not.
+/// Best practice is for it to show `(healthy)` in `docker ps` and
+/// in tools like lazydocker / cAdvisor / k8s-style health probes —
+/// the deploy-time gate yoink already runs is invisible there.
+///
+/// User-defined services intentionally inherit whatever HEALTHCHECK
+/// their image's Dockerfile declares (or none); yoink doesn't yet
+/// expose a config knob to override that.
+fn docker_healthcheck_for(service: &ServiceConfig) -> Option<bollard::models::HealthConfig> {
+    use bollard::models::HealthConfig;
+    if service.kind != Some(crate::config::ServiceKind::Proxy) {
+        return None;
+    }
+    // Probe Caddy's admin endpoint on its own loopback. /config/
+    // returns the live config blob and is what yoink itself uses
+    // as the deploy-time gate. BusyBox `wget --spider` exits 0 on
+    // 200, non-zero otherwise — caddy:2 (alpine-based) ships it.
+    Some(HealthConfig {
+        test: Some(vec![
+            "CMD-SHELL".into(),
+            "wget --spider --quiet http://127.0.0.1:2019/config/ || exit 1".into(),
+        ]),
+        // 30 s is enough headroom for Caddy's admin loop without
+        // making `docker ps` lag the actual state.
+        interval: Some(30 * 1_000_000_000),
+        timeout: Some(5 * 1_000_000_000),
+        // Caddy boots in well under a second; keep the start grace
+        // generous so a slow first-load (TLS bootstrap on first run)
+        // doesn't get reported as unhealthy.
+        start_period: Some(10 * 1_000_000_000),
+        retries: Some(3),
+        ..Default::default()
+    })
 }
 
 /// Parse + content-hash every entry in `service.run.files`. Failure to

--- a/yoink/src/docker.rs
+++ b/yoink/src/docker.rs
@@ -6,8 +6,8 @@
 use std::collections::{BTreeMap, HashMap};
 
 use bollard::models::{
-    ContainerCreateBody, EndpointSettings, HostConfig, NetworkingConfig, PortBinding,
-    RestartPolicy, RestartPolicyNameEnum,
+    ContainerCreateBody, EndpointSettings, HealthConfig, HostConfig, NetworkingConfig,
+    PortBinding, RestartPolicy, RestartPolicyNameEnum,
 };
 use sha2::{Digest, Sha256};
 use thiserror::Error;
@@ -76,6 +76,16 @@ pub struct RunSpec {
     /// docker-cli volume strings, e.g. `"named-volume:/data"`. Concatenated
     /// onto `host_config.binds` (Docker accepts named volumes there too).
     pub volumes: Vec<String>,
+    /// Docker-native HEALTHCHECK directive (`Config.Healthcheck`).
+    /// Distinct from `ServiceRun.healthcheck_path`, which yoink uses
+    /// as its deploy-time HTTP probe gate. When set, this becomes
+    /// the container-image-level healthcheck that `docker ps` /
+    /// `docker inspect` / lazydocker / cAdvisor read — i.e. the
+    /// "is this container running cleanly RIGHT NOW" signal that
+    /// outlives the deploy. Currently populated by yoink only for
+    /// the synthesized `yoink-proxy`; user services inherit whatever
+    /// HEALTHCHECK their image's Dockerfile declares.
+    pub docker_healthcheck: Option<HealthConfig>,
 }
 
 /// Build the typed body for `bollard.create_container`.
@@ -107,6 +117,7 @@ pub fn build_container(spec: &RunSpec) -> Result<ContainerCreateBody, BuildError
         },
         user: spec.options.user.clone(),
         exposed_ports: vec_opt(&exposed_ports),
+        healthcheck: spec.docker_healthcheck.clone(),
         host_config: Some(host_config),
         networking_config: Some(networking_config),
         ..Default::default()
@@ -460,6 +471,33 @@ pub fn compute_spec_hash(spec: &RunSpec) -> String {
     feed_list(&mut h, "publish", &spec.publish);
     feed_list(&mut h, "binds", &spec.binds);
     feed_list(&mut h, "volumes", &spec.volumes);
+    if let Some(hc) = &spec.docker_healthcheck {
+        // Stringify each field independently. test is the load-bearing
+        // bit; interval/timeout/retries/start_period are tuning knobs
+        // that should still trigger a re-roll when changed (e.g.
+        // bumping retries from 3 → 5).
+        feed_opt_list(&mut h, "healthcheck.test", hc.test.as_deref());
+        feed(
+            &mut h,
+            "healthcheck.interval_ns",
+            hc.interval.unwrap_or(0).to_le_bytes().as_slice(),
+        );
+        feed(
+            &mut h,
+            "healthcheck.timeout_ns",
+            hc.timeout.unwrap_or(0).to_le_bytes().as_slice(),
+        );
+        feed(
+            &mut h,
+            "healthcheck.retries",
+            hc.retries.unwrap_or(0).to_le_bytes().as_slice(),
+        );
+        feed(
+            &mut h,
+            "healthcheck.start_period_ns",
+            hc.start_period.unwrap_or(0).to_le_bytes().as_slice(),
+        );
+    }
 
     let opts = &spec.options;
     feed_list(&mut h, "network_aliases", &opts.network_aliases);
@@ -593,6 +631,7 @@ mod tests {
             publish: vec![],
             binds: vec![],
             volumes: vec![],
+            docker_healthcheck: None,
         }
     }
 
@@ -629,6 +668,49 @@ mod tests {
         assert_eq!(host.auto_remove, Some(false));
         let rp = host.restart_policy.unwrap();
         assert_eq!(rp.name, Some(RestartPolicyNameEnum::UNLESS_STOPPED));
+    }
+
+    #[test]
+    fn build_container_emits_docker_healthcheck_when_set() {
+        let mut spec = sample_spec();
+        spec.docker_healthcheck = Some(HealthConfig {
+            test: Some(vec![
+                "CMD-SHELL".into(),
+                "wget --spider --quiet http://127.0.0.1:2019/config/ || exit 1".into(),
+            ]),
+            interval: Some(30 * 1_000_000_000),
+            timeout: Some(5 * 1_000_000_000),
+            retries: Some(3),
+            start_period: Some(10 * 1_000_000_000),
+            ..Default::default()
+        });
+        let body = build_container(&spec).unwrap();
+        let hc = body.healthcheck.expect("healthcheck on body");
+        let test = hc.test.unwrap();
+        assert_eq!(test[0], "CMD-SHELL");
+        assert!(test[1].contains("127.0.0.1:2019/config/"));
+        assert_eq!(hc.interval, Some(30_000_000_000));
+        assert_eq!(hc.retries, Some(3));
+    }
+
+    #[test]
+    fn spec_hash_differs_when_healthcheck_changes() {
+        let base = sample_spec();
+        let baseline = compute_spec_hash(&base);
+        let mut with_hc = base.clone();
+        with_hc.docker_healthcheck = Some(HealthConfig {
+            test: Some(vec!["CMD".into(), "true".into()]),
+            ..Default::default()
+        });
+        let with_hc_hash = compute_spec_hash(&with_hc);
+        assert_ne!(baseline, with_hc_hash, "adding a healthcheck must reroll");
+        let mut tighter = with_hc.clone();
+        tighter.docker_healthcheck.as_mut().unwrap().retries = Some(5);
+        assert_ne!(
+            with_hc_hash,
+            compute_spec_hash(&tighter),
+            "tightening retries must reroll"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

The bundled \`yoink-proxy\` (synthesized when \`proxy:\` is configured) used \`caddy:2\` as-is — and caddy:2 ships no HEALTHCHECK directive. So while every user service whose Dockerfile sets one shows \`(healthy)\` in \`docker ps\`, lazydocker, cAdvisor, etc., yoink-proxy showed plain \`Up 12 hours\` with no health indicator. Bad signal — yoink-proxy IS the front door, "is it healthy?" is the most important question to answer at a glance.

Yoink runs its own deploy-time gate against Caddy's admin \`/config/\` endpoint, but that's invisible to anything watching docker runtime state. Add a Docker-native HEALTHCHECK so the bundled proxy is a first-class citizen in the container UX.

## How

- New \`RunSpec.docker_healthcheck: Option<HealthConfig>\` field
- \`build_container\` threads it into \`ContainerCreateBody.healthcheck\`
- \`compute_spec_hash\` folds it in (re-roll triggers if probe / tuning changes)
- \`build_run_spec\` populates it for \`kind: Some(ServiceKind::Proxy)\` only — user services keep inheriting whatever HEALTHCHECK their image's Dockerfile declares (or none)
- The probe itself: \`CMD-SHELL wget --spider --quiet http://127.0.0.1:2019/config/\`. caddy:2 is alpine-based, BusyBox wget is in \$PATH, \`--spider\` exits 0 on HTTP 200 / non-zero otherwise.
- Tuning: 30 s interval, 5 s timeout, 10 s start_period, 3 retries — generous on start so first-boot TLS bootstrap doesn't trip \`unhealthy\`.

## Verified

\`cargo test --quiet\` → 240 passed (was 238; +2 for HEALTHCHECK round-trip and spec_hash change-detection).

\`cargo clippy --all-targets\` → no new warnings on the touched files.

## Test plan

- [ ] Merge → release → \`brew upgrade yoink\` → \`yoink up\`
- [ ] \`docker ps --filter name=yoink-proxy\` shows \`(healthy)\`
- [ ] \`docker inspect yoink-proxy-* | jq .[0].State.Health.Status\` reports \`healthy\`
- [ ] An intentionally broken Caddy admin port (kill the process inside) flips \`docker ps\` to \`(unhealthy)\` within ~90 s