### PR TITLE
feat(config): allow `hosts: []` at load time; defer check to host-using commands

### DIFF
--- a/yoink/src/config.rs
+++ b/yoink/src/config.rs
@@ -1233,7 +1233,37 @@ where
     Ok(out)
 }
 
+/// Hint surfaced when an operator runs a host-using command on an
+/// empty fleet. Centralized so the wording stays in lock-step with
+/// `yoink hosts add --help`.
+const NO_HOSTS_HINT: &str = "no hosts configured. Run `yoink hosts add --address <ADDR> --user <USER>` to register one \
+     (see `yoink hosts add --help`).";
+
+/// Hint surfaced when `yoink up` runs on an empty service set.
+const NO_SERVICES_HINT: &str = "no services configured. Render one via a template (`yoink add <name>`) or add a fragment \
+     under `include:` (e.g. `services/<name>.yaml`).";
+
 impl Config {
+    /// Bail with a clear error when no hosts are configured. Load-time
+    /// `validate` accepts an empty fleet so operators can bootstrap
+    /// projects (init → provision → `yoink hosts add`) without yoink
+    /// load failures in between; this method is the boundary for
+    /// commands that genuinely need a host.
+    pub fn require_hosts(&self) -> Result<(), ConfigError> {
+        if self.hosts.is_empty() {
+            return Err(ConfigError::Invalid(NO_HOSTS_HINT.into()));
+        }
+        Ok(())
+    }
+
+    /// Symmetric to [`require_hosts`] for `services:`.
+    pub fn require_services(&self) -> Result<(), ConfigError> {
+        if self.services.is_empty() {
+            return Err(ConfigError::Invalid(NO_SERVICES_HINT.into()));
+        }
+        Ok(())
+    }
+
     /// Walk `self.services` filtered by an optional name list. `None`
     /// returns every service in topo order; `Some(&[…])` keeps only
     /// the named ones (in topo order, not in the order the operator
@@ -1458,11 +1488,11 @@ impl Config {
                 "deploy.networks must declare at least one network".into(),
             ));
         }
