### PR TITLE
feat(tui): refresh secrets cache after a successful in-TUI edit

### DIFF
--- a/yoink/src/tui/app.rs
+++ b/yoink/src/tui/app.rs
@@ -1466,8 +1466,10 @@ impl App {
         if self.secrets_state.confirming_remove() {
             let confirm = matches!(key.code, KeyCode::Char('y') | KeyCode::Enter);
             if confirm {
-                if let Some(key) = self.secrets_state.confirm_remove() {
-                    self.secrets_state.apply_remove(key);
+                if let Some(key) = self.secrets_state.confirm_remove()
+                    && self.secrets_state.apply_remove(key)
+                {
+                    self.spawn_secrets_loader();
                 }
             } else {
                 self.secrets_state.cancel_edit();
@@ -1483,8 +1485,10 @@ impl App {
             match key.code {
                 KeyCode::Esc => self.secrets_state.cancel_edit(),
                 KeyCode::Enter => {
-                    if let Some(commit) = self.secrets_state.commit_input() {
-                        self.secrets_state.apply_commit(commit);
+                    if let Some(commit) = self.secrets_state.commit_input()
+                        && self.secrets_state.apply_commit(commit)
+                    {
+                        self.spawn_secrets_loader();
                     }
                 }
                 KeyCode::Backspace => self.secrets_state.backspace(),

--- a/yoink/src/tui/secrets.rs
+++ b/yoink/src/tui/secrets.rs
@@ -267,39 +267,48 @@ impl SecretsState {
     }
 
     /// Apply a confirmed `EditCommit` to the in-memory map and
-    /// re-seal to disk. Updates the flash with the result.
-    pub fn apply_commit(&mut self, commit: EditCommit) {
+    /// re-seal to disk. Updates the flash with the result. Returns
+    /// `true` when the new sealed file made it to disk — the caller
+    /// uses the signal to refresh the app's drift-detection bundle
+    /// cache so the dashboard drift cell picks up the edit on the
+    /// very next tick instead of waiting for a TUI restart.
+    pub fn apply_commit(&mut self, commit: EditCommit) -> bool {
         let LoadStatus::Loaded(bundle) = &mut self.bundle else {
             self.flash("internal: bundle not loaded");
-            return;
+            return false;
         };
-        match commit {
+        let saved = match commit {
             EditCommit::Set { key, value } => {
                 bundle.values.insert(key.clone(), value);
                 bundle.keys = bundle.values.keys().cloned().collect();
                 if let Err(e) = persist(bundle) {
                     self.flash(format!("save failed: {e}"));
-                    return;
+                    return false;
                 }
                 self.flash(format!("set {key}"));
+                true
             }
             EditCommit::Remove { key } => {
                 bundle.values.remove(&key);
                 bundle.keys = bundle.values.keys().cloned().collect();
                 if let Err(e) = persist(bundle) {
                     self.flash(format!("save failed: {e}"));
-                    return;
+                    return false;
                 }
                 self.flash(format!("removed {key}"));
+                true
             }
-        }
+        };
         let n = self.bundle_len();
         clamp_selection(&mut self.table, n);
+        saved
     }
 
     /// Convenience for the on_key handler: confirmed remove path.
-    pub fn apply_remove(&mut self, key: String) {
-        self.apply_commit(EditCommit::Remove { key });
+    /// Returns the same `did-we-persist` bool as `apply_commit` so the
+    /// caller can refresh the drift cache on success.
+    pub fn apply_remove(&mut self, key: String) -> bool {
+        self.apply_commit(EditCommit::Remove { key })
     }
 
     pub fn select_next(&mut self) {
@@ -841,6 +850,53 @@ mod tests {
         assert_eq!(parsed.get("FOO").unwrap(), "bar baz");
 
         std::fs::remove_dir_all(dir).ok();
+    }
+
+    #[test]
+    fn apply_commit_signals_persist_success() {
+        // The bool return drives the app's spawn_secrets_loader call —
+        // we want a refresh on persist success, not on read-only or
+        // failure paths.
+        let dir = tempdir();
+        let path = dir.join("secrets.age");
+        let id = age::x25519::Identity::generate();
+        let recipient = id.to_public().to_string();
+        let mut s = SecretsState::new();
+        s.bundle = LoadStatus::Loaded(LoadedBundle {
+            values: BTreeMap::new(),
+            keys: Vec::new(),
+            title: "test".into(),
+            write_target: Some(WriteTarget {
+                path,
+                recipients: vec![recipient],
+            }),
+        });
+        let saved = s.apply_commit(EditCommit::Set {
+            key: "K".into(),
+            value: "v".into(),
+        });
+        assert!(saved, "successful set must signal persist");
+        let removed = s.apply_remove("K".into());
+        assert!(removed, "successful remove must signal persist");
+        std::fs::remove_dir_all(dir).ok();
+    }
+
+    #[test]
+    fn apply_commit_returns_false_on_read_only_bundle() {
+        // provider:command bundles arrive with write_target=None;
+        // commits should fail loud and not signal a refresh.
+        let mut s = SecretsState::new();
+        s.bundle = LoadStatus::Loaded(LoadedBundle {
+            values: BTreeMap::new(),
+            keys: Vec::new(),
+            title: "test".into(),
+            write_target: None,
+        });
+        let saved = s.apply_commit(EditCommit::Set {
+            key: "K".into(),
+            value: "v".into(),
+        });
+        assert!(!saved);
     }
 
     fn tempdir() -> PathBuf {


### PR DESCRIPTION
## Summary

Editing a secret via the TUI's secrets pane (\`a\` add, \`e\` edit, \`x\`/y remove) writes the new sealed file to disk immediately, but the app's cached \`SecretsBundle\` — the one used to render the dashboard's drift cell — kept the pre-edit values until the operator restarted the TUI.

Concretely: an operator notices a stale value, fixes it through the pane (sealed file rewritten), but the dashboard keeps reporting drift on every service that consumes the changed key for the rest of the session. Confusing — the only way to clear it without this fix was \`q\` then re-launch.

## Fix

\`apply_commit\` / \`apply_remove\` now return a "did we persist?" bool. The run loop, on \`true\`, fires \`spawn_secrets_loader\` — the same loader that runs at startup. It re-reads the freshly-written sealed file and swaps \`self.secrets\` (Arc<RwLock<…>>). The dashboard drift cell already reads the bundle on every render via \`render_drift_cell\`, so no plumbing beyond the cache swap.

## Tests

240 → 242. Two new in \`secrets::tests\`:
- \`apply_commit_signals_persist_success\` — successful \`Set\` and \`Remove\` return \`true\` (so the refresh fires)
- \`apply_commit_returns_false_on_read_only_bundle\` — \`provider: command\` bundles arrive with \`write_target=None\`; commits should not signal a refresh

\`cargo clippy --all-targets\` clean.

## Discovered while

End-to-end testing the secrets-mechanism migration on a long-lived TUI session against backtrack-eu-1. The drift cell flap that prompted #26 was caused by a stale cached bundle; this PR addresses the related "edit-via-TUI doesn't propagate" gap.