### PR TITLE
feat(run): expose `devices:` for hardware passthrough

### DIFF
--- a/docs/content/docs/guide/security-defaults.md
+++ b/docs/content/docs/guide/security-defaults.md
@@ -17,6 +17,7 @@ Compose's defaults are dev-friendly, not prod-friendly: every container runs wit
 | `pids_limit` | `1024` | bounds the fork-bomb class of exploits | `pids_limit: null` (unlimited), or any positive int |
 | `cpus` | `null` (uncapped) | — | set to `"2"`, `"500m"`, `"1.5"`, etc. — k8s style |
 | `memory` | `null` (uncapped) | — | set to `"512Mi"`, `"1Gi"`, `"512m"`, `"1g"` — k8s + docker styles both accepted |
+| `devices` | `[]` | only the kernel-whitelisted set is visible; host hardware (GPUs, USB hubs, `/dev/fuse`, …) is unreachable | list explicit `--device`-style entries — see [hardware passthrough recipe](/docs/recipes/hardware-passthrough). Narrower than `--privileged` (which yoink doesn't expose at all). |
 
 ## Surgical opt-outs in practice
 
@@ -24,26 +25,38 @@ Compose's defaults are dev-friendly, not prod-friendly: every container runs wit
 # caddy needs to bind :80/:443 — re-add NET_BIND_SERVICE only.
 - name: caddy
   run:
-    cap_drop: [ALL]
-    cap_add:  [NET_BIND_SERVICE]
-    cpus: "0.5"
-    memory: "64Mi"
+    options:
+      cap_drop: [ALL]
+      cap_add:  [NET_BIND_SERVICE]
+      cpus: "0.5"
+      memory: "64Mi"
 
 # pgadmin's image scribbles all over its rootfs at startup — back out
 # of read_only, keep the rest of the hardened defaults.
 - name: pgadmin
   run:
-    read_only: false
-    cpus: "1"
-    memory: "256Mi"
+    options:
+      read_only: false
+      cpus: "1"
+      memory: "256Mi"
 
 # Image with stubborn legacy code that needs root + writable /etc.
 - name: legacy-thing
   run:
-    user: "0:0"
-    read_only: false
-    cap_drop: []
-    security_opt: []
+    options:
+      user: "0:0"
+      read_only: false
+      cap_drop: []
+      security_opt: []
+
+# Hardware passthrough — opt into specific device nodes only,
+# not the whole privileged blast radius. See the recipe for more.
+- name: jellyfin
+  run:
+    options:
+      user: "0:0"        # most media images need root for HW access
+      devices:
+        - /dev/dri       # Intel/AMD VAAPI — read+write+mknod default
 ```
 
 ## Non-root in practice
@@ -65,10 +78,11 @@ The app still needs *somewhere* to write — `/tmp`, sometimes `/run`, occasiona
 
 ```yaml
 run:
-  read_only: true
-  tmpfs:
-    /tmp: "size=64m,mode=1777"
-    /var/cache/app: "size=128m,mode=0755"
+  options:
+    read_only: true
+    tmpfs:
+      /tmp: "size=64m,mode=1777"
+      /var/cache/app: "size=128m,mode=0755"
 ```
 
 ## No host port binds by default — and `yoink pf` keeps that practical

--- a/docs/content/docs/recipes/_index.md
+++ b/docs/content/docs/recipes/_index.md
@@ -13,6 +13,7 @@ Task-oriented how-tos. Each recipe stands alone — pick the one that matches wh
   {{< card link="/docs/recipes/age-in-github-actions" title="AGE secrets in GitHub Actions" subtitle="Generate a CI-only identity, paste into a GitHub secret, deploy. One env var." icon="lightning-bolt" >}}
   {{< card link="/docs/recipes/cloudflare-origin-certs" title="Cloudflare Origin Certificates" subtitle="Skip Let's Encrypt — 15-year cert + origin-pull mTLS that locks your origin to Cloudflare's edge." icon="cloud" >}}
   {{< card link="/docs/recipes/grpc-hosting" title="Hosting gRPC backends" subtitle="`upstream_h2c: true` for native gRPC (Tonic, grpc-go, grpc-java) — covers REST too." icon="switch-horizontal" >}}
+  {{< card link="/docs/recipes/hardware-passthrough" title="Hardware passthrough (`devices:`)" subtitle="GPUs (Jellyfin, Ollama), USB hubs (Zigbee), FUSE, webcams, TPM. Narrower than `--privileged`." icon="chip" >}}
   {{< card link="/docs/recipes/caddy-snippets" title="Caddy snippets cookbook" subtitle="Copy-paste recipes for forward_auth, basic_auth, IP allowlists, headers, redirects, body limits." icon="book-open" >}}
   {{< card link="/docs/recipes/multi-host-redis-storage" title="Multi-host Let's Encrypt with Redis" subtitle="Share ACME state across hosts to avoid Let's Encrypt rate limits." icon="database" >}}
   {{< card link="/docs/recipes/staging-alongside-prod" title="Run staging alongside prod" subtitle="Same hosts, two configs, namespaced services + networks." icon="duplicate" >}}

--- a/docs/content/docs/recipes/hardware-passthrough.md
+++ b/docs/content/docs/recipes/hardware-passthrough.md
@@ -1,0 +1,131 @@
+---
+title: Hardware passthrough (`devices:`)
+weight: 9
+---
+
+Pass host devices into a container — GPUs, USB-attached hubs, FUSE, audio, webcams, TPMs — using the same `<host>[:<container>[:<perms>]]` syntax as docker's `--device` flag, with the rest of yoink's hardened defaults intact. Narrower than `--privileged` (which yoink deliberately doesn't expose): only the listed devices become accessible.
+
+## Shape
+
+```yaml
+services:
+  - name: media
+    image: jellyfin/jellyfin
+    tag: "10.10"
+    run:
+      port: 8096
+      options:
+        devices:
+          - /dev/dri              # all Intel/AMD GPU nodes
+          - /dev/dri/card0:/dev/dri/card0:rw   # explicit perms
+```
+
+Each entry is bind-mounted into the container *and* added to the cgroup `devices.allow` list. Both are required: bind-mount alone hits `EPERM` on `open()` from the cgroup whitelist, allow alone is invisible. Yoink does both in one declaration.
+
+`<perms>` is some combination of `r`, `w`, `m` — defaults to `rwm` when omitted. `m` is `mknod` (creating new device nodes inside the container, almost never needed).
+
+## Common patterns
+
+### GPU transcode (Plex / Jellyfin / Frigate / Ollama)
+
+```yaml
+- name: jellyfin
+  image: jellyfin/jellyfin
+  tag: "10.10"
+  run:
+    port: 8096
+    options:
+      user: "0:0"             # most media images need root for HW access
+      devices:
+        - /dev/dri            # Intel/AMD VAAPI
+        # - /dev/nvidia0      # NVIDIA — see below
+        # - /dev/nvidiactl
+        # - /dev/nvidia-uvm
+```
+
+NVIDIA needs the `nvidia-container-runtime` on the host, plus the nodes above. Ollama / vLLM / whisper-server follow the same pattern.
+
+### USB-attached hub (Zigbee / Z-Wave / serial)
+
+```yaml
+- name: zigbee2mqtt
+  image: koenkk/zigbee2mqtt
+  tag: latest
+  run:
+    options:
+      user: "0:0"
+      devices:
+        - /dev/ttyUSB0:/dev/ttyACM0:rw   # remap if your stick reports a different node
+```
+
+Use `udev` rules on the host to give the device a stable `/dev/serial/by-id/...` path if `/dev/ttyUSB*` reorders across reboots.
+
+### FUSE (e.g. JuiceFS, sshfs, restic mount)
+
+```yaml
+- name: juicefs
+  image: juicedata/mount
+  tag: latest
+  run:
+    options:
+      user: "0:0"
+      cap_add: [SYS_ADMIN]    # mount(2) needs the cap
+      read_only: false        # FUSE userspace daemons write to /var/lib
+      devices:
+        - /dev/fuse
+```
+
+`cap_add: [SYS_ADMIN]` is the price of FUSE — userspace `mount(2)` requires it. The rest of the hardened defaults (no-new-privileges, cap_drop=ALL except SYS_ADMIN, non-root if the daemon supports it) still apply.
+
+### Webcam (Frigate)
+
+```yaml
+- name: frigate
+  image: ghcr.io/blakeblackshear/frigate
+  tag: stable
+  run:
+    options:
+      user: "0:0"
+      devices:
+        - /dev/video0
+        - /dev/dri              # also use VAAPI for hw decode
+```
+
+### TPM / hardware crypto
+
+```yaml
+- name: vault
+  image: hashicorp/vault
+  run:
+    options:
+      cap_add: [IPC_LOCK]
+      devices:
+        - /dev/tpm0:/dev/tpm0:rw
+```
+
+## What `devices:` does NOT do
+
+- **`--device-cgroup-rule`** (raw cgroup rules like `c 81:* rmw`) isn't exposed. If you need a glob over a major number, list each minor explicitly or open an issue with the use case.
+- **`--gpus`** (NVIDIA's high-level runtime selector). Use the explicit `/dev/nvidia*` device list above plus the `nvidia-container-runtime` on the host. The selector flag is a runtime-specific shortcut yoink doesn't pass through.
+- **`--privileged`** is deliberately not exposed at all. If you actually need full privilege (rare — usually means the workload is wrong for a container), run it via `docker run --privileged` outside yoink.
+- **Default-deny narrowing.** `devices:` *adds* explicit accesses; it doesn't tighten the runtime's default device whitelist. On cgroup v2 hosts, the default policy varies — tighten with kernel/runtime config, not yoink.
+
+## Validation
+
+`yoink validate` rejects malformed entries up front so they don't blow up at deploy time:
+
+```sh
+$ yoink validate
+yoink: invalid config: service "media".run.options.devices:
+  invalid device spec "dev/fuse": expected
+  "<host-path>[:<container-path>[:<perms>]]" where paths begin with `/`
+  and `<perms>` is some non-empty combination of `r`, `w`, `m`
+```
+
+Caught: relative paths, empty perms (`...:`), unknown perm chars (e.g. `rwx`), duplicate chars (`rrw`), oversize perms (longer than 3).
+
+## See also
+
+- [Reference: `RunOptions`](/docs/reference/config#runoptions) — every per-service runtime knob.
+- [Secure by default](/docs/guide/security-defaults) — what stays locked down when you opt into a device.
+- Docker's [`--device`](https://docs.docker.com/engine/reference/commandline/run/#device) — the underlying primitive.

--- a/docs/content/docs/reference/config.md
+++ b/docs/content/docs/reference/config.md
@@ -159,6 +159,7 @@ The hardened defaults make new containers prod-safe out of the box. Override per
 | `restart` | string | `unless-stopped` | Docker restart policy. |
 | `user` | string | `"65534:65534"` (nobody) | UID/GID. Default runs non-root. Override with `"0:0"` for images that genuinely need root, or a specific uid:gid (`"1000:1000"`, `"redis"`) when the image has pre-baked file ownership. |
 | `network_aliases` | list of string | `[name]` | Extra DNS names on the attached networks. |
+| `devices` | list of string | `[]` | Host devices to expose. Each entry is `<host-path>[:<container-path>[:<perms>]]` (docker's `--device` syntax). `<perms>` is some combination of `r`, `w`, `m`; defaults to `rwm`. Both bind-mounts the device file and adds it to the cgroup `devices.allow` list. Narrower than `--privileged` — only the listed devices become accessible. Common uses: `/dev/nvidia*` (GPU), `/dev/dri` (Intel/AMD VAAPI), `/dev/ttyUSB*` (USB serial), `/dev/fuse` (with `cap_add: [SYS_ADMIN]`), `/dev/snd` (audio). |
 
 See [Security defaults](/docs/guide/security-defaults) for the full picture.
 

--- a/yoink/src/config.rs
+++ b/yoink/src/config.rs
@@ -795,6 +795,18 @@ pub struct RunOptions {
     /// (systemd-in-containers, s6-overlay, supervisord, …).
     #[serde(default = "default_init")]
     pub init: bool,
+    /// Host devices to expose into the container (docker's `--device`).
+    /// Each entry is `<host-path>[:<container-path>[:<perms>]]`;
+    /// `<perms>` is a combination of `r`, `w`, `m` (defaults to `rwm`).
+    /// Each listed device is both bind-mounted *and* added to the
+    /// cgroup `devices.allow` list — bind alone hits `EPERM` on
+    /// `open()` from the cgroup whitelist. Narrower than
+    /// `--privileged` (deliberately not exposed): only the listed
+    /// devices become accessible. See the [hardware passthrough
+    /// recipe](https://yoink.dev/docs/recipes/hardware-passthrough/)
+    /// for GPU / USB / FUSE / TPM patterns.
+    #[serde(default)]
+    pub devices: Vec<String>,
 }
 
 fn default_cap_drop() -> Vec<String> {
@@ -845,6 +857,7 @@ impl Default for RunOptions {
             restart: None,
             user: default_user(),
             init: default_init(),
+            devices: Vec::new(),
         }
     }
 }
@@ -1281,6 +1294,14 @@ impl Config {
                     "service {:?}.run.port required when healthcheck_path is set",
                     service.name
                 )));
+            }
+            for spec in &service.run.options.devices {
+                if let Err(e) = crate::docker::validate_device_spec(spec) {
+                    return Err(ConfigError::Invalid(format!(
+                        "service {:?}.run.options.devices: {e}",
+                        service.name
+                    )));
+                }
             }
             // depends_on validation (refs + duplicates + self). Cycle
             // detection lives in `topo_sort_services` since it needs
@@ -2027,6 +2048,73 @@ services:
         assert!(opts.read_only);
         assert!(opts.init);
         assert_eq!(opts.pids_limit, Some(1024));
+        assert!(opts.devices.is_empty());
+    }
+
+    #[test]
+    fn devices_validate_rejects_relative_host_path() {
+        let s = r#"
+hosts:
+  - { address: h, user: u }
+services:
+  - name: media
+    image: jellyfin/jellyfin
+    tag: v1
+    run:
+      port: 8096
+      options:
+        devices: ["dev/fuse"]
+"#;
+        let err = Config::parse_str(s).unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("invalid device spec") && msg.contains("dev/fuse"),
+            "expected device-spec rejection, got: {msg}",
+        );
+    }
+
+    #[test]
+    fn devices_validate_rejects_bad_perms() {
+        let s = r#"
+hosts:
+  - { address: h, user: u }
+services:
+  - name: media
+    image: jellyfin/jellyfin
+    tag: v1
+    run:
+      port: 8096
+      options:
+        devices: ["/dev/fuse:/dev/fuse:rwx"]
+"#;
+        let err = Config::parse_str(s).unwrap_err();
+        assert!(err.to_string().contains("invalid device spec"));
+    }
+
+    #[test]
+    fn devices_round_trip_through_yaml() {
+        let s = r#"
+hosts:
+  - { address: h, user: u }
+services:
+  - name: media
+    image: jellyfin/jellyfin
+    tag: v1
+    run:
+      port: 8096
+      options:
+        devices:
+          - /dev/dri
+          - /dev/fuse:/dev/fuse:rwm
+"#;
+        let c = Config::parse_str(s).unwrap();
+        assert_eq!(
+            c.services[0].run.options.devices,
+            vec![
+                "/dev/dri".to_string(),
+                "/dev/fuse:/dev/fuse:rwm".to_string()
+            ],
+        );
     }
 
     #[test]

--- a/yoink/src/docker.rs
+++ b/yoink/src/docker.rs
@@ -48,6 +48,64 @@ pub fn image_registry_host(image: &str) -> Option<&str> {
     (head == "localhost" || head.contains('.') || head.contains(':')).then_some(head)
 }
 
+/// Validate a single `--device` spec without producing the bollard
+/// `DeviceMapping`. Same grammar as [`parse_device`]; used by
+/// `Config::validate()` so malformed entries are caught at config-load
+/// time without dragging bollard's types into `config.rs`.
+pub(crate) fn validate_device_spec(spec: &str) -> Result<(), BuildError> {
+    parse_device(spec).map(|_| ())
+}
+
+/// Parse a single `--device` spec — `<host-path>[:<container-path>[:<perms>]]`,
+/// matching docker's CLI. Defaults: container path == host path; perms `rwm`.
+///
+/// Validates: both paths must begin with `/`; perms (when present) must be
+/// non-empty, drawn from `{r, w, m}`, with no duplicates.
+fn parse_device(spec: &str) -> Result<bollard::models::DeviceMapping, BuildError> {
+    let parts: Vec<&str> = spec.splitn(3, ':').collect();
+    let bad = || BuildError::Device(spec.to_string());
+
+    let host = *parts.first().ok_or_else(bad)?;
+    if host.is_empty() || !host.starts_with('/') {
+        return Err(bad());
+    }
+
+    let container = match parts.get(1).copied() {
+        None => host,
+        Some(c) if c.starts_with('/') => c,
+        _ => return Err(bad()),
+    };
+
+    let perms = match parts.get(2).copied() {
+        None => "rwm",
+        Some(p) => {
+            if p.is_empty() || p.len() > 3 {
+                return Err(bad());
+            }
+            let mut seen = [false; 3];
+            for ch in p.chars() {
+                let idx = match ch {
+                    'r' => 0,
+                    'w' => 1,
+                    'm' => 2,
+                    _ => return Err(bad()),
+                };
+                if seen[idx] {
+                    return Err(bad());
+                }
+                seen[idx] = true;
+            }
+            p
+        }
+    };
+
+    Ok(bollard::models::DeviceMapping {
+        path_on_host: Some(host.to_string()),
+        path_in_container: Some(container.to_string()),
+        cgroup_permissions: Some(perms.to_string()),
+    })
+}
+
 #[derive(Debug, Error)]
 pub enum BuildError {
     #[error("invalid memory value {0:?}: expected like \"512m\", \"512Mi\", or \"1Gi\"")]
@@ -56,6 +114,11 @@ pub enum BuildError {
         "invalid cpus value {0:?}: expected an absolute core count like \"2\", \"1.5\", or \"500m\""
     )]
     Cpus(String),
+    #[error(
+        "invalid device spec {0:?}: expected \"<host-path>[:<container-path>[:<perms>]]\" \
+         with absolute paths and `<perms>` drawn from `r`, `w`, `m`"
+    )]
+    Device(String),
     #[error("unknown restart policy {0:?}: expected one of no|always|unless-stopped|on-failure")]
     RestartPolicy(String),
     #[error(
@@ -217,6 +280,18 @@ fn build_host_config(
     let cap_add = vec_opt(&options.cap_add);
     let security_opt = vec_opt(&options.security_opt);
 
+    let devices = if options.devices.is_empty() {
+        None
+    } else {
+        Some(
+            options
+                .devices
+                .iter()
+                .map(|s| parse_device(s))
+                .collect::<Result<Vec<_>, _>>()?,
+        )
+    };
+
     let mut binds: Vec<String> = Vec::new();
     binds.extend(spec.binds.iter().map(|b| default_bind_to_ro(b)));
     binds.extend(spec.volumes.iter().cloned());
@@ -240,6 +315,7 @@ fn build_host_config(
         tmpfs,
         binds,
         port_bindings,
+        devices,
         restart_policy: Some(RestartPolicy {
             name: Some(restart_policy),
             maximum_retry_count: None,
@@ -536,6 +612,7 @@ pub fn compute_spec_hash(spec: &RunSpec) -> String {
     feed_list(&mut h, "cap_drop", &opts.cap_drop);
     feed_list(&mut h, "cap_add", &opts.cap_add);
     feed_list(&mut h, "security_opt", &opts.security_opt);
+    feed_list(&mut h, "devices", &opts.devices);
     feed(&mut h, "read_only", &[u8::from(opts.read_only)]);
     feed(&mut h, "init", &[u8::from(opts.init)]);
     feed_map(&mut h, "tmpfs", &opts.tmpfs);
@@ -661,6 +738,7 @@ mod tests {
                 restart: None,
                 user: None,
                 init: true,
+                devices: Vec::new(),
             },
             entrypoint: None,
             command: vec![],
@@ -1032,5 +1110,98 @@ mod tests {
         let aliases = yoink_ep.aliases.as_ref().unwrap();
         assert!(aliases.contains(&"app-a-a1b2c3d".to_string()));
         assert!(aliases.contains(&"api".to_string()));
+    }
+
+    #[test]
+    fn parse_device_one_field_defaults_container_path_and_perms() {
+        let d = parse_device("/dev/fuse").unwrap();
+        assert_eq!(d.path_on_host.as_deref(), Some("/dev/fuse"));
+        assert_eq!(d.path_in_container.as_deref(), Some("/dev/fuse"));
+        assert_eq!(d.cgroup_permissions.as_deref(), Some("rwm"));
+    }
+
+    #[test]
+    fn parse_device_two_fields_remaps_container_path() {
+        let d = parse_device("/dev/sdb:/dev/disk").unwrap();
+        assert_eq!(d.path_on_host.as_deref(), Some("/dev/sdb"));
+        assert_eq!(d.path_in_container.as_deref(), Some("/dev/disk"));
+        assert_eq!(d.cgroup_permissions.as_deref(), Some("rwm"));
+    }
+
+    #[test]
+    fn parse_device_three_fields_honors_perms() {
+        let d = parse_device("/dev/null:/dev/null:r").unwrap();
+        assert_eq!(d.cgroup_permissions.as_deref(), Some("r"));
+
+        let d = parse_device("/dev/x:/dev/x:wm").unwrap();
+        assert_eq!(d.cgroup_permissions.as_deref(), Some("wm"));
+    }
+
+    #[test]
+    fn parse_device_rejects_relative_paths() {
+        assert!(matches!(
+            parse_device("dev/fuse"),
+            Err(BuildError::Device(_))
+        ));
+        assert!(matches!(
+            parse_device("/dev/fuse:dev/x"),
+            Err(BuildError::Device(_))
+        ));
+    }
+
+    #[test]
+    fn parse_device_rejects_bad_perms() {
+        // Empty perms (trailing colon).
+        assert!(matches!(
+            parse_device("/dev/fuse:/dev/fuse:"),
+            Err(BuildError::Device(_))
+        ));
+        // Unknown char.
+        assert!(matches!(
+            parse_device("/dev/fuse:/dev/fuse:rwx"),
+            Err(BuildError::Device(_))
+        ));
+        // Duplicates.
+        assert!(matches!(
+            parse_device("/dev/fuse:/dev/fuse:rrw"),
+            Err(BuildError::Device(_))
+        ));
+        // Too long.
+        assert!(matches!(
+            parse_device("/dev/fuse:/dev/fuse:rwmw"),
+            Err(BuildError::Device(_))
+        ));
+    }
+
+    #[test]
+    fn build_host_config_emits_devices_when_set() {
+        let mut spec = sample_spec();
+        spec.options.devices = vec!["/dev/fuse".into(), "/dev/dri:/dev/dri:rw".into()];
+        let host = build_host_config(&spec, HashMap::new()).unwrap();
+        let devices = host.devices.expect("devices should be set");
+        assert_eq!(devices.len(), 2);
+        assert_eq!(devices[0].path_on_host.as_deref(), Some("/dev/fuse"));
+        assert_eq!(devices[0].cgroup_permissions.as_deref(), Some("rwm"));
+        assert_eq!(devices[1].path_in_container.as_deref(), Some("/dev/dri"));
+        assert_eq!(devices[1].cgroup_permissions.as_deref(), Some("rw"));
+    }
+
+    #[test]
+    fn build_host_config_omits_devices_when_empty() {
+        let host = build_host_config(&sample_spec(), HashMap::new()).unwrap();
+        assert!(host.devices.is_none());
+    }
+
+    #[test]
+    fn spec_hash_differs_when_devices_change() {
+        let base = compute_spec_hash(&sample_spec());
+
+        let mut with_dev = sample_spec();
+        with_dev.options.devices = vec!["/dev/fuse".into()];
+        assert_ne!(base, compute_spec_hash(&with_dev));
+
+        let mut other_dev = sample_spec();
+        other_dev.options.devices = vec!["/dev/dri".into()];
+        assert_ne!(compute_spec_hash(&with_dev), compute_spec_hash(&other_dev));
     }
 }


### PR DESCRIPTION
## Summary

Adds `run.options.devices:` so services can declare host-device passthrough — same shape as docker's `--device <host>[:<container>[:<perms>]]`. Narrower than `--privileged` (deliberately not exposed): only the listed devices become accessible; `cap_drop`, `no-new-privileges`, `read_only`, the rest of yoink's hardened defaults stay intact.

## Why

Real use cases in yoink's small-fleet niche, all of which today fall back to bare `docker run` outside yoink's drift detection / sealed-secrets / proxy story:

| Use case | Devices | Other RunOptions |
|---|---|---|
| Self-hosted Plex/Jellyfin with hw transcode | `/dev/dri` or `/dev/nvidia*` | none |
| GPU inference (Ollama, vLLM, whisper) | `/dev/nvidia*`, `/dev/nvidiactl` | nvidia-runtime |
| Home-lab Zigbee/ZWave hub | `/dev/ttyUSB0`, `/dev/ttyACM0` | none |
| Webcam-driven (frigate) | `/dev/video0` | none |
| FUSE mount (e.g. JuiceFS, restic recovery) | `/dev/fuse` | `cap_add: [SYS_ADMIN]` |
| TPM / hardware crypto | `/dev/tpm0` | varies |

## What changed

- **`yoink/src/config.rs`** — new `RunOptions.devices: Vec<String>`, default empty. Doc-comment explains why both bind + cgroup whitelist are required and lists the common use cases.
- **`yoink/src/docker.rs`** —
  - `parse_device(spec) -> Result<DeviceMapping, BuildError>` validates the docker-CLI shape: paths must start with `/`; perms (when present) non-empty, drawn from `{r, w, m}`, no duplicates.
  - `BuildError::Device(String)` variant for bad specs.
  - `build_host_config` populates `HostConfig.devices` (bollard's `DeviceMapping { path_on_host, path_in_container, cgroup_permissions }`).
  - `compute_spec_hash` folds the device list in, so changing it rolls the container.
- **`docs/content/docs/reference/config.md`** — new row in the RunOptions table.

## Backward compatibility

- Default is empty; existing services keep current behavior unchanged.
- No new top-level fields, no flag changes, no migration.
- `parse_device` is internal; the public surface is YAML config + docker's already-documented `--device` syntax.

## Test plan

- [x] `cargo test --workspace` — 376 pass (8 new device-related tests in `docker.rs`)
  - parser: 1-field / 2-field / 3-field success paths
  - parser: rejects relative paths, empty perms, unknown chars, duplicates, oversize perms
  - host-config: emits `devices` when set, `None` when empty
  - spec-hash: changes when device list changes
- [x] `cargo build --release`
- [x] `cargo clippy --all-targets` — 0 new warnings in touched files
- [ ] Live verify on a Hetzner box: `services: [- name: x, image: alpine, run: { options: { devices: ["/dev/null:/dev/x:r"] }, ... }]`, `yoink up`, `docker exec x ls -l /dev/x` → device node present, perms enforced (operator).

## Files

- `yoink/src/config.rs` — field + doc + Default impl
- `yoink/src/docker.rs` — parser, BuildError variant, HostConfig mapping, spec-hash, 8 unit tests
- `docs/content/docs/reference/config.md` — reference table row