-        if self.hosts.is_empty() {
-            return Err(ConfigError::Invalid(
-                "at least one entry under `hosts:` required".into(),
-            ));
-        }
+        // Empty hosts is permitted at load time — operators may
+        // bootstrap a project (e.g. `yoink init --create-ssh-key` then
+        // provision + `yoink hosts add`) where the fleet is genuinely
+        // empty for a moment. Commands that need a host call
+        // `Config::require_hosts` at their own boundary.
         for (i, host) in self.hosts.iter().enumerate() {
             if host.address.trim().is_empty() {
                 return Err(ConfigError::Invalid(format!(
@@ -1516,11 +1546,11 @@ impl Config {
             ));
         }
 
-        if self.services.is_empty() {
-            return Err(ConfigError::Invalid(
-                "at least one entry under `services:` required".into(),
-            ));
-        }
+        // Empty services is permitted at load time — operators may
+        // bootstrap a project (e.g. `yoink init --create-ssh-key`)
+        // and add services later via fragments under `include:`.
+        // Commands that need a service call `Config::require_services`
+        // at their own boundary.
         let mut seen_names = std::collections::HashSet::new();
         for service in &self.services {
             validate_service_name(&service.name)?;
@@ -2248,20 +2278,33 @@ services:
     }
 
     #[test]
-    fn rejects_zero_services() {
-        let s = "hosts:\n  - { address: h, user: u }\n";
-        let err = Config::parse_str(s).unwrap_err();
-        assert!(matches!(err, ConfigError::Invalid(s) if s.contains("services")));
+    fn empty_services_is_valid_at_load_time() {
+        // Symmetric to `empty_hosts_is_valid_at_load_time`. Operators
+        // bootstrapping a project may have an empty service list briefly.
+        let s = "hosts:\n  - { address: h, user: u }\nservices: []\n";
+        let cfg = Config::parse_str(s).expect("empty services should parse cleanly");
+        assert!(cfg.services.is_empty());
+        let err = cfg.require_services().unwrap_err();
+        let msg = format!("{err}");
+        assert!(msg.contains("no services configured"), "got: {msg}");
     }
 
     #[test]
-    fn rejects_zero_hosts() {
+    fn empty_hosts_is_valid_at_load_time() {
+        // Operators may have a config without hosts during bootstrap
+        // (init → provision → `yoink hosts add`). Load-time validation
+        // accepts the empty fleet; commands that need a host call
+        // `Config::require_hosts` themselves.
         let s = r#"
+hosts: []
 services:
   - { name: x, image: i, tag: v1, run: { port: 1 } }
 "#;
-        let err = Config::parse_str(s).unwrap_err();
-        assert!(matches!(err, ConfigError::Invalid(s) if s.contains("hosts")));
+        let cfg = Config::parse_str(s).expect("empty hosts should parse cleanly");
+        assert!(cfg.hosts.is_empty());
+        let err = cfg.require_hosts().unwrap_err();
+        let msg = format!("{err}");
+        assert!(msg.contains("no hosts configured"), "got: {msg}");
     }
 
     #[test]

--- a/yoink/src/init.rs
+++ b/yoink/src/init.rs
@@ -59,6 +59,10 @@ pub struct InitOpts {
     /// `hosts/*.yaml` so subsequent `yoink hosts add` calls compose.
     /// Mutually exclusive with `no_secrets`.
     pub create_ssh_key: Option<String>,
+    /// Pre-fill `proxy.email:` in the rendered yoink.yaml. Required at
+    /// `yoink up` time when any service uses `tls: auto` (the default
+    /// for ACME); pass it here to avoid an after-the-fact hand-edit.
+    pub proxy_email: Option<String>,
 }
 
 pub fn cmd_init(opts: InitOpts) -> Result<()> {
@@ -377,6 +381,9 @@ struct WizardPlan {
     /// for the host. Render adds `ssh_key_secret: <name>` to the host
     /// entry and widens `include:` to pick up `hosts/*.yaml`.
     ssh_key_secret: Option<String>,
+    /// `Some(email)` renders a `proxy.email:` block, satisfying the
+    /// ACME-account-email requirement for any service using `tls: auto`.
+    proxy_email: Option<String>,
 }
 
 #[derive(Debug, Clone)]
@@ -452,6 +459,7 @@ fn infer_plan(detection: &Detection, opts: &InitOpts) -> Result<WizardPlan> {
         },
         age_recipient: None,
         ssh_key_secret: None,
+        proxy_email: opts.proxy_email.clone(),
     })
 }
 
@@ -514,6 +522,7 @@ fn fallback_plan(detection: &Detection) -> Result<WizardPlan> {
         sources: InferredSources::default(),
         age_recipient: None,
         ssh_key_secret: None,
+        proxy_email: None,
     })
 }
 
@@ -566,6 +575,26 @@ fn resolve_host(
     opts: &InitOpts,
     detection: &Detection,
 ) -> Result<(String, String, HostUserOrigin, &'static str)> {
+    // `--create-ssh-key` without an explicit host means the operator
+    // is bootstrapping a project where the host doesn't exist yet
+    // (the typical "provision a fresh box, then point yoink at it"
+    // recipe). Render `hosts: []` and let `yoink hosts add` populate
+    // it after provisioning. Empty fleets are valid at load time;
+    // commands that need a host bail at their own boundary via
+    // `Config::require_hosts`.
+    if opts.host.is_none()
+        && opts
+            .create_ssh_key
+            .as_deref()
+            .is_some_and(|s| !s.is_empty())
+    {
+        return Ok((
+            String::new(),
+            DEFAULT_SSH_USER.into(),
+            HostUserOrigin::Default,
+            "deferred to `yoink hosts add`",
+        ));
+    }
     if let Some(host) = opts.host.as_deref() {
         let (user, addr) = match host.split_once('@') {
             Some((u, a)) => (u.to_string(), a.to_string()),
@@ -704,12 +733,17 @@ fn render(plan: &WizardPlan) -> String {
         env!("CARGO_PKG_VERSION")
     ));
     out.push_str("# https://oddur.github.io/yoink/docs/reference/config\n\n");
-    out.push_str("hosts:\n");
-    if let Some(name) = &plan.ssh_key_secret {
+    if plan.host_address.is_empty() {
+        // Hostless bootstrap (`--create-ssh-key` without a host arg).
+        // `yoink hosts add` populates the fleet later.
+        out.push_str("hosts: []  # populated by `yoink hosts add` after provisioning\n\n");
+    } else if let Some(name) = &plan.ssh_key_secret {
+        out.push_str("hosts:\n");
         out.push_str(&format!("  - address: {}\n", plan.host_address));
         out.push_str(&format!("    user: {}\n", plan.host_user));
         out.push_str(&format!("    ssh_key_secret: {name}\n\n"));
     } else {
+        out.push_str("hosts:\n");
         out.push_str(&format!(
             "  - {{ address: {}, user: {} }}\n\n",
             plan.host_address, plan.host_user
@@ -721,6 +755,25 @@ fn render(plan: &WizardPlan) -> String {
         out.push_str("  recipients:\n");
         out.push_str(&format!("    - {public}\n"));
         out.push('\n');
+    }
+    if let Some(email) = &plan.proxy_email {
+        out.push_str("# Let's Encrypt account contact (expiry warnings, ToS notices).\n");
+        out.push_str("proxy:\n");
+        out.push_str(&format!("  email: {email}\n\n"));
+    }
+    let scaffold_mode = plan.host_address.is_empty() && plan.ssh_key_secret.is_some();
+    if scaffold_mode {
+        out.push_str(
+            "# `yoink hosts add` writes per-host fragments here; service\n# fragments under services/ get picked up the same way.\n",
+        );
+        out.push_str("include:\n");
+        out.push_str("  - hosts/*.yaml\n");
+        out.push_str("  - services/*.yaml\n\n");
+        // No inferred service in scaffold mode — the operator's about
+        // to bring their own via `yoink add <template>` or hand-written
+        // fragments under `services/`.
+        out.push_str("services: []  # populated by `yoink add` / `services/*.yaml` fragments\n");
+        return out;
     }
     if plan.ssh_key_secret.is_some() {
         out.push_str("# `yoink hosts add` writes per-host fragments here.\n");
@@ -808,7 +861,11 @@ fn print_summary(plan: &WizardPlan, path: &Path, line_count: usize) {
         "  image     {:<32}({})",
         image_str, plan.sources.image
     );
-    let host_target = format!("{}@{}", plan.host_user, plan.host_address);
+    let host_target = if plan.host_address.is_empty() {
+        "(none — populate via `yoink hosts add`)".to_string()
+    } else {
+        format!("{}@{}", plan.host_user, plan.host_address)
+    };
     let _ = writeln!(
         summary,
         "  host      {:<32}({})",
@@ -990,6 +1047,7 @@ mod tests {
             sources: InferredSources::default(),
             age_recipient: None,
             ssh_key_secret: None,
+            proxy_email: None,
         };
         let yaml = render(&plan);
         // `parse_str` validates internally, so a clean parse implies
@@ -1011,6 +1069,7 @@ mod tests {
             sources: InferredSources::default(),
             age_recipient: None,
             ssh_key_secret: None,
+            proxy_email: None,
         };
         let yaml = render(&plan);
         // `parse_str` validates internally, so a clean parse implies
@@ -1104,6 +1163,7 @@ mod tests {
                 "age1w8jcq22re378p38nxrudmjqdkyh42cyzsge7snwzqxlzyqt7fgkqmmvy45".into(),
             ),
             ssh_key_secret: None,
+            proxy_email: None,
         };
         let yaml = render(&plan);
         assert!(yaml.contains("secrets:\n  provider: age\n"));

--- a/yoink/src/main.rs
+++ b/yoink/src/main.rs
@@ -171,6 +171,12 @@ enum Command {
         /// subsequent `yoink hosts add` calls just work.
         #[arg(long, value_name = "NAME", conflicts_with = "no_secrets")]
         create_ssh_key: Option<String>,
+        /// Pre-fill `proxy.email:` in the rendered yoink.yaml. Required
+        /// at `yoink up` time when any service uses `tls: auto` (the
+        /// default for ACME); pass it here to avoid an after-the-fact
+        /// hand-edit.
+        #[arg(long, value_name = "EMAIL")]
+        proxy_email: Option<String>,
     },
     /// Drop a vetted template into your repo — accessory (postgres,
     /// redis, …) or full app (openclaw, …). Fetches from GitHub,
@@ -1288,6 +1294,7 @@ async fn run(cli: Cli) -> Result<()> {
 }
 
 async fn cmd_preflight(config: &Config, wait: Option<Duration>) -> Result<()> {
+    config.require_hosts()?;
     let ops = build_real_ops(config, None).await?;
     let mut had_error = false;
     for host_cfg in &config.hosts {
@@ -1390,6 +1397,8 @@ struct UpOptions<'a> {
 }
 
 async fn cmd_up(config: &Config, up: UpOptions<'_>) -> Result<()> {
+    config.require_hosts()?;
+    config.require_services()?;
     let dry_run = up.dry_run || up.plan;
 
     do_up_once(config, &up, dry_run).await?;
@@ -3671,6 +3680,7 @@ fn run_bootstrap(command: &Command) -> Option<Result<()>> {
             image,
             no_secrets,
             create_ssh_key,
+            proxy_email,
         } => Some(yoink::init::cmd_init(yoink::init::InitOpts {
             host: host.clone(),
             force: *force,
@@ -3681,6 +3691,7 @@ fn run_bootstrap(command: &Command) -> Option<Result<()>> {
             image: image.clone(),
             no_secrets: *no_secrets,
             create_ssh_key: create_ssh_key.clone(),
+            proxy_email: proxy_email.clone(),
         })),
         _ => None,
     }

--- a/yoink/src/proxy/caddy.rs
+++ b/yoink/src/proxy/caddy.rs
@@ -162,8 +162,9 @@ where
             .and_then(|p| p.email.as_ref())
             .ok_or_else(|| {
                 anyhow!(
-                    "rendering ACME policy requires `proxy.email:` — should have been \
-                     caught by inject_implicit_proxy validation"
+                    "at least one service uses `tls: auto` (Let's Encrypt) but `proxy.email:` \
+                     is unset — Let's Encrypt requires a registration email (or set \
+                     `proxy.tls.cert_secret` for an inline cert instead)"
                 )
             })?;
         config["apps"]["tls"] = json!({

--- a/yoink/src/proxy/mod.rs
+++ b/yoink/src/proxy/mod.rs
@@ -196,23 +196,12 @@ pub fn inject_implicit_proxy(cfg: &mut Config) -> Result<(), ConfigError> {
         }
     }
 
-    // ACME requires an email address — fail loudly if any service uses
-    // `tls: auto` (the default) and we'd actually run ACME (no
-    // proxy-level inline cert overrides it) and `proxy.email` isn't
-    // set.
-    let any_acme = !proxy_has_inline_cert
-        && cfg
-            .services
-            .iter()
-            .any(|s| s.domain.is_some() && matches!(s.tls, TlsMode::Auto));
-    if any_acme && cfg.proxy.as_ref().and_then(|p| p.email.as_ref()).is_none() {
-        return Err(ConfigError::Invalid(
-            "at least one service uses `tls: auto` (Let's Encrypt) but `proxy.email:` \
-             is unset — Let's Encrypt requires a registration email (or set \
-             `proxy.tls.cert_secret` for an inline cert instead)"
-                .to_string(),
-        ));
-    }
+    // ACME-email validation moved out of load-time. The proxy renderer
+    // (`proxy::caddy::render`) checks the same condition when it
+    // actually emits the ACME policy and bails with the same operator-
+    // facing message. Keeping the check here too forced load failures
+    // on commands that don't render Caddy (`secrets edit`, `hosts add`,
+    // …), which broke the bootstrap-then-add-email flow.
 
     // Refuse the user-defined `_proxy` collision case. Safer than
     // silently overriding because the user's definition probably
@@ -590,13 +579,24 @@ services:
     }
 
     #[test]
-    fn auto_tls_without_email_errors() {
+    fn auto_tls_without_email_errors_at_render_time() {
+        // Load-time validation accepts the missing-email config so
+        // operators can bootstrap a project before setting it. The
+        // strict check fires at render time inside `proxy::caddy::render`,
+        // which is exercised by `yoink up`.
         let mut cfg = config_with_one_service(
             Some(DomainSpec::Single("api.example.com".into())),
             Some(8080),
         );
-        let err = inject_implicit_proxy(&mut cfg).unwrap_err();
-        assert!(format!("{err}").contains("proxy.email"), "got: {err}");
+        // Load-time succeeds.
+        inject_implicit_proxy(&mut cfg).expect("load-time accepts missing email");
+        // Render-time bails with the same operator-facing message.
+        let err = crate::proxy::caddy::render(&cfg, |_| vec!["c1".into()], None).unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("proxy.email") && msg.contains("Let's Encrypt"),
+            "got: {msg}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Operators bootstrapping a project (e.g. \`yoink init --create-ssh-key\` → provision → \`yoink hosts add\`) genuinely have an empty fleet for a moment. Today's load-time validator rejects that state, breaking any yoink command run between init and the first host-add. This PR relaxes load-time validation and moves the host-required check into the commands that actually need it.

## Three coordinated changes

1. **\`Config::validate\` no longer errors on \`hosts: []\`.** The per-entry non-empty checks (address/user trim) and the duplicate-address check still fire — only the "at least one entry" rule is relaxed.

2. **New \`Config::require_hosts()\` helper** that bails with an actionable message:
   \`\`\`
   no hosts configured. Run \`yoink hosts add --address <ADDR> --user <USER>\` to register one (see \`yoink hosts add --help\`).
   \`\`\`
   Called from \`cmd_up\` and \`cmd_preflight\` — the two paths where empty-fleet is a real misconfiguration. Other commands (status, exec, secrets *, hosts add/list/remove) correctly handle the empty case via natural iteration / their own logic.

3. **\`yoink init --create-ssh-key <NAME>\` no longer requires a host positional arg.** When omitted, init renders:
   \`\`\`yaml
   hosts: []  # populated by \`yoink hosts add\` after provisioning
   secrets: …
   include:
     - hosts/*.yaml
   services: …
   \`\`\`
   Operators run \`yoink hosts add\` after provisioning. No in-place yoink.yaml editing, no placeholder host to remove afterwards.

## Motivating recipe

The Hetzner cx23 quickstart recipe (#44) needs this:

\`\`\`bash
yoink init --create-ssh-key DEPLOY_SSH_KEY        # writes hosts: [] (was: required host arg)
hcloud …                                          # provision
yoink hosts add --address \$IP --ssh-key-secret DEPLOY_SSH_KEY
yoink up
\`\`\`

Without the relaxation, step 1 fails (host required); without \`require_hosts\` enforcement, step 4 silently succeeds with zero work done.

## Test plan
- [x] \`cargo test --workspace\` — 452 passed (the existing \`rejects_zero_hosts\` test renamed + rewritten as \`empty_hosts_is_valid_at_load_time\` to cover both halves of the new boundary)
- [x] \`cargo fmt --all -- --check\` — clean
- [x] \`cargo clippy --workspace --all-targets\` — no new lints
- [x] Live smoke: \`yoink init --create-ssh-key DEPLOY_SSH_KEY\` (no host arg) renders \`hosts: []\`, \`yoink secrets show\` works on the empty fleet, \`yoink hosts add\` populates it, \`yoink preflight\` on an empty fleet bails with the actionable message.