### PR TITLE
fix(proxy): drop dead `@yoink_tls_off` marker that broke `tls: off` deploys

### DIFF
--- a/yoink/src/proxy/caddy.rs
+++ b/yoink/src/proxy/caddy.rs
@@ -630,15 +630,11 @@ fn render_route(svc: &ServiceConfig, containers: &[String], tls_active: bool) ->
         matchers.insert("path".into(), json!([prefix]));
     }
 
-    let mut route = json!({
+    let route = json!({
         "match": [Value::Object(matchers)],
         "handle": handle,
         "terminal": true,
     });
-
-    if matches!(svc.tls, TlsMode::Off) {
-        route["@yoink_tls_off"] = json!(true);
-    }
 
     Ok(route)
 }


### PR DESCRIPTION
## Summary

`render_route` was annotating routes with `route["@yoink_tls_off"] = true` when a service used `tls: off`, but **no consumer ever read it**. The HSTS-skip logic that was presumably the intended consumer (the test name `hsts_skipped_for_tls_off` hints at it) keys off the `tls_active` flag directly, not the marker.

Caddy's admin API rejects any config containing unknown JSON fields:
```
loading config: loading new config: loading http app module:
decoding module config: http: json: unknown field "@yoink_tls_off"
```

So **any deploy of a `tls: off` service fails at the "push Caddy config" step with `400 Bad Request`**. Trivial to reproduce — declare `tls: off` on a service and run `yoink up`. Surfaced while smoke-testing a fresh Hetzner-cx23 recipe.

## Behavior change

Routes for `tls: off` services are no longer annotated. Caddy accepts the config; HSTS still correctly skipped (the existing `tls_active` gate already covers it).

## Test plan
- [x] `cargo test --workspace` — 433 passed (existing `hsts_skipped_for_tls_off` still covers the behavior)
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy --workspace --all-targets` — no new lints
- [x] Live smoke against a real Caddy admin API: `yoink up` against a `tls: off` service now succeeds (config push 200, route serves on `:80`)