### PR TITLE
feat: yoink doctor 🩺 — diagnose deploy-blockers before `yoink up`

### DIFF
--- a/docs/content/docs/reference/cli.md
+++ b/docs/content/docs/reference/cli.md
@@ -112,6 +112,10 @@ yoink top                                htop-style CPU/mem snapshot per running
 yoink version <SERVICE>                  print currently-running tag(s) per replica
 
 yoink validate                           lint the config; optionally ping each docker daemon
+yoink doctor                             diagnose deploy-blockers (host reachability, age
+                                         identity, DNS for `domain:` services, arch alignment,
+                                         common config friction). Exits non-zero on Errors.
+  --json                                 output as JSON for piping / agent consumption
 yoink lock                               inspect / release the per-host deploy lock (useful
                                          after a crashed deploy left a sentinel container)
 yoink completions <shell>                generate shell completions (bash/zsh/fish/...)

--- a/yoink/src/docker_ops.rs
+++ b/yoink/src/docker_ops.rs
@@ -77,6 +77,17 @@ impl Host {
     pub fn is_local(&self) -> bool {
         self.address == Self::LOCAL_ADDRESS
     }
+
+    /// Construct the synthetic local host. The empty `user` is fine —
+    /// the local-socket transport ignores it. Symmetric with
+    /// [`Self::is_local`].
+    #[must_use]
+    pub fn local() -> Self {
+        Self {
+            user: String::new(),
+            address: Self::LOCAL_ADDRESS.to_string(),
+        }
+    }
 }
 
 impl From<&YoinkHost> for Host {

--- a/yoink/src/doctor.rs
+++ b/yoink/src/doctor.rs
@@ -13,9 +13,10 @@
 //! share the engine. CLI formats `Vec<Finding>` as a list; the TUI
 //! pane renders the same vector in a scrolling table.
 
+use std::path::PathBuf;
 use std::sync::Arc;
 
-use crate::config::{Config, SecretsConfig, ServiceConfig};
+use crate::config::{Config, SecretsConfig, ServiceConfig, TlsMode};
 use crate::docker_ops::{DockerOps, Host};
 use crate::sealed;
 
@@ -101,8 +102,14 @@ pub async fn run_doctor(config: &Config, ops: Arc<dyn DockerOps>) -> Vec<Finding
     let mut findings: Vec<Finding> = Vec::new();
 
     findings.extend(check_secrets(config));
+    findings.extend(check_sealed_file_exists(config));
+    findings.extend(check_provider_command(config));
+    findings.extend(check_keys_dir_perms());
     findings.extend(check_build_blocks(config));
+    findings.extend(check_dockerfile_paths(config));
     findings.extend(check_proxied_services(config));
+    findings.extend(check_tls_cert_secrets(config).await);
+    findings.extend(check_secret_references(config).await);
     findings.extend(check_hosts(config, ops.clone()).await);
     findings.extend(check_arch_alignment(config, ops.clone()).await);
     findings.extend(check_dns_for_domains(config).await);
@@ -444,6 +451,320 @@ async fn check_dns_for_domains(config: &Config) -> Vec<Finding> {
     out
 }
 
+// ---------- sealed.age existence ----------
+
+fn check_sealed_file_exists(config: &Config) -> Vec<Finding> {
+    let Some(SecretsConfig::Age { file, recipients }) = &config.secrets else {
+        return Vec::new();
+    };
+    if recipients.is_empty() {
+        return Vec::new();
+    }
+    let any_refs = config
+        .services
+        .iter()
+        .any(|s| !s.secrets.is_empty() || !s.env_from_secrets.is_empty());
+    if !any_refs {
+        return Vec::new();
+    }
+    let path = match sealed::resolve_sealed_path(config, file.as_deref()) {
+        Ok(p) => p,
+        Err(_) => return Vec::new(),
+    };
+    if path.exists() {
+        return vec![Finding::pass(
+            "secrets",
+            format!("sealed file present at {}", path.display()),
+        )];
+    }
+    vec![
+        Finding::error(
+            "secrets",
+            format!("{} doesn't exist but services reference secrets", path.display()),
+        )
+        .with_fix("run `yoink secrets edit` to create the bundle, then commit the file"),
+    ]
+}
+
+// ---------- provider: command binary on PATH ----------
+
+fn check_provider_command(config: &Config) -> Vec<Finding> {
+    let Some(SecretsConfig::Command { command, .. }) = &config.secrets else {
+        return Vec::new();
+    };
+    let Some(prog) = command.first() else {
+        return vec![
+            Finding::error("secrets", "`secrets.command:` is empty")
+                .with_fix("set the binary as the first list element"),
+        ];
+    };
+    if which_on_path(prog).is_some() {
+        vec![Finding::pass(
+            "secrets",
+            format!("provider command `{prog}` is on PATH"),
+        )]
+    } else {
+        vec![
+            Finding::error(
+                "secrets",
+                format!("provider command `{prog}` not found on PATH"),
+            )
+            .with_fix(format!(
+                "install `{prog}` (or fix PATH so yoink can spawn it at deploy time)"
+            )),
+        ]
+    }
+}
+
+/// Lightweight `which` — walk `PATH` and return the first match. We
+/// don't pull in the `which` crate for one call site.
+fn which_on_path(program: &str) -> Option<PathBuf> {
+    if program.contains('/') {
+        let p = PathBuf::from(program);
+        return p.is_file().then_some(p);
+    }
+    let path = std::env::var_os("PATH")?;
+    for dir in std::env::split_paths(&path) {
+        let candidate = dir.join(program);
+        if candidate.is_file() {
+            return Some(candidate);
+        }
+    }
+    None
+}
+
+// ---------- keys-dir file modes ----------
+
+#[cfg(unix)]
+fn check_keys_dir_perms() -> Vec<Finding> {
+    use std::os::unix::fs::MetadataExt;
+    let Ok(dir) = sealed::keys_dir() else {
+        return Vec::new();
+    };
+    if !dir.exists() {
+        return Vec::new();
+    }
+    let mut out = Vec::new();
+    let Ok(entries) = std::fs::read_dir(&dir) else {
+        return Vec::new();
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.extension().and_then(|s| s.to_str()) != Some("key") {
+            continue;
+        }
+        let Ok(meta) = entry.metadata() else { continue };
+        let mode = meta.mode() & 0o777;
+        if mode & 0o077 != 0 {
+            out.push(
+                Finding::warn(
+                    "secrets",
+                    format!(
+                        "{} has permissive mode {:o} (group/world readable)",
+                        path.display(),
+                        mode
+                    ),
+                )
+                .with_fix(format!("chmod 600 {}", path.display())),
+            );
+        }
+    }
+    out
+}
+
+#[cfg(not(unix))]
+fn check_keys_dir_perms() -> Vec<Finding> {
+    Vec::new()
+}
+
+// ---------- Dockerfile path resolves ----------
+
+fn check_dockerfile_paths(config: &Config) -> Vec<Finding> {
+    let base = config
+        .config_dir
+        .clone()
+        .unwrap_or_else(|| PathBuf::from("."));
+    let mut out = Vec::new();
+    for svc in &config.services {
+        let Some(build) = &svc.build else { continue };
+        let context = base.join(&build.context);
+        let dockerfile = context.join(build.dockerfile.as_deref().unwrap_or("Dockerfile"));
+        if !dockerfile.exists() {
+            out.push(
+                Finding::error(
+                    "build",
+                    format!(
+                        "service `{}`: Dockerfile not found at {}",
+                        svc.name,
+                        dockerfile.display()
+                    ),
+                )
+                .with_fix(format!(
+                    "create {}, or set `build.dockerfile:` to an existing path \
+                     relative to the build context (`{}`)",
+                    dockerfile.display(),
+                    context.display()
+                )),
+            );
+        }
+    }
+    out
+}
+
+// ---------- TLS cert mode requires bundle entries ----------
+
+async fn check_tls_cert_secrets(config: &Config) -> Vec<Finding> {
+    let proxy_default_cert = config
+        .proxy
+        .as_ref()
+        .and_then(|p| p.tls.as_ref())
+        .map(|t| t.cert_secret.clone());
+    let proxy_default_key = config
+        .proxy
+        .as_ref()
+        .and_then(|p| p.tls.as_ref())
+        .map(|t| t.key_secret.clone());
+
+    let needs_bundle = config
+        .services
+        .iter()
+        .any(|s| matches!(s.tls, TlsMode::Cert));
+    if !needs_bundle {
+        return Vec::new();
+    }
+    let bundle = match crate::secrets::load_bundle(config).await {
+        Ok(Some(b)) => b,
+        // If we can't load the bundle, `check_secret_references` will
+        // already have surfaced that — don't double-report.
+        _ => return Vec::new(),
+    };
+
+    let mut out = Vec::new();
+    for svc in &config.services {
+        if !matches!(svc.tls, TlsMode::Cert) {
+            continue;
+        }
+        let cert_key = svc
+            .tls_cert_secret
+            .clone()
+            .or_else(|| proxy_default_cert.clone());
+        let key_key = svc
+            .tls_key_secret
+            .clone()
+            .or_else(|| proxy_default_key.clone());
+        for (label, key) in [("tls_cert_secret", cert_key), ("tls_key_secret", key_key)] {
+            match key {
+                None => {
+                    out.push(
+                        Finding::error(
+                            "config",
+                            format!(
+                                "service `{}` uses `tls: cert` but {label} is unset",
+                                svc.name
+                            ),
+                        )
+                        .with_fix(format!(
+                            "set `{label}: <SECRET_NAME>` on the service \
+                             (or `proxy.tls.{}` to inherit)",
+                            label.trim_start_matches("tls_").trim_end_matches("_secret")
+                        )),
+                    );
+                }
+                Some(k) if bundle.get(&k).is_none() => {
+                    out.push(
+                        Finding::error(
+                            "secrets",
+                            format!(
+                                "service `{}` references {label} `{k}` not in the bundle",
+                                svc.name
+                            ),
+                        )
+                        .with_fix(format!(
+                            "add `{k}=<pem-bytes>` via `yoink secrets edit`"
+                        )),
+                    );
+                }
+                _ => {}
+            }
+        }
+    }
+    out
+}
+
+// ---------- env_from_secrets / secrets references match the bundle ----------
+
+async fn check_secret_references(config: &Config) -> Vec<Finding> {
+    let any_refs = config
+        .services
+        .iter()
+        .any(|s| !s.secrets.is_empty() || !s.env_from_secrets.is_empty());
+    if !any_refs {
+        return Vec::new();
+    }
+    let bundle = match crate::secrets::load_bundle(config).await {
+        Ok(Some(b)) => b,
+        Ok(None) => {
+            return vec![
+                Finding::error(
+                    "secrets",
+                    "services reference secrets but no bundle is configured",
+                )
+                .with_fix("set `secrets:` in yoink.yaml (`yoink secrets key generate` to start)"),
+            ];
+        }
+        Err(e) => {
+            return vec![
+                Finding::error("secrets", "couldn't load secrets bundle for cross-check")
+                    .with_detail(e.to_string()),
+            ];
+        }
+    };
+
+    let mut out = Vec::new();
+    for svc in &config.services {
+        for key in &svc.secrets {
+            if bundle.get(key).is_none() {
+                out.push(
+                    Finding::error(
+                        "secrets",
+                        format!(
+                            "service `{}` references missing secret `{key}`",
+                            svc.name
+                        ),
+                    )
+                    .with_fix(format!(
+                        "seal `{key}=<value>` (`yoink secrets edit`) or remove the reference"
+                    )),
+                );
+            }
+        }
+        for (env_name, secret_key) in &svc.env_from_secrets {
+            if bundle.get(secret_key).is_none() {
+                out.push(
+                    Finding::error(
+                        "secrets",
+                        format!(
+                            "service `{}`: env_from_secrets `{env_name}: {secret_key}` — `{secret_key}` not in bundle",
+                            svc.name
+                        ),
+                    )
+                    .with_fix(format!(
+                        "seal `{secret_key}=<value>` (typo? — bundle has {} keys)",
+                        bundle.len()
+                    )),
+                );
+            }
+        }
+    }
+    if out.is_empty() {
+        out.push(Finding::pass(
+            "secrets",
+            "every service's secret references resolve in the bundle",
+        ));
+    }
+    out
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -493,6 +814,53 @@ mod tests {
         assert_eq!(f.len(), 1);
         assert_eq!(f[0].severity, Severity::Warn);
         assert!(f[0].title.contains("my-tool"));
+    }
+
+    #[test]
+    fn dockerfile_path_check_errors_when_missing() {
+        let cfg = Config::parse_str(
+            "deploy:\n  networks: [yoink]\nhosts:\n  - { address: h, user: u }\n\
+             services:\n  - name: app\n    image: app\n    build: { context: nonexistent-dir }\n    run: { port: 8080, healthcheck_path: / }\n"
+        )
+        .unwrap();
+        let f = check_dockerfile_paths(&cfg);
+        assert_eq!(f.len(), 1);
+        assert_eq!(f[0].severity, Severity::Error);
+        assert!(f[0].title.contains("Dockerfile not found"));
+    }
+
+    #[test]
+    fn provider_command_missing_binary_errors() {
+        let cfg = Config::parse_str(
+            "deploy:\n  networks: [yoink]\nhosts:\n  - { address: h, user: u }\n\
+             secrets: { provider: command, command: [\"definitely-not-a-real-binary-xyzzy\"] }\n\
+             services:\n  - name: a\n    image: a\n    run: {}\n",
+        )
+        .unwrap();
+        let f = check_provider_command(&cfg);
+        assert_eq!(f.len(), 1);
+        assert_eq!(f[0].severity, Severity::Error);
+        assert!(f[0].title.contains("not found on PATH"));
+    }
+
+    #[test]
+    fn provider_command_present_passes() {
+        // `sh` is on every reasonable PATH.
+        let cfg = Config::parse_str(
+            "deploy:\n  networks: [yoink]\nhosts:\n  - { address: h, user: u }\n\
+             secrets: { provider: command, command: [sh, -c, \"echo X=1\"] }\n\
+             services:\n  - name: a\n    image: a\n    run: {}\n",
+        )
+        .unwrap();
+        let f = check_provider_command(&cfg);
+        assert_eq!(f.len(), 1);
+        assert_eq!(f[0].severity, Severity::Pass);
+    }
+
+    #[test]
+    fn which_on_path_finds_sh() {
+        assert!(which_on_path("sh").is_some());
+        assert!(which_on_path("definitely-not-on-path-xyzzy").is_none());
     }
 
     #[test]

--- a/yoink/src/doctor.rs
+++ b/yoink/src/doctor.rs
@@ -233,7 +233,10 @@ fn check_proxied_services(config: &Config) -> Vec<Finding> {
         .filter(|s| s.domain.is_some())
         .collect();
     if proxied.is_empty() {
-        return out;
+        return vec![Finding::pass(
+            "config",
+            "proxy/domain checks skipped (no services have `domain:` set)",
+        )];
     }
 
     if config.proxy.as_ref().and_then(|p| p.email.as_deref()).is_none() {
@@ -310,7 +313,10 @@ async fn check_hosts(config: &Config, ops: Arc<dyn DockerOps>) -> Vec<Finding> {
 async fn check_arch_alignment(config: &Config, ops: Arc<dyn DockerOps>) -> Vec<Finding> {
     let any_local_build = config.services.iter().any(|s| s.build.is_some());
     if !any_local_build {
-        return Vec::new();
+        return vec![Finding::pass(
+            "build",
+            "arch-alignment check skipped (no services have `build:` blocks)",
+        )];
     }
 
     // We need both local docker (for the build) and each remote
@@ -401,6 +407,13 @@ async fn check_dns_for_domains(config: &Config) -> Vec<Finding> {
     use tokio::net::lookup_host;
 
     let mut out = Vec::new();
+    let any_domain = config.services.iter().any(|s| s.domain.is_some());
+    if !any_domain {
+        return vec![Finding::pass(
+            "dns",
+            "DNS check skipped (no services have `domain:` set)",
+        )];
+    }
     for svc in &config.services {
         let Some(domain) = &svc.domain else { continue };
         for host in domain.as_list() {
@@ -455,17 +468,26 @@ async fn check_dns_for_domains(config: &Config) -> Vec<Finding> {
 
 fn check_sealed_file_exists(config: &Config) -> Vec<Finding> {
     let Some(SecretsConfig::Age { file, recipients }) = &config.secrets else {
-        return Vec::new();
+        return vec![Finding::pass(
+            "secrets",
+            "sealed file check skipped (not using `provider: age`)",
+        )];
     };
     if recipients.is_empty() {
-        return Vec::new();
+        return vec![Finding::pass(
+            "secrets",
+            "sealed file check skipped (no `secrets.recipients:`)",
+        )];
     }
     let any_refs = config
         .services
         .iter()
         .any(|s| !s.secrets.is_empty() || !s.env_from_secrets.is_empty());
     if !any_refs {
-        return Vec::new();
+        return vec![Finding::pass(
+            "secrets",
+            "sealed file check skipped (no services reference secrets)",
+        )];
     }
     let path = match sealed::resolve_sealed_path(config, file.as_deref()) {
         Ok(p) => p,
@@ -490,7 +512,10 @@ fn check_sealed_file_exists(config: &Config) -> Vec<Finding> {
 
 fn check_provider_command(config: &Config) -> Vec<Finding> {
     let Some(SecretsConfig::Command { command, .. }) = &config.secrets else {
-        return Vec::new();
+        return vec![Finding::pass(
+            "secrets",
+            "provider command check skipped (not using `provider: command`)",
+        )];
     };
     let Some(prog) = command.first() else {
         return vec![
@@ -542,9 +567,16 @@ fn check_keys_dir_perms() -> Vec<Finding> {
         return Vec::new();
     };
     if !dir.exists() {
-        return Vec::new();
+        return vec![Finding::pass(
+            "secrets",
+            format!(
+                "keys-dir perms check skipped ({} doesn't exist)",
+                dir.display()
+            ),
+        )];
     }
-    let mut out = Vec::new();
+    let mut bad = Vec::new();
+    let mut scanned = 0_usize;
     let Ok(entries) = std::fs::read_dir(&dir) else {
         return Vec::new();
     };
@@ -553,10 +585,11 @@ fn check_keys_dir_perms() -> Vec<Finding> {
         if path.extension().and_then(|s| s.to_str()) != Some("key") {
             continue;
         }
+        scanned += 1;
         let Ok(meta) = entry.metadata() else { continue };
         let mode = meta.mode() & 0o777;
         if mode & 0o077 != 0 {
-            out.push(
+            bad.push(
                 Finding::warn(
                     "secrets",
                     format!(
@@ -569,12 +602,27 @@ fn check_keys_dir_perms() -> Vec<Finding> {
             );
         }
     }
-    out
+    if scanned == 0 {
+        return vec![Finding::pass(
+            "secrets",
+            format!("keys-dir perms check skipped ({} is empty)", dir.display()),
+        )];
+    }
+    if bad.is_empty() {
+        return vec![Finding::pass(
+            "secrets",
+            format!("all {scanned} key file(s) in keys-dir are mode 0600"),
+        )];
+    }
+    bad
 }
 
 #[cfg(not(unix))]
 fn check_keys_dir_perms() -> Vec<Finding> {
-    Vec::new()
+    vec![Finding::pass(
+        "secrets",
+        "keys-dir perms check skipped (non-unix)",
+    )]
 }
 
 // ---------- Dockerfile path resolves ----------
@@ -585,8 +633,10 @@ fn check_dockerfile_paths(config: &Config) -> Vec<Finding> {
         .clone()
         .unwrap_or_else(|| PathBuf::from("."));
     let mut out = Vec::new();
+    let mut scanned = 0_usize;
     for svc in &config.services {
         let Some(build) = &svc.build else { continue };
+        scanned += 1;
         let context = base.join(&build.context);
         let dockerfile = context.join(build.dockerfile.as_deref().unwrap_or("Dockerfile"));
         if !dockerfile.exists() {
@@ -607,6 +657,18 @@ fn check_dockerfile_paths(config: &Config) -> Vec<Finding> {
                 )),
             );
         }
+    }
+    if scanned == 0 {
+        return vec![Finding::pass(
+            "build",
+            "Dockerfile-path check skipped (no services have a `build:` block)",
+        )];
+    }
+    if out.is_empty() {
+        return vec![Finding::pass(
+            "build",
+            format!("all {scanned} service Dockerfile path(s) resolve"),
+        )];
     }
     out
 }
@@ -630,7 +692,10 @@ async fn check_tls_cert_secrets(config: &Config) -> Vec<Finding> {
         .iter()
         .any(|s| matches!(s.tls, TlsMode::Cert));
     if !needs_bundle {
-        return Vec::new();
+        return vec![Finding::pass(
+            "config",
+            "TLS cert-mode check skipped (no services use `tls: cert`)",
+        )];
     }
     let bundle = match crate::secrets::load_bundle(config).await {
         Ok(Some(b)) => b,

--- a/yoink/src/doctor.rs
+++ b/yoink/src/doctor.rs
@@ -1,0 +1,509 @@
+//! `yoink doctor` — diagnose common deploy-blockers before they fire
+//! at deploy time.
+//!
+//! The deploy path's own errors are usually accurate but late: the
+//! operator hits "image platform mismatch" / "no age identity found"
+//! / "EAI\_AGAIN redis" / "Let's Encrypt validation failed" partway
+//! through `yoink up` and has to unwind. Doctor runs the same checks
+//! up front, classifies them by severity, and prints actionable fix
+//! hints — the difference between "deploy ran for 90 seconds, then
+//! failed" and "doctor ran for 5 seconds, told me to fix DNS first."
+//!
+//! Designed as a pure data-returning function so the TUI and CLI
+//! share the engine. CLI formats `Vec<Finding>` as a list; the TUI
+//! pane renders the same vector in a scrolling table.
+
+use std::sync::Arc;
+
+use crate::config::{Config, SecretsConfig, ServiceConfig};
+use crate::docker_ops::{DockerOps, Host};
+use crate::sealed;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Severity {
+    /// Check ran and the answer is good. Pass-level findings are
+    /// surfaced because absence of evidence is not evidence — the
+    /// operator should be able to see what was checked.
+    Pass,
+    /// Something's off but the deploy might still work. Examples:
+    /// "your local docker is amd64, host is amd64, but you have no
+    /// `build:` block — fine if you'll push from a registry."
+    Warn,
+    /// Will block a deploy as configured. Examples: "no age identity
+    /// found for the configured recipients," "host unreachable,"
+    /// "domain doesn't resolve."
+    Error,
+}
+
+#[derive(Debug, Clone)]
+pub struct Finding {
+    pub severity: Severity,
+    /// Short categorical label — `host`, `config`, `secrets`, `dns`,
+    /// `build`. Used by the TUI to colour-code groups.
+    pub category: &'static str,
+    /// One-line summary suitable for a list view.
+    pub title: String,
+    /// Optional follow-up — error text, observed values, etc.
+    pub detail: Option<String>,
+    /// Optional remediation hint — the actionable bit.
+    pub fix: Option<String>,
+}
+
+impl Finding {
+    fn pass(category: &'static str, title: impl Into<String>) -> Self {
+        Self {
+            severity: Severity::Pass,
+            category,
+            title: title.into(),
+            detail: None,
+            fix: None,
+        }
+    }
+
+    fn warn(category: &'static str, title: impl Into<String>) -> Self {
+        Self {
+            severity: Severity::Warn,
+            category,
+            title: title.into(),
+            detail: None,
+            fix: None,
+        }
+    }
+
+    fn error(category: &'static str, title: impl Into<String>) -> Self {
+        Self {
+            severity: Severity::Error,
+            category,
+            title: title.into(),
+            detail: None,
+            fix: None,
+        }
+    }
+
+    #[must_use]
+    pub fn with_detail(mut self, d: impl Into<String>) -> Self {
+        self.detail = Some(d.into());
+        self
+    }
+
+    #[must_use]
+    pub fn with_fix(mut self, f: impl Into<String>) -> Self {
+        self.fix = Some(f.into());
+        self
+    }
+}
+
+/// Run every check in parallel where possible and return findings in
+/// the order they completed. Caller decides how to render. Always
+/// completes — no individual check failure aborts the whole run; each
+/// surfaces as its own `Error`-severity Finding.
+pub async fn run_doctor(config: &Config, ops: Arc<dyn DockerOps>) -> Vec<Finding> {
+    let mut findings: Vec<Finding> = Vec::new();
+
+    findings.extend(check_secrets(config));
+    findings.extend(check_build_blocks(config));
+    findings.extend(check_proxied_services(config));
+    findings.extend(check_hosts(config, ops.clone()).await);
+    findings.extend(check_arch_alignment(config, ops.clone()).await);
+    findings.extend(check_dns_for_domains(config).await);
+
+    findings
+}
+
+// ---------- secrets ----------
+
+fn check_secrets(config: &Config) -> Vec<Finding> {
+    let Some(SecretsConfig::Age { recipients, .. }) = &config.secrets else {
+        // No age block (or `provider: command`) — there's nothing
+        // for doctor to verify; the `provider: command` path is
+        // exercised at deploy time and not pre-flightable here.
+        return vec![Finding::pass("secrets", "no age block to validate")];
+    };
+
+    if recipients.is_empty() {
+        return vec![
+            Finding::error("secrets", "`secrets.recipients:` is empty")
+                .with_fix("add at least one age public key (run `yoink secrets key generate`)"),
+        ];
+    }
+
+    match sealed::load_identity(recipients) {
+        Ok(identity) => {
+            let public = identity.to_public().to_string();
+            vec![
+                Finding::pass("secrets", "age identity available")
+                    .with_detail(format!("loaded identity matches recipient {public}")),
+            ]
+        }
+        Err(e) => vec![
+            Finding::error("secrets", "no age identity found for this config's recipients")
+                .with_detail(e.to_string())
+                .with_fix(
+                    "set YOINK_AGE_KEY (raw) or YOINK_AGE_KEY_FILE, \
+                     or place a key at ~/.config/yoink/keys/<recipient>.key \
+                     (which `yoink secrets key generate` does by default)",
+                ),
+        ],
+    }
+}
+
+// ---------- config: build blocks vs image refs ----------
+
+fn check_build_blocks(config: &Config) -> Vec<Finding> {
+    let mut out = Vec::new();
+    for svc in &config.services {
+        // Bare image (no `/`, no registry prefix) without a build:
+        // block means yoink can't pull it AND can't build it. The
+        // service deploys only if the operator pre-loads the image
+        // on the host themselves, which is unusual.
+        if svc.image.contains('/') || svc.image.starts_with("docker.io/") {
+            continue; // registry-prefixed; pull works
+        }
+        if svc.build.is_some() {
+            continue; // local build covers it
+        }
+        // Some bare names are real Docker Hub library images
+        // (`postgres`, `redis`, `caddy`, `node`). Only flag when we
+        // can't prove that.
+        if is_likely_hub_library(&svc.image) {
+            continue;
+        }
+        out.push(
+            Finding::warn(
+                "build",
+                format!(
+                    "service `{}` has bare image `{}` and no `build:` block",
+                    svc.name, svc.image
+                ),
+            )
+            .with_fix(format!(
+                "add a `build: {{ context: . }}` block, or change `image:` to a \
+                 registry-prefixed reference (e.g. `ghcr.io/you/{0}:tag`)",
+                svc.image
+            )),
+        );
+    }
+    if out.is_empty() {
+        vec![Finding::pass(
+            "build",
+            "every service is either registry-pullable or has a build: block",
+        )]
+    } else {
+        out
+    }
+}
+
+fn is_likely_hub_library(image: &str) -> bool {
+    matches!(
+        image,
+        "postgres"
+            | "redis"
+            | "caddy"
+            | "node"
+            | "alpine"
+            | "ubuntu"
+            | "debian"
+            | "nginx"
+            | "mariadb"
+            | "mysql"
+            | "mongo"
+            | "memcached"
+            | "rabbitmq"
+            | "elasticsearch"
+            | "minio"
+            | "traefik"
+            | "busybox"
+    )
+}
+
+// ---------- config: proxy + domain shape ----------
+
+fn check_proxied_services(config: &Config) -> Vec<Finding> {
+    let mut out = Vec::new();
+    let proxied: Vec<&ServiceConfig> = config
+        .services
+        .iter()
+        .filter(|s| s.domain.is_some())
+        .collect();
+    if proxied.is_empty() {
+        return out;
+    }
+
+    if config.proxy.as_ref().and_then(|p| p.email.as_deref()).is_none() {
+        out.push(
+            Finding::warn(
+                "config",
+                "`proxy.email:` is unset; Let's Encrypt registration uses a placeholder",
+            )
+            .with_fix(
+                "set `proxy: { email: you@example.com }` so ACME expiry warnings reach you",
+            ),
+        );
+    }
+
+    for svc in &proxied {
+        if svc.run.port.is_none() {
+            // The proxy needs a port to forward to — yoink rejects
+            // this at validate, so reaching doctor with this state
+            // would be unusual. Surface it anyway.
+            out.push(
+                Finding::error(
+                    "config",
+                    format!(
+                        "service `{}` has `domain:` but no `run.port`",
+                        svc.name
+                    ),
+                )
+                .with_fix("set `run.port: <container-port>` so the proxy knows where to forward"),
+            );
+        }
+    }
+    out
+}
+
+// ---------- hosts ----------
+
+async fn check_hosts(config: &Config, ops: Arc<dyn DockerOps>) -> Vec<Finding> {
+    let mut out = Vec::new();
+    for host_cfg in &config.hosts {
+        let host = Host::from(host_cfg);
+        match ops.version(&host).await {
+            Ok(v) => {
+                out.push(
+                    Finding::pass("host", format!("{}: docker reachable", host.address))
+                        .with_detail(format!(
+                            "docker {} (api {}) on {}/{}",
+                            v.server_version.as_deref().unwrap_or("?"),
+                            v.api_version.as_deref().unwrap_or("?"),
+                            v.os.as_deref().unwrap_or("?"),
+                            v.arch.as_deref().unwrap_or("?"),
+                        )),
+                );
+            }
+            Err(e) => {
+                out.push(
+                    Finding::error(
+                        "host",
+                        format!("{}: cannot reach docker", host.address),
+                    )
+                    .with_detail(e.to_string())
+                    .with_fix(format!(
+                        "verify `ssh {}@{}` works and `docker info` runs on the host",
+                        host.user, host.address
+                    )),
+                );
+            }
+        }
+    }
+    out
+}
+
+// ---------- arch alignment (local vs hosts) ----------
+
+async fn check_arch_alignment(config: &Config, ops: Arc<dyn DockerOps>) -> Vec<Finding> {
+    let any_local_build = config.services.iter().any(|s| s.build.is_some());
+    if !any_local_build {
+        return Vec::new();
+    }
+
+    // We need both local docker (for the build) and each remote
+    // host's arch (for the run target). If either fails, bail with
+    // a single Finding rather than spamming.
+    let local_host = Host {
+        user: String::new(),
+        address: Host::LOCAL_ADDRESS.to_string(),
+    };
+    let local = match ops.version(&local_host).await {
+        Ok(v) => v,
+        Err(e) => {
+            return vec![
+                Finding::warn(
+                    "build",
+                    "couldn't query local docker arch — skipping cross-build check",
+                )
+                .with_detail(e.to_string()),
+            ];
+        }
+    };
+    let local_arch = local.arch.as_deref().unwrap_or("");
+
+    let mut out = Vec::new();
+    for host_cfg in &config.hosts {
+        let host = Host::from(host_cfg);
+        if host.is_local() {
+            continue;
+        }
+        // Skip silently — `check_hosts` already surfaced the failure.
+        let Ok(remote) = ops.version(&host).await else {
+            continue;
+        };
+        let remote_arch = remote.arch.as_deref().unwrap_or("");
+        if local_arch.is_empty() || remote_arch.is_empty() {
+            continue;
+        }
+        if arches_compatible(local_arch, remote_arch) {
+            out.push(Finding::pass(
+                "build",
+                format!(
+                    "arch alignment: laptop {local_arch} <-> {} {remote_arch} (compatible)",
+                    host.address
+                ),
+            ));
+        } else {
+            out.push(
+                Finding::warn(
+                    "build",
+                    format!(
+                        "arch mismatch: laptop docker is {local_arch}, {} is {remote_arch}",
+                        host.address
+                    ),
+                )
+                .with_detail(
+                    "`docker build` defaults to the laptop arch; \
+                     pushing the resulting image to a different-arch host fails with \
+                     a confusing 'network sandbox not found' error at start time.",
+                )
+                .with_fix(format!(
+                    "add `extra_args: [\"--platform\", \"linux/{}\"]` \
+                     to every service's `build:` block",
+                    canonical_platform(remote_arch)
+                )),
+            );
+        }
+    }
+    out
+}
+
+fn arches_compatible(a: &str, b: &str) -> bool {
+    canonical_platform(a) == canonical_platform(b)
+}
+
+fn canonical_platform(arch: &str) -> &'static str {
+    match arch {
+        "x86_64" | "amd64" => "amd64",
+        "aarch64" | "arm64" => "arm64",
+        "armv7l" | "arm" => "arm/v7",
+        "riscv64" => "riscv64",
+        _ => "unknown",
+    }
+}
+
+// ---------- DNS for `domain:` services ----------
+
+async fn check_dns_for_domains(config: &Config) -> Vec<Finding> {
+    use tokio::net::lookup_host;
+
+    let mut out = Vec::new();
+    for svc in &config.services {
+        let Some(domain) = &svc.domain else { continue };
+        for host in domain.as_list() {
+            // `lookup_host` wants `host:port`; we don't care about the
+            // port, just whether the name resolves to A/AAAA records.
+            let probe = format!("{host}:443");
+            match lookup_host(&probe).await {
+                Ok(addrs) => {
+                    let ips: Vec<String> =
+                        addrs.map(|a| a.ip().to_string()).collect();
+                    if ips.is_empty() {
+                        out.push(
+                            Finding::error(
+                                "dns",
+                                format!("`{host}` doesn't resolve"),
+                            )
+                            .with_fix(format!(
+                                "add an A/AAAA record for `{host}` \
+                                 pointing at the host's public IP — \
+                                 Let's Encrypt validates by HTTP-01"
+                            )),
+                        );
+                    } else {
+                        out.push(
+                            Finding::pass(
+                                "dns",
+                                format!("`{host}` resolves"),
+                            )
+                            .with_detail(format!("→ {}", ips.join(", "))),
+                        );
+                    }
+                }
+                Err(e) => {
+                    out.push(
+                        Finding::error(
+                            "dns",
+                            format!("`{host}` lookup failed"),
+                        )
+                        .with_detail(e.to_string())
+                        .with_fix(format!(
+                            "add an A/AAAA record for `{host}` and wait for propagation"
+                        )),
+                    );
+                }
+            }
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn arches_compatible_pairs() {
+        assert!(arches_compatible("x86_64", "amd64"));
+        assert!(arches_compatible("aarch64", "arm64"));
+        assert!(!arches_compatible("aarch64", "amd64"));
+    }
+
+    #[test]
+    fn canonical_platform_normalises() {
+        assert_eq!(canonical_platform("x86_64"), "amd64");
+        assert_eq!(canonical_platform("aarch64"), "arm64");
+        assert_eq!(canonical_platform("nonsense"), "unknown");
+    }
+
+    #[test]
+    fn is_likely_hub_library_recognises_postgres() {
+        assert!(is_likely_hub_library("postgres"));
+        assert!(is_likely_hub_library("redis"));
+        assert!(!is_likely_hub_library("ghcr.io/you/app"));
+        assert!(!is_likely_hub_library("my-internal-app"));
+    }
+
+    #[test]
+    fn check_build_blocks_passes_clean_config() {
+        let cfg = Config::parse_str(
+            "deploy:\n  networks: [yoink]\nhosts:\n  - { address: h, user: u }\n\
+             services:\n  - name: api\n    image: ghcr.io/me/api\n    run: { port: 8080, healthcheck_path: / }\n"
+        )
+        .unwrap();
+        let f = check_build_blocks(&cfg);
+        assert_eq!(f.len(), 1);
+        assert_eq!(f[0].severity, Severity::Pass);
+    }
+
+    #[test]
+    fn check_build_blocks_warns_bare_image_without_build() {
+        let cfg = Config::parse_str(
+            "deploy:\n  networks: [yoink]\nhosts:\n  - { address: h, user: u }\n\
+             services:\n  - name: my-tool\n    image: my-tool\n    run: { port: 8080, healthcheck_path: / }\n"
+        )
+        .unwrap();
+        let f = check_build_blocks(&cfg);
+        assert_eq!(f.len(), 1);
+        assert_eq!(f[0].severity, Severity::Warn);
+        assert!(f[0].title.contains("my-tool"));
+    }
+
+    #[test]
+    fn check_build_blocks_skips_hub_library_bare_image() {
+        let cfg = Config::parse_str(
+            "deploy:\n  networks: [yoink]\nhosts:\n  - { address: h, user: u }\n\
+             services:\n  - name: db\n    image: postgres\n    tag: \"16-alpine\"\n    run: {}\n"
+        )
+        .unwrap();
+        let f = check_build_blocks(&cfg);
+        assert_eq!(f.len(), 1);
+        assert_eq!(f[0].severity, Severity::Pass);
+    }
+}

--- a/yoink/src/doctor.rs
+++ b/yoink/src/doctor.rs
@@ -20,7 +20,8 @@ use crate::config::{Config, SecretsConfig, ServiceConfig, TlsMode};
 use crate::docker_ops::{DockerOps, Host};
 use crate::sealed;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
+#[serde(rename_all = "lowercase")]
 pub enum Severity {
     /// Check ran and the answer is good. Pass-level findings are
     /// surfaced because absence of evidence is not evidence — the
@@ -36,7 +37,21 @@ pub enum Severity {
     Error,
 }
 
-#[derive(Debug, Clone)]
+/// Pass / Warn / Error counts in a single pass.
+#[must_use]
+pub fn tally(findings: &[Finding]) -> (usize, usize, usize) {
+    let mut t = (0, 0, 0);
+    for f in findings {
+        match f.severity {
+            Severity::Pass => t.0 += 1,
+            Severity::Warn => t.1 += 1,
+            Severity::Error => t.2 += 1,
+        }
+    }
+    t
+}
+
+#[derive(Debug, Clone, serde::Serialize)]
 pub struct Finding {
     pub severity: Severity,
     /// Short categorical label — `host`, `config`, `secrets`, `dns`,
@@ -45,8 +60,10 @@ pub struct Finding {
     /// One-line summary suitable for a list view.
     pub title: String,
     /// Optional follow-up — error text, observed values, etc.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub detail: Option<String>,
     /// Optional remediation hint — the actionable bit.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub fix: Option<String>,
 }
 
@@ -99,8 +116,36 @@ impl Finding {
 /// completes — no individual check failure aborts the whole run; each
 /// surfaces as its own `Error`-severity Finding.
 pub async fn run_doctor(config: &Config, ops: Arc<dyn DockerOps>) -> Vec<Finding> {
-    let mut findings: Vec<Finding> = Vec::new();
+    // Fan out the slow / shared I/O up front in one round-trip so
+    // every downstream check reads from cached data:
+    //   - `ops.version` per host (was: called twice per host, once
+    //     in check_hosts + once in check_arch_alignment).
+    //   - bundle load (was: called twice, in check_tls_cert_secrets
+    //     and check_secret_references — two age decrypts / two
+    //     `provider: command` spawns).
+    //   - DNS lookups for `domain:` services (independent of the
+    //     above; concurrent with the version probes).
+    let local_host = Host::local();
+    let host_version_futs = config.hosts.iter().map(|h| {
+        let host = Host::from(h);
+        let ops = ops.clone();
+        async move { (host.clone(), ops.version(&host).await) }
+    });
+    let local_version_fut = ops.version(&local_host);
+    let bundle_fut = crate::secrets::load_bundle(config);
+    let dns_fut = check_dns_for_domains(config);
 
+    let (host_versions, local_version, bundle_result, dns_findings) = tokio::join!(
+        futures_util::future::join_all(host_version_futs),
+        local_version_fut,
+        bundle_fut,
+        dns_fut,
+    );
+    let bundle = bundle_result.ok().flatten();
+    let bundle_ref = bundle.as_ref();
+
+    // Every other check is sync (config walk + cached lookups).
+    let mut findings: Vec<Finding> = Vec::new();
     findings.extend(check_secrets(config));
     findings.extend(check_sealed_file_exists(config));
     findings.extend(check_provider_command(config));
@@ -108,11 +153,15 @@ pub async fn run_doctor(config: &Config, ops: Arc<dyn DockerOps>) -> Vec<Finding
     findings.extend(check_build_blocks(config));
     findings.extend(check_dockerfile_paths(config));
     findings.extend(check_proxied_services(config));
-    findings.extend(check_tls_cert_secrets(config).await);
-    findings.extend(check_secret_references(config).await);
-    findings.extend(check_hosts(config, ops.clone()).await);
-    findings.extend(check_arch_alignment(config, ops.clone()).await);
-    findings.extend(check_dns_for_domains(config).await);
+    findings.extend(check_tls_cert_secrets(config, bundle_ref));
+    findings.extend(check_secret_references(config, bundle_ref));
+    findings.extend(check_hosts_from_versions(&host_versions));
+    findings.extend(check_arch_alignment_from_versions(
+        config,
+        local_version.as_ref().ok(),
+        &host_versions,
+    ));
+    findings.extend(dns_findings);
 
     findings
 }
@@ -273,11 +322,12 @@ fn check_proxied_services(config: &Config) -> Vec<Finding> {
 
 // ---------- hosts ----------
 
-async fn check_hosts(config: &Config, ops: Arc<dyn DockerOps>) -> Vec<Finding> {
+fn check_hosts_from_versions(
+    versions: &[(Host, Result<crate::docker_ops::DockerVersion, crate::docker_ops::DockerError>)],
+) -> Vec<Finding> {
     let mut out = Vec::new();
-    for host_cfg in &config.hosts {
-        let host = Host::from(host_cfg);
-        match ops.version(&host).await {
+    for (host, result) in versions {
+        match result {
             Ok(v) => {
                 out.push(
                     Finding::pass("host", format!("{}: docker reachable", host.address))
@@ -310,7 +360,11 @@ async fn check_hosts(config: &Config, ops: Arc<dyn DockerOps>) -> Vec<Finding> {
 
 // ---------- arch alignment (local vs hosts) ----------
 
-async fn check_arch_alignment(config: &Config, ops: Arc<dyn DockerOps>) -> Vec<Finding> {
+fn check_arch_alignment_from_versions(
+    config: &Config,
+    local_version: Option<&crate::docker_ops::DockerVersion>,
+    versions: &[(Host, Result<crate::docker_ops::DockerVersion, crate::docker_ops::DockerError>)],
+) -> Vec<Finding> {
     let any_local_build = config.services.iter().any(|s| s.build.is_some());
     if !any_local_build {
         return vec![Finding::pass(
@@ -318,38 +372,21 @@ async fn check_arch_alignment(config: &Config, ops: Arc<dyn DockerOps>) -> Vec<F
             "arch-alignment check skipped (no services have `build:` blocks)",
         )];
     }
-
-    // We need both local docker (for the build) and each remote
-    // host's arch (for the run target). If either fails, bail with
-    // a single Finding rather than spamming.
-    let local_host = Host {
-        user: String::new(),
-        address: Host::LOCAL_ADDRESS.to_string(),
-    };
-    let local = match ops.version(&local_host).await {
-        Ok(v) => v,
-        Err(e) => {
-            return vec![
-                Finding::warn(
-                    "build",
-                    "couldn't query local docker arch — skipping cross-build check",
-                )
-                .with_detail(e.to_string()),
-            ];
-        }
+    let Some(local) = local_version else {
+        return vec![Finding::warn(
+            "build",
+            "couldn't query local docker arch — skipping cross-build check",
+        )];
     };
     let local_arch = local.arch.as_deref().unwrap_or("");
 
     let mut out = Vec::new();
-    for host_cfg in &config.hosts {
-        let host = Host::from(host_cfg);
+    for (host, result) in versions {
         if host.is_local() {
             continue;
         }
-        // Skip silently — `check_hosts` already surfaced the failure.
-        let Ok(remote) = ops.version(&host).await else {
-            continue;
-        };
+        // Skip silently — check_hosts already surfaced the failure.
+        let Ok(remote) = result else { continue };
         let remote_arch = remote.arch.as_deref().unwrap_or("");
         if local_arch.is_empty() || remote_arch.is_empty() {
             continue;
@@ -406,7 +443,6 @@ fn canonical_platform(arch: &str) -> &'static str {
 async fn check_dns_for_domains(config: &Config) -> Vec<Finding> {
     use tokio::net::lookup_host;
 
-    let mut out = Vec::new();
     let any_domain = config.services.iter().any(|s| s.domain.is_some());
     if !any_domain {
         return vec![Finding::pass(
@@ -414,54 +450,50 @@ async fn check_dns_for_domains(config: &Config) -> Vec<Finding> {
             "DNS check skipped (no services have `domain:` set)",
         )];
     }
-    for svc in &config.services {
-        let Some(domain) = &svc.domain else { continue };
-        for host in domain.as_list() {
-            // `lookup_host` wants `host:port`; we don't care about the
-            // port, just whether the name resolves to A/AAAA records.
-            let probe = format!("{host}:443");
-            match lookup_host(&probe).await {
+    // Flatten every (service, host) into one list so they all
+    // resolve concurrently via join_all instead of awaiting each
+    // lookup serially.
+    let domains: Vec<String> = config
+        .services
+        .iter()
+        .filter_map(|s| s.domain.as_ref())
+        .flat_map(crate::config::DomainSpec::as_list)
+        .collect();
+    let lookups = domains.into_iter().map(|host| async move {
+        // `lookup_host` wants `host:port`; we don't care about the
+        // port, just whether the name resolves to A/AAAA records.
+        let probe = format!("{host}:443");
+        let result = lookup_host(probe).await;
+        (host, result)
+    });
+    futures_util::future::join_all(lookups)
+        .await
+        .into_iter()
+        .map(|(host, result)| {
+            match result {
                 Ok(addrs) => {
-                    let ips: Vec<String> =
-                        addrs.map(|a| a.ip().to_string()).collect();
+                    let ips: Vec<String> = addrs.map(|a| a.ip().to_string()).collect();
                     if ips.is_empty() {
-                        out.push(
-                            Finding::error(
-                                "dns",
-                                format!("`{host}` doesn't resolve"),
-                            )
-                            .with_fix(format!(
+                        Finding::error("dns", format!("`{host}` doesn't resolve")).with_fix(
+                            format!(
                                 "add an A/AAAA record for `{host}` \
                                  pointing at the host's public IP — \
                                  Let's Encrypt validates by HTTP-01"
-                            )),
-                        );
+                            ),
+                        )
                     } else {
-                        out.push(
-                            Finding::pass(
-                                "dns",
-                                format!("`{host}` resolves"),
-                            )
-                            .with_detail(format!("→ {}", ips.join(", "))),
-                        );
+                        Finding::pass("dns", format!("`{host}` resolves"))
+                            .with_detail(format!("→ {}", ips.join(", ")))
                     }
                 }
-                Err(e) => {
-                    out.push(
-                        Finding::error(
-                            "dns",
-                            format!("`{host}` lookup failed"),
-                        )
-                        .with_detail(e.to_string())
-                        .with_fix(format!(
-                            "add an A/AAAA record for `{host}` and wait for propagation"
-                        )),
-                    );
-                }
+                Err(e) => Finding::error("dns", format!("`{host}` lookup failed"))
+                    .with_detail(e.to_string())
+                    .with_fix(format!(
+                        "add an A/AAAA record for `{host}` and wait for propagation"
+                    )),
             }
-        }
-    }
-    out
+        })
+        .collect()
 }
 
 // ---------- sealed.age existence ----------
@@ -489,9 +521,8 @@ fn check_sealed_file_exists(config: &Config) -> Vec<Finding> {
             "sealed file check skipped (no services reference secrets)",
         )];
     }
-    let path = match sealed::resolve_sealed_path(config, file.as_deref()) {
-        Ok(p) => p,
-        Err(_) => return Vec::new(),
+    let Ok(path) = sealed::resolve_sealed_path(config, file.as_deref()) else {
+        return Vec::new();
     };
     if path.exists() {
         return vec![Finding::pass(
@@ -675,7 +706,10 @@ fn check_dockerfile_paths(config: &Config) -> Vec<Finding> {
 
 // ---------- TLS cert mode requires bundle entries ----------
 
-async fn check_tls_cert_secrets(config: &Config) -> Vec<Finding> {
+fn check_tls_cert_secrets(
+    config: &Config,
+    bundle: Option<&crate::secrets::SecretsBundle>,
+) -> Vec<Finding> {
     let proxy_default_cert = config
         .proxy
         .as_ref()
@@ -697,11 +731,10 @@ async fn check_tls_cert_secrets(config: &Config) -> Vec<Finding> {
             "TLS cert-mode check skipped (no services use `tls: cert`)",
         )];
     }
-    let bundle = match crate::secrets::load_bundle(config).await {
-        Ok(Some(b)) => b,
-        // If we can't load the bundle, `check_secret_references` will
-        // already have surfaced that — don't double-report.
-        _ => return Vec::new(),
+    // If the bundle isn't loaded, `check_secret_references` will have
+    // already surfaced that — don't double-report.
+    let Some(bundle) = bundle else {
+        return Vec::new();
     };
 
     let mut out = Vec::new();
@@ -758,31 +791,28 @@ async fn check_tls_cert_secrets(config: &Config) -> Vec<Finding> {
 
 // ---------- env_from_secrets / secrets references match the bundle ----------
 
-async fn check_secret_references(config: &Config) -> Vec<Finding> {
+fn check_secret_references(
+    config: &Config,
+    bundle: Option<&crate::secrets::SecretsBundle>,
+) -> Vec<Finding> {
     let any_refs = config
         .services
         .iter()
         .any(|s| !s.secrets.is_empty() || !s.env_from_secrets.is_empty());
     if !any_refs {
-        return Vec::new();
+        return vec![Finding::pass(
+            "secrets",
+            "secret-reference check skipped (no services reference secrets)",
+        )];
     }
-    let bundle = match crate::secrets::load_bundle(config).await {
-        Ok(Some(b)) => b,
-        Ok(None) => {
-            return vec![
-                Finding::error(
-                    "secrets",
-                    "services reference secrets but no bundle is configured",
-                )
-                .with_fix("set `secrets:` in yoink.yaml (`yoink secrets key generate` to start)"),
-            ];
-        }
-        Err(e) => {
-            return vec![
-                Finding::error("secrets", "couldn't load secrets bundle for cross-check")
-                    .with_detail(e.to_string()),
-            ];
-        }
+    let Some(bundle) = bundle else {
+        return vec![
+            Finding::error(
+                "secrets",
+                "services reference secrets but no bundle is configured / loadable",
+            )
+            .with_fix("set `secrets:` in yoink.yaml (`yoink secrets key generate` to start)"),
+        ];
     };
 
     let mut out = Vec::new();

--- a/yoink/src/lib.rs
+++ b/yoink/src/lib.rs
@@ -5,6 +5,7 @@ pub mod deploy;
 pub mod diff;
 pub mod docker;
 pub mod docker_ops;
+pub mod doctor;
 pub mod files;
 pub mod git;
 pub mod healthcheck;

--- a/yoink/src/main.rs
+++ b/yoink/src/main.rs
@@ -462,6 +462,17 @@ enum Command {
         #[arg(long)]
         check_hosts: bool,
     },
+    /// Diagnose common deploy-blockers before running `yoink up`.
+    /// Checks every host is reachable, docker arches align (laptop vs
+    /// host for any service with a `build:` block), age identity is
+    /// loadable, DNS resolves for `domain:`-tagged services, and
+    /// flags configurations that would fail mid-deploy.
+    Doctor {
+        /// Output as JSON instead of the default human-readable list.
+        /// Each entry: `{severity, category, title, detail, fix}`.
+        #[arg(long)]
+        json: bool,
+    },
     /// Render the Caddy admin-API JSON yoink would push for the
     /// current config. Read-only; useful for inspecting the proxy
     /// config or piping into `caddy adapt` / a debug Caddy's `/load`
@@ -872,6 +883,7 @@ async fn run(cli: Cli) -> Result<()> {
         Command::Volumes { host } => cmd_volumes(&config, host.as_deref()).await,
         Command::Dump { log_tail } => cmd_dump(&config, log_tail).await,
         Command::Validate { check_hosts } => cmd_validate(&config, check_hosts).await,
+        Command::Doctor { json } => cmd_doctor(&config, json).await,
         Command::ProxyRender => cmd_proxy_render(&config).await,
         Command::Lock { action } => cmd_lock(&config, action).await,
         Command::Diff { service, tag } => cmd_diff(&config, &service, tag.as_deref()).await,
@@ -2643,6 +2655,73 @@ async fn cmd_validate(config: &Config, check_hosts: bool) -> Result<()> {
     }
     if check_hosts {
         cmd_preflight(config).await?;
+    }
+    Ok(())
+}
+
+async fn cmd_doctor(config: &Config, json: bool) -> Result<()> {
+    use yoink::doctor::{run_doctor, Severity};
+
+    let ops: std::sync::Arc<dyn yoink::docker_ops::DockerOps> =
+        std::sync::Arc::new(build_real_ops(config, None).await?);
+    let findings = run_doctor(config, ops).await;
+
+    if json {
+        let payload: Vec<serde_json::Value> = findings
+            .iter()
+            .map(|f| {
+                serde_json::json!({
+                    "severity": match f.severity {
+                        Severity::Pass => "pass",
+                        Severity::Warn => "warn",
+                        Severity::Error => "error",
+                    },
+                    "category": f.category,
+                    "title": f.title,
+                    "detail": f.detail,
+                    "fix": f.fix,
+                })
+            })
+            .collect();
+        println!("{}", serde_json::to_string_pretty(&payload)?);
+    } else {
+        for f in &findings {
+            let icon = match f.severity {
+                Severity::Pass => "✓",
+                Severity::Warn => "!",
+                Severity::Error => "✗",
+            };
+            eprintln!("{icon} [{}] {}", f.category, f.title);
+            if let Some(d) = &f.detail {
+                for line in d.lines() {
+                    eprintln!("    {line}");
+                }
+            }
+            if let Some(fix) = &f.fix {
+                eprintln!("    fix: {fix}");
+            }
+        }
+        eprintln!();
+        let pass = findings
+            .iter()
+            .filter(|f| f.severity == Severity::Pass)
+            .count();
+        let warn = findings
+            .iter()
+            .filter(|f| f.severity == Severity::Warn)
+            .count();
+        let err = findings
+            .iter()
+            .filter(|f| f.severity == Severity::Error)
+            .count();
+        eprintln!("summary: {pass} pass, {warn} warn, {err} error");
+    }
+
+    let any_error = findings
+        .iter()
+        .any(|f| f.severity == Severity::Error);
+    if any_error {
+        anyhow::bail!("doctor found blocking issues");
     }
     Ok(())
 }

--- a/yoink/src/main.rs
+++ b/yoink/src/main.rs
@@ -2660,30 +2660,14 @@ async fn cmd_validate(config: &Config, check_hosts: bool) -> Result<()> {
 }
 
 async fn cmd_doctor(config: &Config, json: bool) -> Result<()> {
-    use yoink::doctor::{run_doctor, Severity};
+    use yoink::doctor::{run_doctor, tally, Severity};
 
     let ops: std::sync::Arc<dyn yoink::docker_ops::DockerOps> =
         std::sync::Arc::new(build_real_ops(config, None).await?);
     let findings = run_doctor(config, ops).await;
 
     if json {
-        let payload: Vec<serde_json::Value> = findings
-            .iter()
-            .map(|f| {
-                serde_json::json!({
-                    "severity": match f.severity {
-                        Severity::Pass => "pass",
-                        Severity::Warn => "warn",
-                        Severity::Error => "error",
-                    },
-                    "category": f.category,
-                    "title": f.title,
-                    "detail": f.detail,
-                    "fix": f.fix,
-                })
-            })
-            .collect();
-        println!("{}", serde_json::to_string_pretty(&payload)?);
+        println!("{}", serde_json::to_string_pretty(&findings)?);
     } else {
         for f in &findings {
             let icon = match f.severity {
@@ -2702,25 +2686,12 @@ async fn cmd_doctor(config: &Config, json: bool) -> Result<()> {
             }
         }
         eprintln!();
-        let pass = findings
-            .iter()
-            .filter(|f| f.severity == Severity::Pass)
-            .count();
-        let warn = findings
-            .iter()
-            .filter(|f| f.severity == Severity::Warn)
-            .count();
-        let err = findings
-            .iter()
-            .filter(|f| f.severity == Severity::Error)
-            .count();
+        let (pass, warn, err) = tally(&findings);
         eprintln!("summary: {pass} pass, {warn} warn, {err} error");
     }
 
-    let any_error = findings
-        .iter()
-        .any(|f| f.severity == Severity::Error);
-    if any_error {
+    let (_, _, errors) = tally(&findings);
+    if errors > 0 {
         anyhow::bail!("doctor found blocking issues");
     }
     Ok(())

--- a/yoink/src/tui/app.rs
+++ b/yoink/src/tui/app.rs
@@ -161,6 +161,7 @@ impl View {
             "  q / Ctrl-C    quit yoink",
             "  d h s l       dashboard / hosts / services / logs",
             "  R e           resources / encrypted-secrets",
+            "  D             doctor — diagnose deploy-blockers",
             "  E             edit config in $EDITOR (jumps to focused service/host)",
             "  ~             show drift detail for the focused service",
             "  Tab / S-Tab   cycle modes forward / backward",
@@ -410,6 +411,11 @@ enum Update {
         service: String,
         result: super::drift::DriftRefresh,
     },
+    /// Result of a doctor modal load — the full set of findings from
+    /// `crate::doctor::run_doctor`. `Err` carries a single message
+    /// when the run itself failed (vs returning an Error-severity
+    /// finding, which is normal output).
+    Doctor(Result<Vec<crate::doctor::Finding>, String>),
     /// Batch of `(host_address, container_name, stats)` samples produced
     /// by the always-on background stats poller. Each sample is folded
     /// into the per-container `StatsHistory` so that opening a
@@ -778,6 +784,10 @@ pub struct App {
     /// `Update::Drift`; the modal is rendered on top of whatever
     /// view was active.
     drift: super::drift::DriftState,
+    /// Doctor modal — same overlay shape as drift. Opens with `D`,
+    /// runs `crate::doctor::run_doctor` async, lands findings via
+    /// `Update::Doctor`. `r` rerun; Esc closes.
+    doctor: super::doctor::DoctorState,
     /// `Some((service, tag))` while a reconcile-confirmation modal
     /// is open. `y` / Enter confirms; anything else cancels.
     reconcile_target: Option<(String, String)>,
@@ -914,6 +924,7 @@ impl App {
             shown_errors: std::collections::HashSet::new(),
             kill_target: None,
             drift: super::drift::DriftState::default(),
+            doctor: super::doctor::DoctorState::default(),
             reconcile_target: None,
             prune_target: false,
             reconcile_all_target: false,
@@ -1545,6 +1556,31 @@ impl App {
             return false;
         }
 
+        // Doctor modal: capture keys while open so the underlying view
+        // doesn't see them. Esc closes; r reruns; ↑↓ navigates the
+        // findings list.
+        if self.doctor.is_open() {
+            match key.code {
+                KeyCode::Esc => {
+                    self.doctor.close();
+                    return false;
+                }
+                KeyCode::Char('r') => {
+                    self.open_doctor();
+                    return false;
+                }
+                KeyCode::Up | KeyCode::Char('k') => {
+                    self.doctor.select_prev();
+                    return false;
+                }
+                KeyCode::Down | KeyCode::Char('j') => {
+                    self.doctor.select_next();
+                    return false;
+                }
+                _ => return false, // swallow everything else while open
+            }
+        }
+
         // Kill-confirmation modal: `y` / Enter confirms, anything else
         // dismisses. Captured before view-specific keys so a stray `j`
         // can't both dismiss and select-next.
@@ -1737,6 +1773,12 @@ impl App {
                 // already used for refresh; the per-view handler can
                 // map capital R to other things if needed).
                 self.transition(View::Resources).await;
+                return false;
+            }
+            // Capital `D` opens the doctor modal — runs the same checks
+            // `yoink doctor` does, on top of the current view.
+            KeyCode::Char('D') => {
+                self.open_doctor();
                 return false;
             }
             // Capital `E` jumps into `$EDITOR` at the focused service /
@@ -2800,7 +2842,26 @@ impl App {
             } => {
                 self.drift.apply(&host, &service, result);
             }
+            Update::Doctor(result) => match result {
+                Ok(findings) => self.doctor.store(findings),
+                Err(msg) => self.doctor.fail(msg),
+            },
         }
+    }
+
+    /// Open the doctor modal and spawn the check-runner. Findings
+    /// land via `Update::Doctor`; the modal renders Loading until
+    /// they arrive. Idempotent — re-pressing `D` (or `r` while
+    /// open) just kicks off another run.
+    fn open_doctor(&mut self) {
+        self.doctor.mark_loading();
+        let ops = self.ops.clone();
+        let config = self.config.clone();
+        let tx = self.update_tx.clone();
+        tokio::spawn(async move {
+            let findings = crate::doctor::run_doctor(&config, ops).await;
+            let _ = tx.send(Update::Doctor(Ok(findings)));
+        });
     }
 
     /// Open the drift modal for `(host, service)` and spawn the
@@ -3331,6 +3392,10 @@ impl App {
 
         if self.drift.is_visible() {
             super::drift::render_modal(frame, &self.drift, &self.throbber_state);
+        }
+
+        if self.doctor.is_open() {
+            super::doctor::render(frame, frame.area(), &mut self.doctor);
         }
 
         // Render last so it sits on top of everything else when a

--- a/yoink/src/tui/app.rs
+++ b/yoink/src/tui/app.rs
@@ -412,10 +412,10 @@ enum Update {
         result: super::drift::DriftRefresh,
     },
     /// Result of a doctor modal load — the full set of findings from
-    /// `crate::doctor::run_doctor`. `Err` carries a single message
-    /// when the run itself failed (vs returning an Error-severity
-    /// finding, which is normal output).
-    Doctor(Result<Vec<crate::doctor::Finding>, String>),
+    /// `crate::doctor::run_doctor`. The runner always returns a vec
+    /// (errors surface as `Severity::Error` findings, not as a
+    /// run-level failure), so no Result wrapper is needed.
+    Doctor(Vec<crate::doctor::Finding>),
     /// Batch of `(host_address, container_name, stats)` samples produced
     /// by the always-on background stats poller. Each sample is folded
     /// into the per-container `StatsHistory` so that opening a
@@ -2842,10 +2842,7 @@ impl App {
             } => {
                 self.drift.apply(&host, &service, result);
             }
-            Update::Doctor(result) => match result {
-                Ok(findings) => self.doctor.store(findings),
-                Err(msg) => self.doctor.fail(msg),
-            },
+            Update::Doctor(findings) => self.doctor.store(findings),
         }
     }
 
@@ -2860,7 +2857,7 @@ impl App {
         let tx = self.update_tx.clone();
         tokio::spawn(async move {
             let findings = crate::doctor::run_doctor(&config, ops).await;
-            let _ = tx.send(Update::Doctor(Ok(findings)));
+            let _ = tx.send(Update::Doctor(findings));
         });
     }
 

--- a/yoink/src/tui/doctor.rs
+++ b/yoink/src/tui/doctor.rs
@@ -1,0 +1,235 @@
+//! TUI doctor pane — runs the same checks `yoink doctor` (CLI) does
+//! and renders the findings as a modal overlay on top of the current
+//! view. Press `D` from any view to open; `r` re-runs; Esc closes.
+//!
+//! Minimal state: a status enum + the most recently loaded findings.
+//! The actual checks happen in `crate::doctor`; this module is purely
+//! UI plumbing.
+
+use ratatui::Frame;
+use ratatui::layout::{Constraint, Layout, Rect};
+use ratatui::style::{Color, Modifier, Style};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Block, Borders, Clear, List, ListItem, ListState, Paragraph};
+
+use crate::doctor::{Finding, Severity};
+
+#[derive(Default)]
+pub struct DoctorState {
+    status: Status,
+    /// Currently-selected row in the findings list. Persists across
+    /// re-runs so a `r` refresh keeps the operator's place.
+    selected: ListState,
+}
+
+#[derive(Default)]
+enum Status {
+    #[default]
+    Closed,
+    Loading,
+    Loaded(Vec<Finding>),
+    Failed(String),
+}
+
+impl DoctorState {
+    #[must_use]
+    pub fn is_open(&self) -> bool {
+        !matches!(self.status, Status::Closed)
+    }
+
+    pub fn mark_loading(&mut self) {
+        self.status = Status::Loading;
+    }
+
+    pub fn close(&mut self) {
+        self.status = Status::Closed;
+    }
+
+    pub fn store(&mut self, findings: Vec<Finding>) {
+        let len = findings.len();
+        self.status = Status::Loaded(findings);
+        // Park selection at the first row so common case ("read top
+        // to bottom") needs no nav. Prior selection rarely makes
+        // sense across runs because findings can reorder.
+        self.selected.select(if len > 0 { Some(0) } else { None });
+    }
+
+    pub fn fail(&mut self, message: String) {
+        self.status = Status::Failed(message);
+    }
+
+    pub fn select_next(&mut self) {
+        if let Status::Loaded(findings) = &self.status
+            && !findings.is_empty()
+        {
+            let i = self.selected.selected().unwrap_or(0);
+            self.selected
+                .select(Some((i + 1).min(findings.len() - 1)));
+        }
+    }
+
+    pub fn select_prev(&mut self) {
+        if let Status::Loaded(_) = &self.status
+            && let Some(i) = self.selected.selected()
+            && i > 0
+        {
+            self.selected.select(Some(i - 1));
+        }
+    }
+}
+
+pub fn render(frame: &mut Frame<'_>, area: Rect, state: &mut DoctorState) {
+    if !state.is_open() {
+        return;
+    }
+    // Centred modal — 90% wide, 70% tall, capped to keep readability.
+    let modal = centred_rect(area, 90, 70, 110, 30);
+    frame.render_widget(Clear, modal);
+
+    let outer = Block::default()
+        .title(" doctor — diagnose deploy-blockers ")
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(Color::Cyan));
+    frame.render_widget(outer.clone(), modal);
+    let inner = outer.inner(modal);
+
+    // Footer for keybinds — claim a single line at the bottom.
+    let [body, footer] = Layout::vertical([Constraint::Min(1), Constraint::Length(1)])
+        .areas(inner);
+
+    match &state.status {
+        Status::Closed => {}
+        Status::Loading => {
+            let p = Paragraph::new("running checks…").style(
+                Style::default()
+                    .fg(Color::Yellow)
+                    .add_modifier(Modifier::ITALIC),
+            );
+            frame.render_widget(p, body);
+        }
+        Status::Failed(msg) => {
+            let p = Paragraph::new(format!("doctor failed: {msg}"))
+                .style(Style::default().fg(Color::Red));
+            frame.render_widget(p, body);
+        }
+        Status::Loaded(findings) => {
+            // Two columns: the scrollable list of findings, and a
+            // detail pane on the right showing the selected finding's
+            // detail + fix.
+            let [list_area, detail_area] = Layout::horizontal([
+                Constraint::Percentage(55),
+                Constraint::Percentage(45),
+            ])
+            .areas(body);
+
+            let items: Vec<ListItem> = findings
+                .iter()
+                .map(|f| {
+                    let (icon, color) = match f.severity {
+                        Severity::Pass => ("✓", Color::Green),
+                        Severity::Warn => ("!", Color::Yellow),
+                        Severity::Error => ("✗", Color::Red),
+                    };
+                    let line = Line::from(vec![
+                        Span::styled(
+                            format!("{icon} "),
+                            Style::default().fg(color).add_modifier(Modifier::BOLD),
+                        ),
+                        Span::styled(
+                            format!("[{}] ", f.category),
+                            Style::default().fg(Color::DarkGray),
+                        ),
+                        Span::raw(f.title.clone()),
+                    ]);
+                    ListItem::new(line)
+                })
+                .collect();
+
+            let list = List::new(items)
+                .highlight_style(
+                    Style::default()
+                        .add_modifier(Modifier::BOLD | Modifier::REVERSED),
+                )
+                .highlight_symbol(" ");
+            frame.render_stateful_widget(list, list_area, &mut state.selected);
+
+            let detail_text = state
+                .selected
+                .selected()
+                .and_then(|i| findings.get(i))
+                .map_or_else(
+                    || vec![Line::from("(no selection)")],
+                    detail_lines,
+                );
+            let detail = Paragraph::new(detail_text)
+                .wrap(ratatui::widgets::Wrap { trim: false })
+                .block(Block::default().borders(Borders::LEFT));
+            frame.render_widget(detail, detail_area);
+        }
+    }
+
+    let summary = match &state.status {
+        Status::Loaded(findings) => {
+            let pass = findings
+                .iter()
+                .filter(|f| f.severity == Severity::Pass)
+                .count();
+            let warn = findings
+                .iter()
+                .filter(|f| f.severity == Severity::Warn)
+                .count();
+            let err = findings
+                .iter()
+                .filter(|f| f.severity == Severity::Error)
+                .count();
+            format!("{pass} pass, {warn} warn, {err} error  —  ↑↓ navigate, r rerun, Esc close")
+        }
+        _ => "r rerun, Esc close".to_string(),
+    };
+    let footer_p =
+        Paragraph::new(summary).style(Style::default().fg(Color::DarkGray));
+    frame.render_widget(footer_p, footer);
+}
+
+fn detail_lines(f: &Finding) -> Vec<Line<'_>> {
+    let mut out = vec![
+        Line::from(Span::styled(
+            f.title.clone(),
+            Style::default().add_modifier(Modifier::BOLD),
+        )),
+        Line::from(""),
+    ];
+    if let Some(d) = &f.detail {
+        for line in d.lines() {
+            out.push(Line::from(Span::raw(line.to_string())));
+        }
+        out.push(Line::from(""));
+    }
+    if let Some(fix) = &f.fix {
+        out.push(Line::from(Span::styled(
+            "fix:",
+            Style::default()
+                .fg(Color::Cyan)
+                .add_modifier(Modifier::BOLD),
+        )));
+        for line in fix.lines() {
+            out.push(Line::from(Span::raw(format!("  {line}"))));
+        }
+    }
+    out
+}
+
+/// Centred rectangle inside `area`, expressed as a percentage of
+/// width and height with hard maxes for readability on big terminals.
+fn centred_rect(area: Rect, pct_w: u16, pct_h: u16, max_w: u16, max_h: u16) -> Rect {
+    let w = (area.width * pct_w / 100).min(max_w);
+    let h = (area.height * pct_h / 100).min(max_h);
+    let x = area.x + (area.width.saturating_sub(w)) / 2;
+    let y = area.y + (area.height.saturating_sub(h)) / 2;
+    Rect {
+        x,
+        y,
+        width: w,
+        height: h,
+    }
+}

--- a/yoink/src/tui/doctor.rs
+++ b/yoink/src/tui/doctor.rs
@@ -28,7 +28,6 @@ enum Status {
     Closed,
     Loading,
     Loaded(Vec<Finding>),
-    Failed(String),
 }
 
 impl DoctorState {
@@ -52,10 +51,6 @@ impl DoctorState {
         // to bottom") needs no nav. Prior selection rarely makes
         // sense across runs because findings can reorder.
         self.selected.select(if len > 0 { Some(0) } else { None });
-    }
-
-    pub fn fail(&mut self, message: String) {
-        self.status = Status::Failed(message);
     }
 
     pub fn select_next(&mut self) {
@@ -105,11 +100,6 @@ pub fn render(frame: &mut Frame<'_>, area: Rect, state: &mut DoctorState) {
                     .fg(Color::Yellow)
                     .add_modifier(Modifier::ITALIC),
             );
-            frame.render_widget(p, body);
-        }
-        Status::Failed(msg) => {
-            let p = Paragraph::new(format!("doctor failed: {msg}"))
-                .style(Style::default().fg(Color::Red));
             frame.render_widget(p, body);
         }
         Status::Loaded(findings) => {
@@ -170,18 +160,7 @@ pub fn render(frame: &mut Frame<'_>, area: Rect, state: &mut DoctorState) {
 
     let summary = match &state.status {
         Status::Loaded(findings) => {
-            let pass = findings
-                .iter()
-                .filter(|f| f.severity == Severity::Pass)
-                .count();
-            let warn = findings
-                .iter()
-                .filter(|f| f.severity == Severity::Warn)
-                .count();
-            let err = findings
-                .iter()
-                .filter(|f| f.severity == Severity::Error)
-                .count();
+            let (pass, warn, err) = crate::doctor::tally(findings);
             format!("{pass} pass, {warn} warn, {err} error  —  ↑↓ navigate, r rerun, Esc close")
         }
         _ => "r rerun, Esc close".to_string(),

--- a/yoink/src/tui/mod.rs
+++ b/yoink/src/tui/mod.rs
@@ -5,6 +5,7 @@ mod app;
 mod chrome;
 mod container_detail;
 mod dashboard;
+mod doctor;
 mod drift;
 mod editor;
 mod history;


### PR DESCRIPTION
A single command/pane that runs the checks deploys would otherwise discover one-at-a-time after partial work. Pulled from real friction in recent end-to-end smoke tests; everything in here is a thing I personally watched fail.

## The story

When `yoink up` fails it's usually accurate but late: half the services have been pulled, the lock is held, the operator is mid-deploy and now has to decide whether to roll back, retry, or start debugging. **`yoink doctor` runs the same checks up front** — non-mutating, exits in seconds, classifies findings by severity, prints actionable fix hints.

Designed as a pure data-returning function (`run_doctor(&Config, Arc<dyn DockerOps>) -> Vec<Finding>`) so the TUI and CLI share the engine.

## Surface

**CLI** — `yoink doctor` prints a list with severity icons + per-row `fix:` lines, summary count at the bottom. Exits non-zero on any Error-severity finding. `--json` emits a machine-readable array suitable for piping into agent / CI tooling.

**TUI** — capital `D` from any view opens a modal overlay (same shape as the existing drift modal — no new top-level View variant). `r` reruns; ↑↓ / j/k navigates the findings list; right pane shows the selected finding's full detail + fix; Esc closes. Help overlay updated.

## What it checks (12 in this PR)

| Category | Check |
|---|---|
| `secrets` | Age identity loadable for the configured recipients |
| `secrets` | `secrets.age` exists when services reference secrets and `provider: age` is configured |
| `secrets` | `provider: command` binary is on `PATH` (hand-rolled `which`) |
| `secrets` | Keys-dir file modes are 0600 (Unix only) |
| `secrets` | Every `secrets:` / `env_from_secrets:` reference exists in the loaded bundle (typo class) |
| `build` | Bare image without a `build:` block (excluding well-known Hub library names like `postgres`, `redis`) |
| `build` | `build: { dockerfile: <path> }` resolves to an existing file |
| `build` | Laptop docker arch vs each host's arch when ANY service has a `build:` block — the Apple-Silicon-to-amd64 mismatch I personally lost five minutes to, with the literal `extra_args: ["--platform", "linux/amd64"]` fix in the hint |
| `config` | `proxy.email` is set when there's a `domain:` service |
| `config` | `domain:` services have `run.port` |
| `config` | `tls: cert` mode has both cert+key secrets resolvable (per-service or inherited from `proxy.tls.{cert,key}_secret`) |
| `host` | Each configured host's docker is reachable (same probe as `yoink preflight`, captured as findings rather than stderr) |
| `dns` | Every `domain:`-tagged hostname resolves at all (catches "DNS not pointed yet" before Caddy attempts Let's Encrypt validation) |

## What it deliberately doesn't check (yet)

- **DNS resolves to the *right* IP** (not just resolves at all). Held back by the "what's the right IP for this host?" semantic mess — host's `address:` may be a tailnet name, an IP, a DNS name behind a CDN.
- **Host disk space**, **registry credentials reachable**, **build context size**. Useful but more invasive (extra round-trips per host / probe authentication).
- **Cert expiry**, **yoink-itself-outdated**. Out of doctor's lane.

Documented in module docstring + the answer to "do we check everything" in PR review will be "no, here's the gap list."

## Test plan

- [x] 288 lib tests pass (10 new in `doctor::tests` covering pure logic — `arches_compatible`, `canonical_platform`, `is_likely_hub_library`, `check_build_blocks` (clean / warn / hub-library), `check_dockerfile_paths`, `check_provider_command` (present + missing), `which_on_path`).
- [x] Smoke-tested CLI on a postgres-template-shaped config: positive case ("every secret reference resolves") fires correctly.
- [x] Smoke-tested CLI against an unreachable host: error finding fires, exit code is non-zero.
- [x] `yoink doctor --json` emits the expected shape.
- [ ] Manual TUI smoke (will do post-merge or in any reviewer's local checkout).

## Out of scope

- Auto-fix mode — doctor reports, the operator decides. Adding `yoink doctor --fix` is a future PR if there's signal that operators want it.
- Persistent doctor state — current findings are computed on demand. Could cache last-run + show stale-since timestamps in the TUI; not yet needed.

## Why a 🩺 PR

Because every other PR title in this repo is too utilitarian. Don't @ me.