### PR TITLE
docs(pf): clarify auto-mode help + document replica routing

### DIFF
--- a/docs/content/docs/recipes/port-forward.md
+++ b/docs/content/docs/recipes/port-forward.md
@@ -1,6 +1,6 @@
 ---
 title: Port-forward to any service
-weight: 13
+weight: 8
 ---
 
 `yoink pf <service>` opens a tunnel from your laptop to a container port — the same shape `kubectl port-forward` gives you, reusing the SSH connection yoink already has to the host. Two paths under the hood, picked automatically:
@@ -38,9 +38,10 @@ In other words: the security posture and the debugging posture stop fighting. Th
 
 Anything yoink runs:
 
-- **Published** (pgadmin on `127.0.0.1:5050:80`, the operator UI): published path. Fastest.
-- **Caddy-fronted, sealed-network** (api on the `api` network, no `publish:`): sidecar path. ~500 ms cold-start; ~5 MB image pulled once per host.
+- **Published** (pgadmin on `127.0.0.1:5050:80`, the operator UI): published path. ~50 ms cold-start.
+- **Caddy-fronted, sealed-network** (api on the `api` network, no `publish:`): sidecar path. ~1–2 s cold-start (image pull + container start), ~50 ms warm; ~5 MB image pulled once per host.
 - **Multi-network** (web on `web` + `otel`): sidecar joins the first declared network and the operator dials the service's docker DNS alias.
