### PR TITLE
feat(init): `--create-ssh-key <NAME>` generates + seals a deploy SSH key

### DIFF
--- a/yoink/src/init.rs
+++ b/yoink/src/init.rs
@@ -52,6 +52,13 @@ pub struct InitOpts {
     /// `recipients:` block to drop in) or when the project will use
     /// `provider: command` instead.
     pub no_secrets: bool,
+    /// When set, also generate an ed25519 SSH keypair and seal the
+    /// private half into the new `secrets.age` under this name. The
+    /// rendered yoink.yaml's host entry references it via
+    /// `ssh_key_secret:`, and the `include:` glob is widened to
+    /// `hosts/*.yaml` so subsequent `yoink hosts add` calls compose.
+    /// Mutually exclusive with `no_secrets`.
+    pub create_ssh_key: Option<String>,
 }
 
 pub fn cmd_init(opts: InitOpts) -> Result<()> {
@@ -86,6 +93,39 @@ pub fn cmd_init(opts: InitOpts) -> Result<()> {
         Some(bootstrap_age_identity()?)
     };
     plan.age_recipient = bootstrap.as_ref().map(|b| b.public.clone());
+
+    // If the operator asked for a sealed deploy SSH key, generate it
+    // alongside the AGE identity so the rendered yoink.yaml can
+    // reference it via `ssh_key_secret:`. We do this BEFORE rendering
+    // so the field lands in the file from the start.
+    if let Some(seal_as) = opts.create_ssh_key.as_deref().filter(|s| !s.is_empty()) {
+        let recipients = plan
+            .age_recipient
+            .as_ref()
+            .map(std::slice::from_ref)
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "--create-ssh-key requires an age identity to seal against; remove --no-secrets or provide one"
+                )
+            })?;
+        let secrets_path = cwd.join("secrets.age");
+        let pub_openssh = crate::sealed::ssh_keygen_into_bundle(
+            &secrets_path,
+            recipients,
+            seal_as,
+            Some("yoink-init"),
+        )?;
+        plan.ssh_key_secret = Some(seal_as.to_string());
+        eprintln!(
+            "✓ sealed deploy SSH key as {seal_as:?} into {} (public: {})",
+            secrets_path.display(),
+            pub_openssh
+                .split_whitespace()
+                .take(2)
+                .collect::<Vec<_>>()
+                .join(" ")
+        );
+    }
 
     let yaml = render(&plan);
     // `Config::parse_str` runs `validate()` internally, so a clean
@@ -333,6 +373,10 @@ struct WizardPlan {
     /// — render emits a `secrets:` block. `None` when the operator
     /// passed `--no-secrets`.
     age_recipient: Option<String>,
+    /// `Some(seal_name)` when init also generated a sealed SSH key
+    /// for the host. Render adds `ssh_key_secret: <name>` to the host
+    /// entry and widens `include:` to pick up `hosts/*.yaml`.
+    ssh_key_secret: Option<String>,
 }
 
 #[derive(Debug, Clone)]
@@ -407,6 +451,7 @@ fn infer_plan(detection: &Detection, opts: &InitOpts) -> Result<WizardPlan> {
             healthcheck_dup,
         },
         age_recipient: None,
+        ssh_key_secret: None,
     })
 }
 
@@ -468,6 +513,7 @@ fn fallback_plan(detection: &Detection) -> Result<WizardPlan> {
         user_override: None,
         sources: InferredSources::default(),
         age_recipient: None,
+        ssh_key_secret: None,
     })
 }
 
@@ -659,16 +705,27 @@ fn render(plan: &WizardPlan) -> String {
     ));
     out.push_str("# https://oddur.github.io/yoink/docs/reference/config\n\n");
     out.push_str("hosts:\n");
