### PR TITLE
feat(config): support `${VAR:-default}` fallback in env-var substitution

### DIFF
--- a/docs/content/docs/reference/config.md
+++ b/docs/content/docs/reference/config.md
@@ -305,4 +305,5 @@ Rules:
 - Only the unambiguous `${NAME}` form is recognized. Bare `$NAME` and lone `$` characters pass through unchanged so values containing literal dollar signs are unaffected.
 - `NAME` must match `[A-Za-z_][A-Za-z0-9_]*`. Anything else (including `${HOST-IP}`, `${1BAD}`, or unterminated `${`) errors with a snippet pointing at the bad reference.
 - Missing variables are a hard error rather than silent empty substitution — a quietly-empty `address:` produces baffling failures further down the deploy.
+- The POSIX `${NAME:-default}` form supplies a fallback when `NAME` is unset. Useful for commands that parse the full config but don't actually use the value (e.g. `yoink secrets seal` against a config whose hosts/domains reference `${HOST_IP}`). Set the var explicitly when you do mean to use it.
 - For long-lived secrets, prefer `secrets:` (sealed or `provider: command`) over passing values via env. The substitution path is intended for routing parameters (host IPs, hostnames, port numbers), not credentials.

--- a/yoink/src/config.rs
+++ b/yoink/src/config.rs
@@ -1188,7 +1188,16 @@ where
                 context: rest[dollar..snippet_end].to_string(),
             });
         };
-        let name = &name_and_tail[..close];
+        let inner = &name_and_tail[..close];
+        // `${NAME}` or `${NAME:-default}`. The default form mirrors POSIX
+        // shell `:-` (substitute when the var is unset). Useful for
+        // commands that don't actually need the value but still parse
+        // the full config (e.g. `yoink secrets seal` against a config
+        // whose hosts/domains reference `${HOST_IP}`).
+        let (name, default_value) = match inner.split_once(":-") {
+            Some((n, d)) => (n, Some(d)),
+            None => (inner, None),
+        };
         let valid_name = !name.is_empty()
             && name
                 .bytes()
@@ -1200,9 +1209,15 @@ where
                 context: rest[dollar..=dollar + 2 + close].to_string(),
             });
         }
-        let value = lookup(name).ok_or_else(|| ConfigError::EnvVarUnset {
-            name: name.to_string(),
-        })?;
+        let value = match (lookup(name), default_value) {
+            (Some(v), _) => v,
+            (None, Some(d)) => d.to_string(),
+            (None, None) => {
+                return Err(ConfigError::EnvVarUnset {
+                    name: name.to_string(),
+                });
+            }
+        };
         out.push_str(&value);
         rest = &name_and_tail[close + 1..];
     }
@@ -1845,6 +1860,39 @@ mod tests {
     fn env_expansion_unset_var_errors() {
         let err = expand_env_vars_with("addr: ${NOPE}", lookup(&[])).unwrap_err();
         assert!(matches!(err, ConfigError::EnvVarUnset { ref name } if name == "NOPE"));
+    }
+
+    #[test]
+    fn env_expansion_default_used_when_var_unset() {
+        let out = expand_env_vars_with("addr: ${NOPE:-fallback}", lookup(&[])).unwrap();
+        assert_eq!(out, "addr: fallback");
+    }
+
+    #[test]
+    fn env_expansion_default_ignored_when_var_set() {
+        let out = expand_env_vars_with(
+            "addr: ${HOST_IP:-fallback}",
+            lookup(&[("HOST_IP", "1.2.3.4")]),
+        )
+        .unwrap();
+        assert_eq!(out, "addr: 1.2.3.4");
+    }
+
+    #[test]
+    fn env_expansion_default_can_be_empty() {
+        // POSIX shell `${VAR:-}` substitutes empty when unset.
+        let out = expand_env_vars_with("addr: ${NOPE:-}", lookup(&[])).unwrap();
+        assert_eq!(out, "addr: ");
+    }
+
+    #[test]
+    fn env_expansion_default_value_is_taken_verbatim() {
+        // Default values can contain colons, slashes, dots — anything
+        // shell-shaped except the closing `}`. Operators use this for
+        // hostnames like `${HOST:-localhost:8080}`.
+        let out = expand_env_vars_with("url: ${BASE_URL:-http://localhost:8080/api}", lookup(&[]))
+            .unwrap();
+        assert_eq!(out, "url: http://localhost:8080/api");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

POSIX-shell-style default-value form alongside the existing \`\${VAR}\`. When \`VAR\` is set, behavior is unchanged. When unset, the literal text after \`:-\` is substituted instead of erroring with \`EnvVarUnset\`.

\`\`\`yaml
hosts:
  - address: \${HOST_IP:-placeholder}
    user: root
\`\`\`

\`HOST_IP=1.2.3.4 yoink up\` → \`address: 1.2.3.4\`. Bare \`yoink secrets seal …\` (no env set) → \`address: placeholder\`.

## Motivating case

Commands that parse the full config but don't actually use the substituted value — \`yoink secrets seal\`, \`yoink secrets edit\`, \`yoink secrets show\`, \`yoink validate\` against a config whose hosts/domains reference \`\${HOST_IP}\`. Operators previously had to do \`HOST_IP=placeholder yoink secrets seal …\`. With \`\${HOST_IP:-x}\` the placeholder lives in the file and the command just works.

## Behavior

- \`\${VAR}\` — unchanged: \`Some(value)\` substituted, \`None\` is a hard error.
- \`\${VAR:-default}\` — \`Some(value)\` substituted; on \`None\`, \`default\` is substituted instead.
- \`\${VAR:-}\` — empty default is allowed (matches POSIX).
- The default is taken verbatim through to the closing \`}\` — colons, slashes, dots, the \`http://\` prefix, etc. all work (e.g. \`\${BASE_URL:-http://localhost:8080/api}\`).
- Default-only inside the brace pair; bare \`\$NAME\` and lone \`\$\` still pass through unchanged.

Opting into a default is explicit at the call site, so unset \`\${NAME}\` (no \`:-\`) still fails loudly when the operator meant for the var to be set.

## Test plan
- [x] \`cargo test --workspace\` — 437 passed (5 new tests cover happy path, var-set wins over default, empty default, default with shell-shaped characters, original \`\${NAME}\` unchanged)
- [x] \`cargo fmt --all -- --check\` — clean
- [x] \`cargo clippy --workspace --all-targets\` — no new lints
- [x] Smoke: \`yoink secrets seal --in -\` against a real config with \`\${HOST_IP:-placeholder}\` references now succeeds without setting any env var.