### PR TITLE
feat(secrets): `yoink secrets ssh-key generate --seal-as <NAME>`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -134,7 +134,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -145,7 +145,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -283,6 +283,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "base16ct"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
+
+[[package]]
 name = "base64"
 version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -293,6 +299,12 @@ name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "base64ct"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "basic-toml"
@@ -615,6 +627,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-oid"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
 name = "convert_case"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -720,6 +738,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-bigint"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
+dependencies = [
+ "generic-array",
+ "rand_core 0.6.4",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -748,6 +778,7 @@ dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
  "curve25519-dalek-derive",
+ "digest",
  "fiat-crypto",
  "rustc_version",
  "subtle",
@@ -806,6 +837,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5729f5117e208430e437df2f4843f5e5952997175992d1414f94c57d61e270b4"
 
 [[package]]
+name = "der"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
+dependencies = [
+ "const-oid",
+ "zeroize",
+]
+
+[[package]]
 name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -850,6 +891,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
+ "const-oid",
  "crypto-common",
  "subtle",
 ]
@@ -892,10 +934,64 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
+name = "ecdsa"
+version = "0.16.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
+dependencies = [
+ "der",
+ "digest",
+ "elliptic-curve",
+ "rfc6979",
+ "signature",
+ "spki",
+]
+
+[[package]]
+name = "ed25519"
+version = "2.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
+dependencies = [
+ "signature",
+]
+
+[[package]]
+name = "ed25519-dalek"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
+dependencies = [
+ "curve25519-dalek",
+ "ed25519",
+ "sha2",
+ "subtle",
+]
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
+name = "elliptic-curve"
+version = "0.13.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
+dependencies = [
+ "base16ct",
+ "crypto-bigint",
+ "digest",
+ "ff",
+ "generic-array",
+ "group",
+ "pkcs8",
+ "rand_core 0.6.4",
+ "sec1",
+ "subtle",
+ "zeroize",
+]
 
 [[package]]
 name = "encode_unicode"
@@ -916,7 +1012,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -963,6 +1059,16 @@ dependencies = [
  "portable-atomic",
  "rand 0.10.1",
  "web-time",
+]
+
+[[package]]
+name = "ff"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
+dependencies = [
+ "rand_core 0.6.4",
+ "subtle",
 ]
 
 [[package]]
@@ -1197,6 +1303,7 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+ "zeroize",
 ]
 
 [[package]]
@@ -1245,6 +1352,17 @@ name = "glob"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
+name = "group"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
+dependencies = [
+ "ff",
+ "rand_core 0.6.4",
+ "subtle",
+]
 
 [[package]]
 name = "h2"
@@ -1888,6 +2006,9 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+dependencies = [
+ "spin",
+]
 
 [[package]]
 name = "leb128fmt"
@@ -1900,6 +2021,12 @@ name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+
+[[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libredox"
@@ -2135,6 +2262,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint-dig"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e661dda6640fad38e827a6d4a310ff4763082116fe217f279885c97f511bb0b7"
+dependencies = [
+ "lazy_static",
+ "libm",
+ "num-integer",
+ "num-iter",
+ "num-traits",
+ "rand 0.8.6",
+ "smallvec",
+ "zeroize",
+]
+
+[[package]]
 name = "num-complex"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2198,6 +2341,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -2254,6 +2398,44 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7bb71e1b3fa6ca1c61f383464aaf2bb0e2f8e772a1f01d486832464de363b951"
 dependencies = [
  "num-traits",
+]
+
+[[package]]
+name = "p256"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "sha2",
+]
+
+[[package]]
+name = "p384"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe42f1670a52a47d448f14b6a5c61dd78fce51856e68edaa38f7ae3a46b8d6b6"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "sha2",
+]
+
+[[package]]
+name = "p521"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fc9e2161f1f215afdfce23677034ae137bbd45016a880c2eb3ba8eb95f085b2"
+dependencies = [
+ "base16ct",
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "rand_core 0.6.4",
+ "sha2",
 ]
 
 [[package]]
@@ -2323,6 +2505,15 @@ checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
 dependencies = [
  "digest",
  "hmac",
+]
+
+[[package]]
+name = "pem-rfc7468"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
+dependencies = [
+ "base64ct",
 ]
 
 [[package]]
@@ -2453,6 +2644,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
+name = "pkcs1"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
+dependencies = [
+ "der",
+ "pkcs8",
+ "spki",
+]
+
+[[package]]
+name = "pkcs8"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+dependencies = [
+ "der",
+ "spki",
+]
+
+[[package]]
 name = "plain"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2517,6 +2729,15 @@ checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "primeorder"