-    out.push_str(&format!(
-        "  - {{ address: {}, user: {} }}\n\n",
-        plan.host_address, plan.host_user
-    ));
+    if let Some(name) = &plan.ssh_key_secret {
+        out.push_str(&format!("  - address: {}\n", plan.host_address));
+        out.push_str(&format!("    user: {}\n", plan.host_user));
+        out.push_str(&format!("    ssh_key_secret: {name}\n\n"));
+    } else {
+        out.push_str(&format!(
+            "  - {{ address: {}, user: {} }}\n\n",
+            plan.host_address, plan.host_user
+        ));
+    }
     if let Some(public) = &plan.age_recipient {
         out.push_str("secrets:\n");
         out.push_str("  provider: age\n");
         out.push_str("  recipients:\n");
         out.push_str(&format!("    - {public}\n"));
         out.push('\n');
+    }
+    if plan.ssh_key_secret.is_some() {
+        out.push_str("# `yoink hosts add` writes per-host fragments here.\n");
+        out.push_str("include:\n");
+        out.push_str("  - hosts/*.yaml\n\n");
     }
     out.push_str("services:\n");
     out.push_str(&format!("  - name: {}\n", plan.service));
@@ -932,6 +989,7 @@ mod tests {
             user_override: Some("hono".into()),
             sources: InferredSources::default(),
             age_recipient: None,
+            ssh_key_secret: None,
         };
         let yaml = render(&plan);
         // `parse_str` validates internally, so a clean parse implies
@@ -952,6 +1010,7 @@ mod tests {
             user_override: None,
             sources: InferredSources::default(),
             age_recipient: None,
+            ssh_key_secret: None,
         };
         let yaml = render(&plan);
         // `parse_str` validates internally, so a clean parse implies
@@ -1044,6 +1103,7 @@ mod tests {
             age_recipient: Some(
                 "age1w8jcq22re378p38nxrudmjqdkyh42cyzsge7snwzqxlzyqt7fgkqmmvy45".into(),
             ),
+            ssh_key_secret: None,
         };
         let yaml = render(&plan);
         assert!(yaml.contains("secrets:\n  provider: age\n"));

--- a/yoink/src/main.rs
+++ b/yoink/src/main.rs
@@ -156,6 +156,21 @@ enum Command {
         /// `provider: command` for secrets.
         #[arg(long)]
         no_secrets: bool,
+        /// Also generate a fresh ed25519 SSH keypair and seal the
+        /// private half into the new `secrets.age` under the given
+        /// name. The rendered `yoink.yaml` references it via
+        /// `hosts[0].ssh_key_secret:`, so the deploy target uses it
+        /// instead of the operator's ssh-agent. Pair with
+        /// `yoink secrets ssh-key public --name <NAME>` to extract
+        /// the public half for upload to your cloud provider.
+        ///
+        /// Mutually exclusive with `--no-secrets`. Pass an empty value
+        /// or omit the flag to skip; pass a name like
+        /// `--create-ssh-key DEPLOY_SSH_KEY` to enable. The flag also
+        /// implies a richer `include:` glob (`hosts/*.yaml`) so
+        /// subsequent `yoink hosts add` calls just work.
+        #[arg(long, value_name = "NAME", conflicts_with = "no_secrets")]
+        create_ssh_key: Option<String>,
     },
     /// Drop a vetted template into your repo — accessory (postgres,
     /// redis, …) or full app (openclaw, …). Fetches from GitHub,
@@ -3604,6 +3619,7 @@ fn run_bootstrap(command: &Command) -> Option<Result<()>> {
             no_port,
             image,
             no_secrets,
+            create_ssh_key,
         } => Some(yoink::init::cmd_init(yoink::init::InitOpts {
             host: host.clone(),
             force: *force,
@@ -3613,6 +3629,7 @@ fn run_bootstrap(command: &Command) -> Option<Result<()>> {
             no_port: *no_port,
             image: image.clone(),
             no_secrets: *no_secrets,
+            create_ssh_key: create_ssh_key.clone(),
         })),
         _ => None,
     }
