### PR TITLE
feat(config): include-fragments may carry `hosts:`

### DIFF
--- a/yoink/src/config.rs
+++ b/yoink/src/config.rs
@@ -1112,9 +1112,15 @@ fn default_replicas() -> u32 {
 }
 
 /// Subset of `Config` permitted in fragment files included via the
-/// main config's `include:` globs. Fragments may add services and
-/// pre-deploy hooks; they cannot redefine `hosts`, `deploy.network`,
-/// or `secrets` — those are global and live in the main file.
+/// main config's `include:` globs. Fragments may add services, hosts,
+/// and pre-deploy hooks; they cannot redefine `deploy.network` or
+/// `secrets` — those are global and live in the main file.
+///
+/// Hosts in fragments are appended to the main config's `hosts:` list
+/// before validation, so the existing duplicate-address check catches
+/// collisions across files. Useful pattern: `yoink hosts add` writes
+/// per-host fragment files (`hosts/<name>.yaml`) so yoink never has
+/// to round-trip-edit the operator's authored `yoink.yaml`.
 #[derive(Debug, Default, Clone, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct ConfigFragment {
@@ -1122,6 +1128,8 @@ pub struct ConfigFragment {
     pub services: Vec<ServiceConfig>,
     #[serde(default)]
     pub hooks: HookConfig,
+    #[serde(default)]
+    pub hosts: Vec<HostConfig>,
 }
 
 /// True when one of the platform-default docker socket paths exists.
@@ -1438,6 +1446,7 @@ impl Config {
             let fragment: ConfigFragment = yaml_serde::from_str(&text)?;
             self.services.extend(fragment.services);
             self.hooks.pre_deploy.extend(fragment.hooks.pre_deploy);
+            self.hosts.extend(fragment.hosts);
         }
         Ok(())
     }
@@ -1999,6 +2008,75 @@ hooks:
         assert_eq!(cfg.deploy.networks, vec!["kamal".to_string()]);
         assert_eq!(cfg.hooks.pre_deploy.len(), 1);
         assert_eq!(cfg.hooks.pre_deploy[0].name, "migrate");
+    }
+
+    #[test]
+    fn include_glob_merges_hosts_from_fragments() {
+        let dir = write_temp_tree(&[
+            (
+                "yoink.yaml",
+                r#"
+deploy:
+  networks: [yoink]
+hosts:
+  - { address: prod-1, user: deploy }
+services:
+  - name: a
+    image: img
+    tag: v1
+    run: {}
+include:
+  - hosts/*.yaml
+"#,
+            ),
+            (
+                "hosts/scratch.yaml",
+                r#"
+hosts:
+  - address: 1.2.3.4
+    user: root
+    ssh_key_secret: DEPLOY_SSH_KEY
+"#,
+            ),
+        ]);
+        let cfg = Config::load_from_path(&dir.join("yoink.yaml")).unwrap();
+        let addrs: Vec<&str> = cfg.hosts.iter().map(|h| h.address.as_str()).collect();
+        assert_eq!(addrs, vec!["prod-1", "1.2.3.4"]);
+        let scratch = cfg.hosts.iter().find(|h| h.address == "1.2.3.4").unwrap();
+        assert_eq!(scratch.user, "root");
+        assert_eq!(scratch.ssh_key_secret.as_deref(), Some("DEPLOY_SSH_KEY"));
+    }
+
+    #[test]
+    fn duplicate_host_address_across_files_is_rejected() {
+        let dir = write_temp_tree(&[
+            (
+                "yoink.yaml",
+                r#"
+hosts:
+  - { address: 1.2.3.4, user: root }
+services:
+  - name: a
+    image: img
+    tag: v1
+    run: {}
+include:
+  - hosts/*.yaml
+"#,
+            ),
+            (
+                "hosts/dupe.yaml",
+                r#"
+hosts:
+  - { address: 1.2.3.4, user: deploy }
+"#,
+            ),
+        ]);
+        let err = Config::load_from_path(&dir.join("yoink.yaml")).unwrap_err();
+        assert!(
+            format!("{err}").contains("duplicate hosts.address"),
+            "got: {err}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fragments loaded via the main config's \`include:\` globs can now declare \`hosts:\` entries in addition to \`services:\` and \`hooks.pre_deploy:\`. Each fragment's hosts are appended to the main config's host list before validation, so the existing duplicate-address check catches collisions across files.

## Motivating shape

A future \`yoink hosts add\` command that writes per-host fragment files like:

\`\`\`yaml
# hosts/bt-scratch-01.yaml — generated by \`yoink hosts add\`
hosts:
  - address: 78.46.150.66
    user: root
    ssh_key_secret: DEPLOY_SSH_KEY
\`\`\`

…so yoink never has to round-trip-edit the operator's authored \`yoink.yaml\` (preserving comments + formatting in arbitrary YAML is a footgun we'd rather not introduce). Operators who prefer one big \`yoink.yaml\` keep doing exactly that — fragments are an additive option, not a forced indirection.

## Behavior

- \`ConfigFragment\` gains an optional \`hosts: Vec<HostConfig>\` field. Same shape as the main config's hosts.
- \`merge_includes\` extends \`self.hosts\` with each fragment's contributions before \`validate()\` runs.
- Duplicate addresses across files are rejected by the existing host-uniqueness check — no new validation needed.
- Empty fragments still parse fine; the field is \`#[serde(default)]\`.
- \`deploy.networks:\` and \`secrets:\` remain main-file-only (fragments still can't declare them — \`#[serde(deny_unknown_fields)]\` enforces).

## Test plan
- [x] \`cargo test --workspace\` — 439 passed (2 new tests cover fragment-hosts merging and the duplicate-across-files rejection)
- [x] \`cargo fmt --all -- --check\` — clean
- [x] \`cargo clippy --workspace --all-targets\` — no new lints
- [x] No behavior change for configs without fragment-supplied hosts (existing \`include_glob_appends_services_from_fragments\` test still passes byte-for-byte)