+- **Replicated** (`replicas: 2`): the published path is sticky to one replica (one host port → one container); the sidecar path round-robins across replicas via docker DNS. See [Replicas](#replicas) below for caveats.
 
 ## CLI
 
@@ -83,12 +84,17 @@ Three keys plus a visual indicator on every row whose service has a tunnel open:
 | `o` / `O` | Open the active port-forward URL in the system browser. Works in **any** view; falls back to the most-recently-opened tunnel when the focused row has no forward of its own. |
 | `F` (Shift-F) | Close every active port-forward. Sidecars are force-removed; ssh children killed. The footer band disappears. |
 
-Forwarded service rows show a cyan `↦` prefix on the service cell across the Dashboard, HostDetail, and Services panes — at-a-glance "is this thing tunneled?" without needing to read the footer.
+Forwarded rows show a cyan `↦` prefix on the service cell — at-a-glance "is this thing tunneled?" without needing to read the footer. The marker scope follows how the tunnel was opened:
+
+- **From a Dashboard / HostDetail / ContainerDetail row** — the operator pressed `f` on a specific replica. Only that replica gets the marker. The other replicas of the same service render unmarked, so a `web-1`/`web-2` pair shows which one you're tunneled through.
+- **From the Services pane** or **the CLI** (no row context) — every replica of the service gets the marker. Useful when the operator just cares "is `api` reachable?" rather than "which `api` am I hitting?"
 
 ```
-host          service      container             state    ...
-backtrack-eu-1 ↦ api       api-186bd0cd-0       running  ...
-backtrack-eu-1   web        web-13584766-0       running  ...
+host            service      container             state    ...
+backtrack-eu-1  ↦ web        web-13584766-0       running  ...   ← f pressed here
+backtrack-eu-1    web        web-13584766-1       running  ...
+backtrack-eu-1  ↦ api        api-186bd0cd-0       running  ...   ← yoink pf api on the CLI
+backtrack-eu-1  ↦ api        api-186bd0cd-1       running  ...   ← marked too (CLI = all replicas)
 ```
 
 Sidecars themselves are filtered out of the container lists (their names start with `yoink-pf-`); they exist for the duration of the tunnel and aren't user-facing.
@@ -100,6 +106,23 @@ While any tunnel is open, a one-line footer band stays visible across every pane
 ```
 
 The band is hard to miss on purpose — open tunnels are the kind of thing operators forget about and accidentally leave running between sessions. Yoink's TUI exit (`q` / Ctrl-C) closes every tunnel cleanly: ssh children die synchronously, sidecar containers force-remove via the `auto_remove: true` belt-and-braces.
+
+## Replicas
+
+Services with `replicas: > 1` get one container per replica (`web-13584766-0`, `web-13584766-1`, …). How `pf` reaches them depends on the path:
+
+- **Published path.** `docker-proxy` is bound to a specific host port that ultimately maps to a specific container, so traffic is sticky to one replica for the duration of the tunnel.
+- **Sidecar path.** The sidecar dials the service's docker DNS alias (`socat tcp:web:3000`). Inside docker, that name resolves round-robin across all healthy replicas — so a given TCP connection through the sidecar may land on any one of them. The tunnel is *to a specific sidecar*, but the sidecar's outbound connection is *across the replica set*.
+
+The TUI's `↦` marker reflects which row the operator pressed `f` on — useful as a "this is the tunnel I opened" cue, not a guarantee that "every byte goes to this replica" through the sidecar path.
+
+Flags that influence which replica a connection lands on:
+
+- **`--host <ADDRESS>`** — restricts both the published path and the sidecar's network attachment to replicas on that host. With one replica per host this is enough to pin a tunnel.
+- **`--replica <N>` (0-based)** — currently validates range only (errors if `>= replicas`). Defaults to `0`. Sticky per-replica routing in the sidecar path is follow-up work — it would require the sidecar to dial the target container's IP rather than the service alias.
+- **TUI: select the row first, then press `f`.** Marks the focused replica with `↦`; same routing semantics as the CLI otherwise.
+
+For deterministic single-replica access today: use the published path (`publish:` per replica with distinct host ports), pin via `--host`, or run the service with `replicas: 1`.
 
 ## How it works
 

--- a/yoink/src/main.rs
+++ b/yoink/src/main.rs
@@ -351,12 +351,15 @@ enum Command {
         #[arg(long)]
         host: Option<String>,
     },
-    /// Forward a published container port to the laptop over SSH.
+    /// Forward a container port to the laptop over SSH.
     ///
-    /// Only services with a `publish:` entry are supported — yoink
-    /// reuses the host's existing `docker-proxy` binding and just
-    /// bridges with `ssh -L`. For containers that don't publish
-    /// (api / web behind Caddy) use `yoink shell <service>` instead.
+    /// Auto-mode: when the service has a matching `publish:` entry,
+    /// yoink reuses the host's existing `docker-proxy` binding and
+    /// just bridges with `ssh -L` (~50 ms). When it doesn't (api /
+    /// web behind Caddy), yoink spawns an ephemeral `alpine/socat`
+    /// sidecar on the target's docker network and tunnels through
+    /// that (~2 s warm-start). Either way the operator gets a
+    /// `localhost:N` URL.
     ///
     /// Usage shapes:
     ///   yoink pf pgadmin               # service has 1 publish; LOCAL = OS-assigned
@@ -368,9 +371,10 @@ enum Command {
         service: String,
         /// Either `LOCAL:CONTAINER` or just `CONTAINER` (LOCAL defaults
         /// to the same number as CONTAINER, or use `0:CONTAINER` /
-        /// `--local 0` to ask the OS for a free port). Optional when the
-        /// service has exactly one `publish:` entry — that entry's
-        /// container port is used.
+        /// `--local 0` to ask the OS for a free port). Optional when
+        /// the service has exactly one `publish:` entry (that entry's
+        /// container port is used) or no `publish:` block at all but
+        /// declares `run.port:` (the healthcheck port is used).
         #[arg(value_name = "[LOCAL:]CONTAINER_PORT")]
         port: Option<String>,
         /// Pin to a specific host when the service runs on multiple.


### PR DESCRIPTION
## Summary

- Fix the `yoink pf --help` blurb that still said "only services with a \`publish:\` entry are supported" — auto-fallback to a sidecar landed earlier; the help now describes auto-mode honestly.
- Add a **Replicas** section to the port-forward recipe explaining the routing story: the published path is sticky to one replica, the sidecar path round-robins across replicas via docker DNS. \`--replica <N>\` validates range only today; sticky per-replica routing in the sidecar path is follow-up work.
- Reconcile the \`↦\` marker semantics with the per-replica vs CLI/Services scoping that landed in #29.
- Bump \`port-forward.md\` weight from 13 → 8 (was duplicated with \`ai-agents.md\`).
- Reconcile cold-start time estimates (~50 ms published, ~1–2 s sidecar warm-start).

## Test plan

- [x] \`hugo --minify\` clean (53 pages, 164 ms)
- [x] \`cargo check --bin yoink\` clean