@@ -3648,73 +3665,14 @@ fn cmd_secrets_ssh_key_generate(
     seal_as: &str,
     comment: Option<&str>,
 ) -> Result<()> {
-    use ssh_key::{Algorithm, LineEnding, PrivateKey, rand_core::OsRng};
     use yoink::sealed;
-
-    if seal_as.is_empty()
-        || seal_as
-            .bytes()
-            .next()
-            .is_none_or(|b| !(b.is_ascii_alphabetic() || b == b'_'))
-        || !seal_as
-            .bytes()
-            .all(|b| b.is_ascii_alphanumeric() || b == b'_')
-    {
-        return Err(anyhow::anyhow!(
-            "--seal-as {seal_as:?} is not a valid secret name (must match [A-Za-z_][A-Za-z0-9_]*)"
-        ));
-    }
-
     let (file_override, recipients) = expect_age_block(config)?;
     let target = sealed::resolve_sealed_path(config, file_override.as_deref())?;
-
-    // ed25519 keypair, in memory only.
-    let mut rng = OsRng;
-    let key =
-        PrivateKey::random(&mut rng, Algorithm::Ed25519).context("generate ed25519 keypair")?;
-    let key = if let Some(c) = comment {
-        let mut k = key;
-        k.set_comment(c);
-        k
-    } else {
-        key
-    };
-    let priv_pem = key
-        .to_openssh(LineEnding::LF)
-        .context("encode private key as OpenSSH PEM")?;
-    let pub_openssh = key
-        .public_key()
-        .to_openssh()
-        .context("encode public key as OpenSSH")?;
-
-    // Merge into the existing bundle (if any) so we don't clobber
-    // unrelated keys. Same shape as `yoink secrets edit` on save.
-    let mut bundle = if target.exists() {
-        let identity = sealed::load_identity(recipients)?;
-        let ciphertext =
-            std::fs::read(&target).with_context(|| format!("read {}", target.display()))?;
-        let plaintext = sealed::unseal(&ciphertext, &identity)?;
-        sealed::parse_dotenv(&plaintext)?
-    } else {
-        std::collections::BTreeMap::new()
-    };
-    if bundle.contains_key(seal_as) {
-        return Err(anyhow::anyhow!(
-            "{seal_as:?} already exists in the sealed bundle. Pick a different --seal-as name, \
-             or run `yoink secrets edit` to remove the existing entry first."
-        ));
-    }
-    bundle.insert(seal_as.to_string(), (*priv_pem).clone());
-
-    let canonical = sealed::render_dotenv(&bundle);
-    let sealed_bytes = sealed::seal(canonical.as_bytes(), recipients)?;
-    sealed::write_atomically_secret(&target, &sealed_bytes)?;
-
+    let pub_openssh = sealed::ssh_keygen_into_bundle(&target, recipients, seal_as, comment)?;
     eprintln!(
         "✓ sealed new ed25519 SSH private key as {seal_as:?} into {}",
         target.display()
     );
-    // stdout: just the public key, one line, ready to pipe.
     println!("{pub_openssh}");
     Ok(())
 }

--- a/yoink/src/sealed.rs
+++ b/yoink/src/sealed.rs
@@ -89,6 +89,14 @@ pub enum SealedError {
         path_display: String,
         mode: u32,
     },
+    #[error("invalid secret name {0:?} (must match [A-Za-z_][A-Za-z0-9_]*)")]
+    InvalidSecretName(String),
+    #[error("ssh keygen: {0}")]
+    SshKeygen(String),
+    #[error(
+        "{0:?} already exists in the sealed bundle. Pick a different name, or run `yoink secrets edit` to remove the existing entry first."
+    )]
+    SecretAlreadySealed(String),
 }
 
 /// Resolve where the sealed file lives. Honors `secrets.file:` when