+version = "0.13.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
+dependencies = [
+ "elliptic-curve",
 ]
 
 [[package]]
@@ -2949,6 +3170,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rfc6979"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
+dependencies = [
+ "hmac",
+ "subtle",
+]
+
+[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2960,6 +3191,27 @@ dependencies = [
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rsa"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
+dependencies = [
+ "const-oid",
+ "digest",
+ "num-bigint-dig",
+ "num-integer",
+ "num-traits",
+ "pkcs1",
+ "pkcs8",
+ "rand_core 0.6.4",
+ "sha2",
+ "signature",
+ "spki",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -3040,7 +3292,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3169,6 +3421,20 @@ dependencies = [
  "pbkdf2",
  "salsa20",
  "sha2",
+]
+
+[[package]]
+name = "sec1"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
+dependencies = [
+ "base16ct",
+ "der",
+ "generic-array",
+ "pkcs8",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -3385,6 +3651,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "signature"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+dependencies = [
+ "digest",
+ "rand_core 0.6.4",
+]
+
+[[package]]
 name = "simd-adler32"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3427,7 +3703,65 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+
+[[package]]
+name = "spki"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
+dependencies = [
+ "base64ct",
+ "der",
+]
+
+[[package]]
+name = "ssh-cipher"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caac132742f0d33c3af65bfcde7f6aa8f62f0e991d80db99149eb9d44708784f"
+dependencies = [
+ "cipher",
+ "ssh-encoding",
+]
+
+[[package]]
+name = "ssh-encoding"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb9242b9ef4108a78e8cd1a2c98e193ef372437f8c22be363075233321dd4a15"
+dependencies = [
+ "base64ct",
+ "pem-rfc7468",
+ "sha2",
+]
+
+[[package]]
+name = "ssh-key"
+version = "0.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b86f5297f0f04d08cabaa0f6bff7cb6aec4d9c3b49d87990d63da9d9156a8c3"
+dependencies = [
+ "ed25519-dalek",
+ "p256",
+ "p384",
+ "p521",
+ "rand_core 0.6.4",
+ "rsa",
+ "sec1",
+ "sha2",
+ "signature",
+ "ssh-cipher",
+ "ssh-encoding",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -3584,7 +3918,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4484,7 +4818,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4886,6 +5220,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
+ "ssh-key",
  "tabled",
  "tar",
  "tempfile",

--- a/yoink/Cargo.toml
+++ b/yoink/Cargo.toml
@@ -34,6 +34,7 @@ flate2 = "1"
 glob = "0.3"
 humantime = "2"
 humantime-serde = "1"
+ssh-key = { version = "0.6", features = ["ed25519"] }
 indicatif = "0.18"
 minijinja = { version = "2", default-features = false, features = ["builtins", "serde"] }
 ratatui = "0.30"

--- a/yoink/src/main.rs
+++ b/yoink/src/main.rs
@@ -764,6 +764,50 @@ enum SecretsAction {
     /// old recipient and run `yoink secrets edit` (just save without
     /// changes) to re-seal under the new recipients only.
     Rotate,
+    /// Manage SSH keypairs used by yoink itself (e.g. host
+    /// `ssh_key_secret:` references). Subcommands operate on
+    /// already-sealed bundles, so the private half never touches disk
+    /// in plaintext.
+    SshKey {
+        #[command(subcommand)]
+        action: SshKeyAction,
+    },
+}
+
+#[derive(clap::Subcommand)]
+enum SshKeyAction {
+    /// Generate a fresh ed25519 SSH keypair, seal the private half
+    /// into the configured `secrets.age` under `--seal-as <NAME>`, and
+    /// print the OpenSSH-format public key to stdout (one line, ready
+    /// to pipe into `hcloud ssh-key create --public-key-from-file -`,
+    /// `gh ssh-key add`, your provider's SSH-key form, etc.).
+    ///
+    /// The private half is generated in memory and committed straight
+    /// into the sealed bundle — no plaintext PEM ever lands in /tmp,
+    /// no `shred` cleanup needed. Existing keys in the bundle are
+    /// preserved (same merge logic as `yoink secrets edit`).
+    Generate {
+        /// Name to seal the private key under. Becomes the secret key
+        /// referenced by `hosts[].ssh_key_secret:` (or any other yoink
+        /// surface that resolves a sealed value by name).
+        #[arg(long = "seal-as", value_name = "NAME")]
+        seal_as: String,
+        /// Optional comment baked into the OpenSSH key header. Mirrors
+        /// `ssh-keygen -C`. Default: empty.
+        #[arg(long, value_name = "TEXT")]
+        comment: Option<String>,
+    },
+    /// Print the OpenSSH-format public key derived from a sealed SSH
+    /// private key, one line on stdout. Useful for piping into provider
+    /// SSH-key-upload commands without re-extracting the public half:
+    ///
+    ///   hcloud ssh-key create --name yoink-scratch \
+    ///     --public-key-from-file <(yoink secrets ssh-key public --name DEPLOY_SSH_KEY)
+    Public {
+        /// Name of the sealed SSH private key to derive the public from.
+        #[arg(long, value_name = "NAME")]
+        name: String,
+    },
 }
 
 #[derive(clap::Subcommand)]
@@ -3578,7 +3622,123 @@ fn cmd_secrets(config: &Config, action: SecretsAction) -> Result<()> {
         SecretsAction::Show { reveal } => cmd_secrets_show(config, reveal),
         SecretsAction::Seal { r#in, out } => cmd_secrets_seal(config, r#in.as_deref(), out),
         SecretsAction::Rotate => cmd_secrets_rotate(config),
+        SecretsAction::SshKey { action } => match action {
+            SshKeyAction::Generate { seal_as, comment } => {
+                cmd_secrets_ssh_key_generate(config, &seal_as, comment.as_deref())
+            }
+            SshKeyAction::Public { name } => cmd_secrets_ssh_key_public(config, &name),
+        },
     }
+}
+
+fn cmd_secrets_ssh_key_generate(
+    config: &Config,
+    seal_as: &str,
+    comment: Option<&str>,
+) -> Result<()> {
+    use ssh_key::{Algorithm, LineEnding, PrivateKey, rand_core::OsRng};
+    use yoink::sealed;
+
+    if seal_as.is_empty()
+        || seal_as
+            .bytes()
+            .next()
+            .is_none_or(|b| !(b.is_ascii_alphabetic() || b == b'_'))
+        || !seal_as
+            .bytes()
+            .all(|b| b.is_ascii_alphanumeric() || b == b'_')
+    {
+        return Err(anyhow::anyhow!(
+            "--seal-as {seal_as:?} is not a valid secret name (must match [A-Za-z_][A-Za-z0-9_]*)"
+        ));
+    }
+
+    let (file_override, recipients) = expect_age_block(config)?;
+    let target = sealed::resolve_sealed_path(config, file_override.as_deref())?;
+
+    // ed25519 keypair, in memory only.
+    let mut rng = OsRng;
+    let key =
+        PrivateKey::random(&mut rng, Algorithm::Ed25519).context("generate ed25519 keypair")?;
+    let key = if let Some(c) = comment {
+        let mut k = key;
+        k.set_comment(c);
+        k
+    } else {
+        key
+    };
+    let priv_pem = key
+        .to_openssh(LineEnding::LF)
+        .context("encode private key as OpenSSH PEM")?;
+    let pub_openssh = key
+        .public_key()
+        .to_openssh()
+        .context("encode public key as OpenSSH")?;
+
+    // Merge into the existing bundle (if any) so we don't clobber
+    // unrelated keys. Same shape as `yoink secrets edit` on save.
+    let mut bundle = if target.exists() {
+        let identity = sealed::load_identity(recipients)?;
+        let ciphertext =
+            std::fs::read(&target).with_context(|| format!("read {}", target.display()))?;
+        let plaintext = sealed::unseal(&ciphertext, &identity)?;
+        sealed::parse_dotenv(&plaintext)?
+    } else {
+        std::collections::BTreeMap::new()
+    };
+    if bundle.contains_key(seal_as) {
+        return Err(anyhow::anyhow!(
+            "{seal_as:?} already exists in the sealed bundle. Pick a different --seal-as name, \
+             or run `yoink secrets edit` to remove the existing entry first."
+        ));
+    }
+    bundle.insert(seal_as.to_string(), (*priv_pem).clone());
+
+    let canonical = sealed::render_dotenv(&bundle);
+    let sealed_bytes = sealed::seal(canonical.as_bytes(), recipients)?;
+    sealed::write_atomically_secret(&target, &sealed_bytes)?;
+
+    eprintln!(
+        "✓ sealed new ed25519 SSH private key as {seal_as:?} into {}",
+        target.display()
+    );
+    // stdout: just the public key, one line, ready to pipe.
+    println!("{pub_openssh}");
+    Ok(())
+}
+
+fn cmd_secrets_ssh_key_public(config: &Config, name: &str) -> Result<()> {
+    use ssh_key::PrivateKey;
+    use yoink::sealed;
+
+    let (file_override, recipients) = expect_age_block(config)?;
+    let target = sealed::resolve_sealed_path(config, file_override.as_deref())?;
+    if !target.exists() {
+        return Err(anyhow::anyhow!(
+            "no sealed bundle at {}; nothing to derive {name:?} from",
+            target.display()
+        ));
+    }
+    let identity = sealed::load_identity(recipients)?;
+    let ciphertext =
+        std::fs::read(&target).with_context(|| format!("read {}", target.display()))?;
+    let plaintext = sealed::unseal(&ciphertext, &identity)?;
+    let bundle = sealed::parse_dotenv(&plaintext)?;
+    let pem = bundle.get(name).ok_or_else(|| {
+        anyhow::anyhow!(
+            "{name:?} not found in the sealed bundle at {}",
+            target.display()
+        )
+    })?;
+    let key = PrivateKey::from_openssh(pem.as_bytes())
+        .with_context(|| format!("{name:?} is not a valid OpenSSH-format private key"))?;
+    let pub_openssh = key
+        .public_key()
+        .to_openssh()
+        .context("encode public key as OpenSSH")?;
+    // stdout: just the public key, one line, ready to pipe.
+    println!("{pub_openssh}");
+    Ok(())
 }
 
 fn cmd_secrets_key_public(config: &Config) -> Result<()> {


### PR DESCRIPTION
## Summary

Generate a fresh ed25519 SSH keypair, seal the private half straight into the configured \`secrets.age\` under the given name, and print the OpenSSH-format public key on stdout — ready to pipe into provider SSH-key-upload commands:

\`\`\`bash
yoink secrets ssh-key generate --seal-as DEPLOY_KEY \\
  | hcloud ssh-key create --name yoink-scratch --public-key-from-file -
\`\`\`

Replaces the four-step \`ssh-keygen → echo cat seal → upload pub → shred\` dance with one call. **Private half never touches disk in plaintext.**

## Behavior

- Generates ed25519 in memory using the \`ssh-key\` crate (in-memory; no \`ssh-keygen\` shellout).
- Encodes the private half as OpenSSH PEM, seals it into the configured \`secrets.age\` under \`<NAME>\`.
- Existing entries in the sealed bundle are preserved (same merge logic \`yoink secrets edit\` uses on save).
- \`--seal-as <NAME>\` that already exists errors loudly rather than silently overwriting. Operator runs \`yoink secrets edit\` to drop the old entry first.
- \`<NAME>\` must match \`[A-Za-z_][A-Za-z0-9_]*\` (matches the dotenv key constraint).
- Optional \`--comment <TEXT>\` mirrors \`ssh-keygen -C\`. Default: empty.
- stdout is just the one-line OpenSSH public key — pipeable. Status messages go to stderr.

## Dependency

Adds \`ssh-key = { version = "0.6", features = ["ed25519"] }\` — small crate, MIT, well-maintained, no transitive bloat. Used elsewhere in the Rust ecosystem for the same purpose (\`ssh-keygen\`-equivalent in-process key generation).

## Motivating case

Bootstrap recipes (e.g. the [Hetzner cx23 quickstart](https://github.com/oddur/yoink/pull/44)) currently need:

\`\`\`bash
ssh-keygen -t ed25519 -N "" -f /tmp/yoink_scratch -C yoink-scratch
echo "DEPLOY_KEY=\\"\$(cat /tmp/yoink_scratch)\\"" | yoink secrets seal --in -
hcloud ssh-key create --name yoink-scratch --public-key-from-file /tmp/yoink_scratch.pub
shred -u /tmp/yoink_scratch /tmp/yoink_scratch.pub
\`\`\`

After this PR:

\`\`\`bash
yoink secrets ssh-key generate --seal-as DEPLOY_KEY \\
  | hcloud ssh-key create --name yoink-scratch --public-key-from-file -
\`\`\`

## Test plan
- [x] \`cargo test --workspace\` — 443 passed
- [x] \`cargo fmt --all -- --check\` — clean
- [x] \`cargo clippy --workspace --all-targets\` — no new lints
- [x] Live smoke test: generated, sealed, derived public key from unsealed bytes via \`ssh-keygen -y\`, confirmed it matches stdout. Verified no-clobber behavior, invalid-name rejection, and that a second add preserves the first key.