### PR TITLE
feat(config): expand ${VAR} env references in YAML at load time

### DIFF
--- a/docs/content/docs/reference/config.md
+++ b/docs/content/docs/reference/config.md
@@ -283,3 +283,26 @@ services:
     image: ghcr.io/you/api
     # ...
 ```
+
+## Environment-variable substitution
+
+Any `${VAR}` reference in `yoink.yaml` (or in a fragment loaded via `include:`) is substituted against the process environment at config-load time, before YAML parsing.
+
+```yaml
+hosts:
+  - address: ${HOST_IP}
+    user: root
+services:
+  - name: hello
+    domain:
+      - ${HOST_IP}.nip.io
+```
+
+Run with `HOST_IP=1.2.3.4 yoink up …`. Useful for throwaway-host recipes, ephemeral preview environments, and any other case where one of the values isn't known until invocation time.
+
+Rules:
+
+- Only the unambiguous `${NAME}` form is recognized. Bare `$NAME` and lone `$` characters pass through unchanged so values containing literal dollar signs are unaffected.
+- `NAME` must match `[A-Za-z_][A-Za-z0-9_]*`. Anything else (including `${HOST-IP}`, `${1BAD}`, or unterminated `${`) errors with a snippet pointing at the bad reference.
+- Missing variables are a hard error rather than silent empty substitution — a quietly-empty `address:` produces baffling failures further down the deploy.
+- For long-lived secrets, prefer `secrets:` (sealed or `provider: command`) over passing values via env. The substitution path is intended for routing parameters (host IPs, hostnames, port numbers), not credentials.

--- a/yoink/src/config.rs
+++ b/yoink/src/config.rs
@@ -35,6 +35,12 @@ pub enum ConfigError {
         #[source]
         source: glob::GlobError,
     },
+    #[error("env var ${{{name}}} referenced in config is not set")]
+    EnvVarUnset { name: String },
+    #[error(
+        "malformed env var reference near {context:?} — expected `${{NAME}}` with NAME = [A-Za-z_][A-Za-z0-9_]*"
+    )]
+    EnvVarSyntax { context: String },
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
@@ -1138,6 +1144,72 @@ fn local_socket_exists() -> bool {
     false
 }
 
+/// Substitute `${NAME}` references in `text` against process env vars.
+/// Applied to YAML text *before* deserialization, so any string field
+/// in the config (host addresses, service domains, env values, …) can
+/// reference an env var. Only the `${NAME}` form is recognized — bare
+/// `$NAME`, `$$`, etc. pass through unchanged so YAML strings that
+/// happen to contain a literal dollar are unaffected.
+///
+/// Errors:
+/// - `EnvVarUnset` if `${NAME}` references a var not present in the
+///   environment. (No silent empty substitution — a missing var almost
+///   always indicates a misconfigured deploy, and a quietly-empty
+///   `address:` produces baffling failures downstream.)
+/// - `EnvVarSyntax` if a `${...}` block contains characters outside
+///   `[A-Za-z_][A-Za-z0-9_]*` or is unterminated.
+fn expand_env_vars(text: &str) -> Result<String, ConfigError> {
+    expand_env_vars_with(text, |name| std::env::var(name).ok())
+}
+
+fn expand_env_vars_with<F>(text: &str, lookup: F) -> Result<String, ConfigError>
+where
+    F: Fn(&str) -> Option<String>,
+{
+    // Short-circuit the common case (no `$` anywhere in the YAML) so
+    // load_from_path doesn't pay an allocation on every invocation.
+    if !text.contains('$') {
+        return Ok(text.to_string());
+    }
+    let mut out = String::with_capacity(text.len());
+    let mut rest = text;
+    while let Some(dollar) = rest.find('$') {
+        out.push_str(&rest[..dollar]);
+        let after_dollar = &rest[dollar + 1..];
+        if !after_dollar.starts_with('{') {
+            out.push('$');
+            rest = after_dollar;
+            continue;
+        }
+        let name_and_tail = &after_dollar[1..];
+        let Some(close) = name_and_tail.find('}') else {
+            let snippet_end = (dollar + 16).min(rest.len());
+            return Err(ConfigError::EnvVarSyntax {
+                context: rest[dollar..snippet_end].to_string(),
+            });
+        };
+        let name = &name_and_tail[..close];
+        let valid_name = !name.is_empty()
+            && name
+                .bytes()
+                .next()
+                .is_some_and(|b| b.is_ascii_alphabetic() || b == b'_')
+            && name.bytes().all(|b| b.is_ascii_alphanumeric() || b == b'_');
+        if !valid_name {
+            return Err(ConfigError::EnvVarSyntax {
+                context: rest[dollar..=dollar + 2 + close].to_string(),
+            });
+        }
+        let value = lookup(name).ok_or_else(|| ConfigError::EnvVarUnset {
+            name: name.to_string(),
+        })?;
+        out.push_str(&value);
+        rest = &name_and_tail[close + 1..];
+    }
+    out.push_str(rest);
+    Ok(out)
+}
+
 impl Config {
     /// Walk `self.services` filtered by an optional name list. `None`
     /// returns every service in topo order; `Some(&[…])` keeps only
@@ -1199,6 +1271,7 @@ impl Config {
             path: path.display().to_string(),
             source,
         })?;
+        let text = expand_env_vars(&text)?;
         // Parse the main file *without* validation — fragments contribute
         // services + hooks, so duplicate / dangling-reference checks only
         // make sense after the merge.
@@ -1229,6 +1302,7 @@ impl Config {
             path: path.display().to_string(),
             source,
         })?;
+        let text = expand_env_vars(&text)?;
         let mut cfg: Self = yaml_serde::from_str(&text)?;
         cfg.config_dir = path.parent().map(std::path::Path::to_path_buf);
         cfg.merge_includes()?;
@@ -1345,6 +1419,7 @@ impl Config {
                 path: path.display().to_string(),
                 source,
             })?;
+            let text = expand_env_vars(&text)?;
             let fragment: ConfigFragment = yaml_serde::from_str(&text)?;
             self.services.extend(fragment.services);
             self.hooks.pre_deploy.extend(fragment.hooks.pre_deploy);
@@ -1727,6 +1802,70 @@ fn validate_service_name(name: &str) -> Result<(), ConfigError> {
 mod tests {
     use super::*;
     use pretty_assertions::assert_eq;
+
+    fn lookup<'a>(pairs: &'a [(&'a str, &'a str)]) -> impl Fn(&str) -> Option<String> + 'a {
+        move |name| {
+            pairs.iter().find_map(|(k, v)| {
+                if *k == name {
+                    Some((*v).to_string())
+                } else {
+                    None
+                }
+            })
+        }
+    }
+
+    #[test]
+    fn env_expansion_substitutes_braced_var() {
+        let out =
+            expand_env_vars_with("address: ${HOST_IP}", lookup(&[("HOST_IP", "1.2.3.4")])).unwrap();
+        assert_eq!(out, "address: 1.2.3.4");
+    }
+
+    #[test]
+    fn env_expansion_handles_multiple_and_concatenation() {
+        let out = expand_env_vars_with(
+            "  - ${HOST_IP}.nip.io\n  - ${OTHER}",
+            lookup(&[("HOST_IP", "9.9.9.9"), ("OTHER", "x")]),
+        )
+        .unwrap();
+        assert_eq!(out, "  - 9.9.9.9.nip.io\n  - x");
+    }
+
+    #[test]
+    fn env_expansion_passes_through_bare_dollar_and_no_braces() {
+        // `$HOST_IP` (no braces) and `$$` are left alone — only the
+        // unambiguous `${NAME}` form expands.
+        let out =
+            expand_env_vars_with("price: $5; raw: $HOST_IP", lookup(&[("HOST_IP", "x")])).unwrap();
+        assert_eq!(out, "price: $5; raw: $HOST_IP");
+    }
+
+    #[test]
+    fn env_expansion_unset_var_errors() {
+        let err = expand_env_vars_with("addr: ${NOPE}", lookup(&[])).unwrap_err();
+        assert!(matches!(err, ConfigError::EnvVarUnset { ref name } if name == "NOPE"));
+    }
+
+    #[test]
+    fn env_expansion_unterminated_brace_errors() {
+        let err = expand_env_vars_with("addr: ${HOST", lookup(&[])).unwrap_err();
+        assert!(matches!(err, ConfigError::EnvVarSyntax { .. }));
+    }
+
+    #[test]
+    fn env_expansion_invalid_name_errors() {
+        let err = expand_env_vars_with("x: ${1BAD}", lookup(&[("1BAD", "v")])).unwrap_err();
+        assert!(matches!(err, ConfigError::EnvVarSyntax { .. }));
+        let err = expand_env_vars_with("x: ${HOST-IP}", lookup(&[])).unwrap_err();
+        assert!(matches!(err, ConfigError::EnvVarSyntax { .. }));
+    }
+
+    #[test]
+    fn env_expansion_preserves_utf8() {
+        let out = expand_env_vars_with("# tëst — ${V}", lookup(&[("V", "✓")])).unwrap();
+        assert_eq!(out, "# tëst — ✓");
+    }
 
     fn minimal() -> &'static str {
         r#"


### PR DESCRIPTION
## Summary

Pre-process YAML text with `\${NAME}` substitution (process env → expanded string) before deserialization. Applied in both `load_from_path*` and inside `merge_includes` so fragments under `include:` get the same treatment.

Lets a single config template parameterize over per-deploy values without an upstream `envsubst` step — e.g. a scratch/throwaway-host config can declare:

\`\`\`yaml
hosts:
  - address: \${HOST_IP}
    user: root
services:
  - name: hello
    domain:
      - \${HOST_IP}.nip.io
    # ...
\`\`\`

…and be invoked with `HOST_IP=1.2.3.4 yoink up --config yoink.scratch.yaml`.

Design choices:
- Only the unambiguous `\${NAME}` form is recognized. Bare `\$NAME` or a literal `\$5` passes through unchanged so YAML strings containing a dollar are unaffected.
- Missing vars are a hard error (`EnvVarUnset`) rather than silent empty substitution — a quietly-empty `address:` produces baffling downstream failures.
- Malformed references (unterminated `\${`, invalid name characters) error out (`EnvVarSyntax`) with a snippet.
- `expand_env_vars_with(text, lookup)` is factored out for unit testing without touching process env (`std::env::set_var` is unsafe in Rust 2024).

No new dependencies; ~60 lines of substitution + 7 unit tests.

## Test plan
- [x] \`cargo test --workspace\` — 429 passed, no regressions
- [x] \`cargo fmt --all -- --check\` — clean
- [x] \`cargo clippy --workspace --all-targets\` — no new lints introduced (the existing pedantic backlog is unchanged)
- [ ] Smoke-tested end-to-end against a real config in a follow-up downstream change.