@@ -321,6 +329,74 @@ pub fn keygen() -> (String, String) {
     let secret = id.to_string().expose_secret().to_owned();
     let public = id.to_public().to_string();
     (secret, public)
+}
+
+/// Generate a fresh ed25519 SSH keypair, merge the private half (PEM
+/// format) into the sealed bundle at `target_path` under `seal_as`,
+/// and return the public half in OpenSSH single-line format.
+///
+/// The private key is generated in memory; no plaintext PEM is ever
+/// written to disk outside the sealed bundle. Existing entries in the
+/// bundle are preserved (same merge logic as `secrets edit` on save).
+/// Errors if `seal_as` already exists in the bundle (caller must
+/// remove it first).
+///
+/// `seal_as` is validated against the dotenv key shape
+/// (`[A-Za-z_][A-Za-z0-9_]*`).
+pub fn ssh_keygen_into_bundle(
+    target_path: &Path,
+    recipients: &[String],
+    seal_as: &str,
+    comment: Option<&str>,
+) -> Result<String, SealedError> {
+    use ssh_key::{Algorithm, LineEnding, PrivateKey, rand_core::OsRng};
+
+    if seal_as.is_empty()
+        || seal_as
+            .bytes()
+            .next()
+            .is_none_or(|b| !(b.is_ascii_alphabetic() || b == b'_'))
+        || !seal_as
+            .bytes()
+            .all(|b| b.is_ascii_alphanumeric() || b == b'_')
+    {
+        return Err(SealedError::InvalidSecretName(seal_as.to_string()));
+    }
+
+    let mut rng = OsRng;
+    let mut key = PrivateKey::random(&mut rng, Algorithm::Ed25519)
+        .map_err(|e| SealedError::SshKeygen(format!("generate ed25519: {e}")))?;
+    if let Some(c) = comment {
+        key.set_comment(c);
+    }
+    let priv_pem = key
+        .to_openssh(LineEnding::LF)
+        .map_err(|e| SealedError::SshKeygen(format!("encode private as OpenSSH PEM: {e}")))?;
+    let pub_openssh = key
+        .public_key()
+        .to_openssh()
+        .map_err(|e| SealedError::SshKeygen(format!("encode public as OpenSSH: {e}")))?;
+
+    let mut bundle = if target_path.exists() {
+        let identity = load_identity(recipients)?;
+        let ciphertext = std::fs::read(target_path).map_err(|source| SealedError::Write {
+            path: target_path.to_path_buf(),
+            source,
+        })?;
+        let plaintext = unseal(&ciphertext, &identity)?;
+        parse_dotenv(&plaintext)?
+    } else {
+        BTreeMap::new()
+    };
+    if bundle.contains_key(seal_as) {
+        return Err(SealedError::SecretAlreadySealed(seal_as.to_string()));
+    }
+    bundle.insert(seal_as.to_string(), (*priv_pem).clone());
+
+    let canonical = render_dotenv(&bundle);
+    let sealed_bytes = seal(canonical.as_bytes(), recipients)?;
+    write_atomically_secret(target_path, &sealed_bytes)?;
+    Ok(pub_openssh)
 }
 
 /// Seal `plaintext` against the recipients listed in `recipients`.


### PR DESCRIPTION
Re-opens #50 against \`main\` (auto-closed when its base #47 merged). Clean rebase on top of the now-landed \`secrets ssh-key generate\` work.

## Summary

\`yoink init --create-ssh-key DEPLOY_SSH_KEY\` extends init: alongside the AGE-identity bootstrap, also generates a fresh ed25519 SSH keypair, seals the private half into the new \`secrets.age\`, and renders the host entry with \`ssh_key_secret: <NAME>\` already wired in. The rendered \`include:\` list also widens to \`hosts/*.yaml\` so subsequent \`yoink hosts add\` calls (#51) compose without further edits.

\`\`\`bash
$ yoink init bt-scratch --create-ssh-key DEPLOY_SSH_KEY
✓ sealed deploy SSH key as "DEPLOY_SSH_KEY" into secrets.age (public: ssh-ed25519 AAAA…)
✓ wrote yoink.yaml (24 lines, validates clean)

$ cat yoink.yaml
hosts:
  - address: bt-scratch
    user: deploy
    ssh_key_secret: DEPLOY_SSH_KEY
secrets:
  provider: age
  recipients:
    - age1…
include:
  - hosts/*.yaml
services: …
\`\`\`

## Behavior

- Mutually exclusive with \`--no-secrets\` (the seal needs an age identity).
- Without the flag, init behaves exactly as before — no host rendering changes.
- Calls into \`sealed::ssh_keygen_into_bundle\` (the lib helper landed in #47); same in-memory keygen + bundle-merge as the \`secrets ssh-key generate\` command.

## Test plan
- [x] \`cargo test --workspace\` — all green (existing init test fixtures updated to include the new \`ssh_key_secret\` plan field)
- [x] Live smoke covering: yoink.yaml has the \`ssh_key_secret\` field, secrets.age contains the sealed key, \`yoink secrets ssh-key public --name DEPLOY_SSH_KEY\` round-trips correctly.