### PR TITLE
[BLOCKED] feat(fs): `yoink fs` — laptop-mount a container's filesystem (sshfs/MergedDir design)

### DIFF
--- a/docs/content/docs/how-to/_index.md
+++ b/docs/content/docs/how-to/_index.md
@@ -21,6 +21,7 @@ Task-oriented walkthroughs. Each how-to takes you from "I want X" to "X is runni
   {{< card link="/docs/how-to/caddy-snippets" title="Caddy snippets cookbook" subtitle="Forward auth, basic auth, IP allowlist, custom headers, body-size limit, redirects, maintenance page — both Caddyfile and JSON forms." icon="document-duplicate" >}}
   {{< card link="/docs/how-to/age-in-github-actions" title="AGE secrets in GitHub Actions" subtitle="Generate a CI-only identity, paste into a GitHub secret, deploy. One env var." icon="key" >}}
   {{< card link="/docs/how-to/multi-host-redis-storage" title="Multi-host Let's Encrypt with Redis" subtitle="Share ACME state across hosts to avoid Let's Encrypt rate limits." icon="database" >}}
+  {{< card link="/docs/how-to/fs" title="Mount a container's filesystem" subtitle="`yoink fs <service>` mounts a running container at `/tmp/yoink-fs/<service>/` via SSH+FUSE. Like `yoink pf` but for files. Read-only by default; `--rw` opts in." icon="folder-open" >}}
   {{< card link="/docs/how-to/staging-alongside-prod" title="Run staging alongside prod" subtitle="Same hosts, two configs, namespaced services + networks." icon="duplicate" >}}
   {{< card link="/docs/how-to/self-hosted-registry" title="Self-hosted registry on a yoink host" subtitle="Run registry:2 as a yoink service, expose via tailnet, push to it." icon="cube" >}}
   {{< card link="/docs/how-to/pr-comment-dry-run" title="Pre-merge dry-run on every PR" subtitle="Sticky GitHub PR comment showing what `yoink up` would change before the merge." icon="annotation" >}}

--- a/docs/content/docs/how-to/fs.md
+++ b/docs/content/docs/how-to/fs.md
@@ -1,0 +1,95 @@
+---
+title: Mount a container's filesystem
+weight: 12
+---
+
+Inspecting files inside a running container usually means `docker cp` round-trips or shell-execs that drop into a spartan environment without your editor or tools. `yoink fs <service>` mounts the container's root filesystem on your laptop via SSH+FUSE — `cd /tmp/yoink-fs/api/`, `tail -f var/log/app.log`, open the dir in your editor, ctrl-c to unmount.
+
+Same shape as `yoink pf` but for files. Replica selection, host filtering, and ssh-credential reuse all match.
+
+## Quickstart
+
+```sh
+yoink fs api                     # mounts at /tmp/yoink-fs/api/ (read-only)
+ls /tmp/yoink-fs/api/etc/        # operator can read the container's /etc
+cat /tmp/yoink-fs/api/var/log/app.log
+^C                               # unmount
+```
+
+Multi-host or multi-replica fleet:
+
+```sh
+yoink fs api --host prod-2       # pin to one host
+yoink fs api -r 1 --to ./fs      # replica 1, custom mountpoint
+```
+
+## Prerequisites
+
+- **`sshfs` on your laptop.** `apt install sshfs` (Linux), or [macFUSE](https://macfuse.io) / [FUSE-T](https://www.fuse-t.org) plus `brew install sshfs` on macOS. `yoink doctor` flags this when missing.
+- **`overlay2` on the docker host.** Yoink reads `GraphDriver.Data.MergedDir` for the host-side path that mirrors the container's rootfs. Other drivers (`btrfs`, `zfs`, `vfs`) don't expose a single host path; `yoink fs` errors loudly on them.
+- **The deploy user in the `docker` group on the host.** Already true for any host you've deployed through yoink — `MergedDir` lives under `/var/lib/docker/overlay2/` and the docker group has read access.
+
+## Read-only by default
+
+Writes through the merged view mutate the running container's filesystem and race with the app's own writes — file locks, log rotation, mid-write truncation. The `--rw` flag opts in:
+
+```sh
+yoink fs api --rw
+⚠ mounting api-aaa read-write — writes can race with the running app's writes
+  (file locks, truncation, log rotation). Ctrl-C to abort.
+→ api (replica 0) on host-1 ⇆ /tmp/yoink-fs/api [rw]
+```
+
+For drop-a-config / poke-a-flag / quick patches, `--rw` is the affordance. For app-state writes (database files, in-flight uploads), prefer `docker exec` or app-aware tooling — FUSE write semantics differ from kernel writes in ways that surprise databases and lock managers.
+
+## Schema
+
+| Flag | Type | Default | Notes |
+|---|---|---|---|
+| `service` (positional) | string | required | Service name as declared in `yoink.yaml`. |
+| `--host` | string | — | Pin to one host when the service runs on multiple. |
+| `-r`, `--replica` | int | `0` | Replica index for `replicas: > 1`. |
+| `--to` | path | `/tmp/yoink-fs/<service>/` | Mountpoint on your laptop. Created if missing; rejected if non-empty. |
+| `--rw` | bool | `false` (read-only) | Mount read-write. Prints a warning before mounting. |
+
+## What you see in the mount
+
+The merged view layers the container's read-write top onto the image's read-only lower layers, so `/tmp/yoink-fs/api/` looks like the container's `/`:
+
+```
+/tmp/yoink-fs/api/
+├── bin/             # from the image
+├── etc/             # image + container overrides
+├── var/log/app.log  # written by the running container
+└── …
+```
+
+Two things don't show through:
+
+- **`tmpfs` mounts.** `/run`, `/dev/shm`, anything declared with `tmpfs:` in yoink. The merged view is filesystem-only; tmpfs entries live in the container's mount namespace and aren't reachable from the host.
+- **Symlinks pointing into bind-mounted paths.** `/etc/resolv.conf -> /run/...` resolves inside the container against a bind mount that exists only there. From the host's merged view, the symlink dangles.
+
+For both, `docker exec <container> sh` is the right tool.
+
+## Stale mount recovery
+
+A laptop close, network drop, or `kill -9` mid-session leaves the FUSE mount in a "transport endpoint not connected" state. Running `yoink fs` again detects the stale mountpoint and reaps it before remounting. Manual cleanup if you need it:
+
+```sh
+# Linux
+fusermount -u /tmp/yoink-fs/api
+
+# macOS
+umount /tmp/yoink-fs/api
+```
+
+## File ownership
+
+Container UIDs rarely match your laptop's UID, so without remapping, files show as `nobody:nogroup`. Yoink passes `-o idmap=user` to sshfs, which remaps the SSH-side user (the host's deploy user) to your local UID for display. The actual on-disk ownership inside the container is unchanged.
+
+If a file shows as a different non-deploy UID inside the container — say, an app running as UID 1000 — you'll see that UID locally rather than your own. `chown` it inside the container if you need to write through the mount.
+
+## See also
+
+- [`yoink pf`](/docs/guide/networking#port-forward) — same shape as `yoink fs` but for TCP ports.
+- [Reverse proxy](/docs/guide/proxy) — the `yoink-proxy` service is itself mountable for inspecting Caddy's autosaved config.

--- a/docs/content/docs/how-to/fs.md
+++ b/docs/content/docs/how-to/fs.md
@@ -25,9 +25,18 @@ yoink fs api -r 1 --to ./fs      # replica 1, custom mountpoint
 
 ## Prerequisites
 
-- **`sshfs` on your laptop.** `apt install sshfs` (Linux), or [macFUSE](https://macfuse.io) / [FUSE-T](https://www.fuse-t.org) plus `brew install sshfs` on macOS. `yoink doctor` flags this when missing.
-- **`overlay2` on the docker host.** Yoink reads `GraphDriver.Data.MergedDir` for the host-side path that mirrors the container's rootfs. Other drivers (`btrfs`, `zfs`, `vfs`) don't expose a single host path; `yoink fs` errors loudly on them.
-- **The deploy user in the `docker` group on the host.** Already true for any host you've deployed through yoink — `MergedDir` lives under `/var/lib/docker/overlay2/` and the docker group has read access.
+One operator-side install on macOS:
+
+```sh
+brew install --cask fuse-t-sshfs
+```
+
+This is the kext-free path — pulls [FUSE-T](https://www.fuse-t.org) as a dependency, no kernel extensions, no reboot. `yoink doctor` flags this when missing. On Linux, `apt install sshfs` (or your distro's equivalent).
+
+Two host-side conditions, both true for any standard yoink host:
+
+- **`overlay2` storage driver.** Yoink reads `GraphDriver.Data.MergedDir` for the host-side path that mirrors the container's rootfs. Other drivers (`btrfs`, `zfs`, `vfs`) don't expose a single host path; `yoink fs` errors out on them.
+- **The deploy user in the `docker` group.** `MergedDir` lives under `/var/lib/docker/overlay2/` and the docker group has read access. Required for any yoink host already.
 
 ## Read-only by default
 

--- a/yoink/src/docker_ops.rs
+++ b/yoink/src/docker_ops.rs
@@ -385,6 +385,27 @@ pub struct ContainerDetail {
     pub security_opt: Vec<String>,
     /// `--read-only` (immutable rootfs).
     pub read_only: bool,
+    /// Storage-driver state: `name` is the docker storage driver
+    /// (`overlay2`, `btrfs`, `zfs`, `vfs`, …) and `data` is its
+    /// driver-specific key/value map. For overlay2 this includes the
+    /// host paths `MergedDir`, `LowerDir`, `UpperDir`, `WorkDir` —
+    /// `MergedDir` is the union view that mirrors the container's
+    /// running rootfs. `yoink fs` reads it for the host-side
+    /// sshfs source. `None` when bollard didn't return the field
+    /// (older daemons or non-overlay drivers that don't populate it).
+    pub graph_driver: Option<GraphDriverInfo>,
+}
+
+/// Storage-driver state for a single container, as reported by
+/// `docker inspect` under `.GraphDriver`.
+#[derive(Debug, Clone, Default, PartialEq, Eq, serde::Serialize)]
+pub struct GraphDriverInfo {
+    /// Driver name, e.g. `overlay2`, `btrfs`, `zfs`, `vfs`.
+    pub name: String,
+    /// Driver-specific data. For overlay2: `MergedDir`, `LowerDir`,
+    /// `UpperDir`, `WorkDir`. Empty for drivers that don't expose
+    /// host paths.
+    pub data: BTreeMap<String, String>,
 }
 
 impl ContainerDetail {
@@ -2233,6 +2254,15 @@ fn parse_inspect(name: &str, resp: &bollard::models::ContainerInspectResponse) -
         .into_iter()
         .collect();
 
+    let graph_driver = resp.graph_driver.as_ref().map(|gd| GraphDriverInfo {
+        name: gd.name.clone(),
+        data: gd
+            .data
+            .iter()
+            .map(|(k, v)| (k.clone(), v.clone()))
+            .collect(),
+    });
+
     ContainerDetail {
         name: name.into(),
         image: config.and_then(|c| c.image.clone()),
@@ -2274,6 +2304,7 @@ fn parse_inspect(name: &str, resp: &bollard::models::ContainerInspectResponse) -
             .unwrap_or_default(),
         read_only: host_config.and_then(|h| h.readonly_rootfs).unwrap_or(false),
         labels,
+        graph_driver,
     }
 }
 

--- a/yoink/src/doctor.rs
+++ b/yoink/src/doctor.rs
@@ -163,6 +163,7 @@ pub async fn run_doctor(config: &Config, ops: Arc<dyn DockerOps>) -> Vec<Finding
         &host_versions,
     ));
     findings.extend(dns_findings);
+    findings.extend(check_sshfs_for_yoink_fs());
 
     findings
 }
@@ -638,6 +639,31 @@ fn check_provider_command(config: &Config) -> Vec<Finding> {
             )),
         ]
     }
+}
+
+/// `yoink fs` shells out to `sshfs` for the FUSE mount. Soft-warn when
+/// it isn't on PATH so the operator finds out before they try the
+/// command and hit an opaque "executable not found" error. Pass-quiet
+/// when present so the doctor output stays tight on the common case.
+fn check_sshfs_for_yoink_fs() -> Vec<Finding> {
+    if which_on_path("sshfs").is_some() {
+        return vec![Finding::pass("yoink-fs", "`sshfs` is on PATH")];
+    }
+    let install_hint = if cfg!(target_os = "macos") {
+        "install via macFUSE (https://macfuse.io) or FUSE-T (https://www.fuse-t.org), \
+         then `brew install sshfs`"
+    } else if cfg!(target_os = "linux") {
+        "install via your package manager: `apt install sshfs` / `dnf install fuse-sshfs` / etc"
+    } else {
+        "install sshfs for your OS — required for `yoink fs`"
+    };
+    vec![
+        Finding::warn(
+            "yoink-fs",
+            "`sshfs` not found on PATH — `yoink fs` will refuse to mount",
+        )
+        .with_fix(install_hint),
+    ]
 }
 
 /// Lightweight `which` — walk `PATH` and return the first match. We

--- a/yoink/src/doctor.rs
+++ b/yoink/src/doctor.rs
@@ -650,8 +650,7 @@ fn check_sshfs_for_yoink_fs() -> Vec<Finding> {
         return vec![Finding::pass("yoink-fs", "`sshfs` is on PATH")];
     }
     let install_hint = if cfg!(target_os = "macos") {
-        "install via macFUSE (https://macfuse.io) or FUSE-T (https://www.fuse-t.org), \
-         then `brew install sshfs`"
+        "`brew install --cask fuse-t-sshfs` (kext-free; pulls FUSE-T as a dep)"
     } else if cfg!(target_os = "linux") {
         "install via your package manager: `apt install sshfs` / `dnf install fuse-sshfs` / etc"
     } else {

--- a/yoink/src/fs.rs
+++ b/yoink/src/fs.rs
@@ -1,0 +1,573 @@
+//! `yoink fs` — laptop-mount a running container's filesystem.
+//!
+//! Same shape as `yoink pf` but for files. The mechanism:
+//!
+//! 1. Pick a target container (replica + host filter, like `pf`).
+//! 2. Inspect it; read `GraphDriver.Data["MergedDir"]` — the host
+//!    overlay2 path that mirrors the container's full filesystem
+//!    (rw layer + image layers, unioned).
+//! 3. `sshfs <user>@<host>:<MergedDir> <local-mountpoint>` over the
+//!    same SSH credentials yoink already uses.
+//! 4. Hold the foreground sshfs subprocess until Ctrl-C; on shutdown,
+//!    force-unmount the local mountpoint (FUSE-managed kernel state)
+//!    and reap the child.
+//!
+//! Read-only by default. Writes through `merged` mutate the running
+//! container's filesystem and can race with the app (file locks,
+//! truncation, in-flight log rotation) — `--rw` opts in.
+//!
+//! Overlay2-only for v1. Other storage drivers (btrfs, zfs, vfs) put
+//! the container's rootfs in driver-specific places that don't map
+//! to a single host path; we fail loudly with an actionable error
+//! rather than mount the wrong thing.
+
+use std::path::{Path, PathBuf};
+use std::process::Stdio;
+use std::time::Duration;
+
+use anyhow::Context as _;
+use thiserror::Error;
+use tokio::process::Command;
+
+use crate::config::Config;
+use crate::docker_ops::{ContainerDetail, DockerOps, GraphDriverInfo, Host};
+
+/// Default mountpoint root on the operator's machine. Each `yoink fs`
+/// invocation gets a per-service subdir so two services don't collide.
+pub const DEFAULT_MOUNT_ROOT: &str = "/tmp/yoink-fs";
+
+/// Hard cap on how long we wait for `umount`/`fusermount` to clean up
+/// during shutdown. Real unmounts complete in milliseconds; this is
+/// the safety valve for "ssh died, FUSE is in a weird state."
+const UNMOUNT_TIMEOUT: Duration = Duration::from_secs(5);
+
+#[derive(Debug, Error)]
+pub enum FsError {
+    #[error("service {0:?} not found in config")]
+    ServiceNotFound(String),
+    #[error("service {service:?} has no running container on {host} — was `yoink up` run?")]
+    NoRunningContainer { service: String, host: String },
+    #[error(
+        "service {service:?} has {found} running container(s) on {host}; \
+         --replica {replica} is out of range"
+    )]
+    ReplicaOutOfRange {
+        service: String,
+        host: String,
+        replica: usize,
+        found: usize,
+    },
+    #[error(
+        "container {container:?} on {host} is using docker storage driver {driver:?} — \
+         `yoink fs` only supports overlay2 today (other drivers don't expose a single host path \
+         that mirrors the container's rootfs)"
+    )]
+    UnsupportedStorageDriver {
+        container: String,
+        host: String,
+        driver: String,
+    },
+    #[error(
+        "container {container:?} on {host} reports overlay2 but no MergedDir — \
+         daemon may be too old, or the container is in an unusual state"
+    )]
+    NoMergedDir { container: String, host: String },
+    #[error(
+        "`sshfs` not found on PATH — install macFUSE / FUSE-T (macOS) or `apt install sshfs` (Linux)"
+    )]
+    SshfsMissing,
+    #[error("sshfs exited with status {status}{stderr}", stderr = if .stderr.is_empty() { String::new() } else { format!(":\n{}", .stderr) })]
+    SshfsFailed { status: String, stderr: String },
+    #[error(
+        "mountpoint {0:?} already in use — unmount it (`umount {0}` or `fusermount -u {0}`) and retry"
+    )]
+    MountpointBusy(PathBuf),
+    #[error(transparent)]
+    Io(#[from] std::io::Error),
+    #[error(transparent)]
+    Docker(#[from] crate::docker_ops::DockerError),
+}
+
+/// Settings the CLI / future TUI shape passes in. Kept as a single
+/// struct so adding flags is a one-line schema change instead of a
+/// signature shuffle.
+#[derive(Debug, Clone)]
+pub struct FsOptions {
+    pub host_filter: Option<String>,
+    pub replica: usize,
+    /// Mountpoint on the operator's machine. `None` → defaults to
+    /// `/tmp/yoink-fs/<service>/`.
+    pub to: Option<PathBuf>,
+    /// Mount read-write. Default is read-only — writes through
+    /// the merged view race with the running app's writes (file
+    /// locks, truncation, log rotation), so opting in is loud.
+    pub rw: bool,
+}
+
+/// Pick the running container that matches `(service, host, replica)`.
+/// Used by `cmd_fs` and reachable from tests via the `DockerOps`
+/// trait.
+pub async fn resolve_container(
+    ops: &dyn DockerOps,
+    host: &Host,
+    service: &str,
+    replica: usize,
+) -> Result<String, FsError> {
+    let label = format!("yoink.service={service}");
+    let mut containers = ops.list_containers_by_label(host, &label).await?;
+    // Sort for deterministic replica indexing — list_containers_by_label
+    // ordering is daemon-defined, which would otherwise make `--replica 1`
+    // non-deterministic across calls on a multi-replica deploy.
+    containers.sort_by(|a, b| a.name.cmp(&b.name));
+    let running: Vec<_> = containers
+        .into_iter()
+        .filter(|c| c.state == "running")
+        .collect();
+    if running.is_empty() {
+        return Err(FsError::NoRunningContainer {
+            service: service.to_string(),
+            host: host.address.clone(),
+        });
+    }
+    let found = running.len();
+    running
+        .into_iter()
+        .nth(replica)
+        .map(|c| c.name)
+        .ok_or(FsError::ReplicaOutOfRange {
+            service: service.to_string(),
+            host: host.address.clone(),
+            replica,
+            found,
+        })
+}
+
+/// Extract the host-side path that mirrors the container's running
+/// rootfs. Errors loudly when the storage driver isn't overlay2 or
+/// when the daemon didn't populate `MergedDir` (rare; would need an
+/// older daemon or a transient inspect race).
+pub fn merged_dir<'d>(
+    detail: &'d ContainerDetail,
+    container: &str,
+    host_addr: &str,
+) -> Result<&'d str, FsError> {
+    let GraphDriverInfo { name, data } =
+        detail
+            .graph_driver
+            .as_ref()
+            .ok_or_else(|| FsError::NoMergedDir {
+                container: container.to_string(),
+                host: host_addr.to_string(),
+            })?;
+    if name != "overlay2" {
+        return Err(FsError::UnsupportedStorageDriver {
+            container: container.to_string(),
+            host: host_addr.to_string(),
+            driver: name.clone(),
+        });
+    }
+    data.get("MergedDir")
+        .map(String::as_str)
+        .ok_or_else(|| FsError::NoMergedDir {
+            container: container.to_string(),
+            host: host_addr.to_string(),
+        })
+}
+
+/// Where to mount on the operator's machine when `--to` is unset.
+#[must_use]
+pub fn default_mountpoint(service: &str) -> PathBuf {
+    Path::new(DEFAULT_MOUNT_ROOT).join(service)
+}
+
+/// Spawn `sshfs` in the foreground and return the child handle. The
+/// returned process owns the FUSE mount; killing it (Ctrl-C, drop)
+/// tears the mount down. Caller is responsible for ensuring
+/// `mountpoint` exists as an empty dir.
+pub async fn spawn_sshfs(
+    user: &str,
+    host_addr: &str,
+    remote_dir: &str,
+    mountpoint: &Path,
+    keyfile: Option<&Path>,
+    rw: bool,
+) -> Result<tokio::process::Child, FsError> {
+    let endpoint = format!("{user}@{host_addr}:{remote_dir}");
+    let mut cmd = Command::new("sshfs");
+    cmd.arg(&endpoint).arg(mountpoint);
+    // -f: foreground (no daemonize) — the process IS the FUSE handler;
+    //     killing it propagates to the kernel and unmounts cleanly.
+    // -o BatchMode=yes / ConnectTimeout=10 / idmap=user — same posture
+    //     as the SshTunnel (`transport/tunnel.rs`), with idmap
+    //     remapping container-side UIDs onto the operator's so files
+    //     don't show as nobody:nogroup.
+    let mut opts: Vec<String> = vec![
+        "BatchMode=yes".into(),
+        "ConnectTimeout=10".into(),
+        "idmap=user".into(),
+        "reconnect".into(),
+    ];
+    if !rw {
+        opts.push("ro".into());
+    }
+    if let Some(key) = keyfile {
+        opts.push(format!("IdentityFile={}", key.display()));
+        opts.push("IdentitiesOnly=yes".into());
+    }
+    cmd.arg("-f");
+    cmd.arg("-o").arg(opts.join(","));
+    cmd.stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped())
+        .kill_on_drop(true);
+    let child = cmd.spawn().map_err(|e| {
+        if e.kind() == std::io::ErrorKind::NotFound {
+            FsError::SshfsMissing
+        } else {
+            FsError::Io(e)
+        }
+    })?;
+    Ok(child)
+}
+
+/// Tear down a mountpoint. Picks the right tool for the OS:
+/// `fusermount -u` on Linux (no root needed; the user that mounted
+/// is the user that can unmount), `umount` on macOS / BSD. Best-effort
+/// — caller already SIGKILL'd the sshfs child, this is the explicit
+/// cleanup belt to its suspenders.
+pub async fn unmount(mountpoint: &Path) -> Result<(), FsError> {
+    let (program, args): (&str, Vec<&str>) = if cfg!(target_os = "linux") {
+        ("fusermount", vec!["-u", mountpoint.to_str().unwrap_or("")])
+    } else {
+        ("umount", vec![mountpoint.to_str().unwrap_or("")])
+    };
+    let result = tokio::time::timeout(
+        UNMOUNT_TIMEOUT,
+        Command::new(program)
+            .args(&args)
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status(),
+    )
+    .await;
+    match result {
+        Ok(Ok(status)) if status.success() => Ok(()),
+        Ok(Ok(status)) => {
+            // Non-zero exit usually means "already unmounted" (sshfs
+            // child died and propagated the umount). Log and shrug.
+            tracing::debug!(target: "yoink::fs", %status, ?mountpoint, "unmount returned non-zero");
+            Ok(())
+        }
+        Ok(Err(e)) => Err(FsError::Io(e)),
+        Err(_) => {
+            tracing::warn!(target: "yoink::fs", ?mountpoint, "unmount timed out — try `umount -f` manually");
+            Ok(())
+        }
+    }
+}
+
+/// `true` when `path` looks like a stale FUSE mount: the dir exists
+/// but `metadata` returns "transport endpoint not connected" (errno
+/// 107 / `ENOTCONN`). Caller can offer to reap it before remounting.
+pub fn is_stale_fuse_mount(path: &Path) -> bool {
+    match std::fs::metadata(path) {
+        Ok(_) => false,
+        Err(e) => {
+            // ENOTCONN on Linux, ENXIO on macOS — both surface as
+            // io::Error::raw_os_error() values that aren't NotFound.
+            // Heuristic: any non-`NotFound` error on a path that
+            // exists as a directory entry suggests "broken mount".
+            !matches!(
+                e.kind(),
+                std::io::ErrorKind::NotFound | std::io::ErrorKind::PermissionDenied
+            ) && path.exists()
+        }
+    }
+}
+
+/// Make sure `mountpoint` is an empty, ready-to-use directory.
+/// Reaps a stale FUSE mount in place. Errors when the dir is non-
+/// empty for non-stale-mount reasons (looks like the operator put
+/// real files there).
+pub async fn prepare_mountpoint(mountpoint: &Path) -> Result<(), FsError> {
+    if is_stale_fuse_mount(mountpoint) {
+        tracing::info!(target: "yoink::fs", ?mountpoint, "reaping stale FUSE mount before remount");
+        unmount(mountpoint).await?;
+    }
+    if !mountpoint.exists() {
+        std::fs::create_dir_all(mountpoint)?;
+        return Ok(());
+    }
+    if !mountpoint.is_dir() {
+        return Err(FsError::MountpointBusy(mountpoint.to_path_buf()));
+    }
+    let entries = std::fs::read_dir(mountpoint)?.next();
+    match entries {
+        None => Ok(()),
+        Some(_) => Err(FsError::MountpointBusy(mountpoint.to_path_buf())),
+    }
+}
+
+/// `cmd_fs` resolves the target, inspects it, prepares the
+/// mountpoint, spawns sshfs, prints the URL-equivalent message,
+/// and holds open until Ctrl-C. On shutdown: kill the sshfs child,
+/// run `unmount` to be sure.
+#[allow(clippy::too_many_lines)] // single linear flow, mirroring cmd_pf
+pub async fn cmd_fs(
+    config: &Config,
+    service_name: &str,
+    opts: FsOptions,
+    ops: std::sync::Arc<dyn DockerOps>,
+) -> anyhow::Result<()> {
+    let service = config
+        .services
+        .iter()
+        .find(|s| s.name == service_name)
+        .ok_or_else(|| FsError::ServiceNotFound(service_name.to_string()))?;
+
+    let applicable: Vec<_> = service
+        .applicable_hosts(&config.hosts)
+        .into_iter()
+        .filter(|h| opts.host_filter.as_deref().is_none_or(|f| f == h.address))
+        .collect();
+    let host_cfg = match applicable.as_slice() {
+        [] => anyhow::bail!(
+            "service {service_name:?} has no applicable host{}",
+            opts.host_filter
+                .as_deref()
+                .map_or(String::new(), |f| format!(" matching --host={f}")),
+        ),
+        [single] => *single,
+        many if opts.host_filter.is_some() => many[0],
+        many => anyhow::bail!(
+            "service {service_name:?} runs on {} hosts; pin one with --host:\n{}",
+            many.len(),
+            many.iter()
+                .map(|h| format!("  {}", h.address))
+                .collect::<Vec<_>>()
+                .join("\n"),
+        ),
+    };
+
+    let host = Host::from(host_cfg);
+    if host.address == Host::LOCAL_ADDRESS {
+        anyhow::bail!(
+            "service {service_name:?} runs on `address: local` (the local docker socket), \
+             which has no SSH endpoint to mount through. `yoink fs` is for remote hosts; \
+             use `docker cp` or bind-mount the path locally instead."
+        );
+    }
+    let keyfile = ops.ssh_keyfile(&host);
+    crate::ssh_probe::probe(&host, keyfile.as_deref().and_then(|p| p.to_str()))
+        .await
+        .map_err(|e| anyhow::anyhow!("ssh probe to {}: {e}", host.address))?;
+
+    let container = resolve_container(&*ops, &host, service_name, opts.replica).await?;
+    let detail = ops.inspect_container(&host, &container).await?;
+    let merged = merged_dir(&detail, &container, &host.address)?;
+
+    let mountpoint = opts
+        .to
+        .clone()
+        .unwrap_or_else(|| default_mountpoint(service_name));
+    prepare_mountpoint(&mountpoint).await?;
+
+    if opts.rw {
+        eprintln!(
+            "⚠ mounting {} read-write — writes can race with the running app's writes \
+             (file locks, truncation, log rotation). Ctrl-C to abort.",
+            container
+        );
+    }
+
+    let mut child = spawn_sshfs(
+        &host.user,
+        &host.address,
+        merged,
+        &mountpoint,
+        keyfile.as_deref(),
+        opts.rw,
+    )
+    .await?;
+
+    eprintln!(
+        "→ {service_name} (replica {}) on {} ⇆ {}{}\n  Ctrl-C to unmount",
+        opts.replica,
+        host.address,
+        mountpoint.display(),
+        if opts.rw { " [rw]" } else { " [ro]" },
+    );
+
+    // Race: sshfs failure (network drop, permission denied) vs
+    // operator Ctrl-C. Whichever fires first wins; both paths run
+    // the cleanup.
+    tokio::select! {
+        status = child.wait() => {
+            let exit = status.context("waiting on sshfs")?;
+            if exit.success() {
+                // sshfs exited cleanly on its own (rare; usually means
+                // the daemon was killed by something else). Treat as
+                // graceful shutdown.
+                eprintln!("\n✓ unmounted (sshfs exited)");
+            } else {
+                let mut stderr = String::new();
+                if let Some(mut s) = child.stderr.take() {
+                    use tokio::io::AsyncReadExt;
+                    let _ = s.read_to_string(&mut stderr).await;
+                }
+                let _ = unmount(&mountpoint).await;
+                return Err(FsError::SshfsFailed {
+                    status: exit.to_string(),
+                    stderr,
+                }
+                .into());
+            }
+        }
+        _ = tokio::signal::ctrl_c() => {
+            // Order: SIGTERM the sshfs child (its SIGINT handler
+            // should umount and exit), then explicit umount as the
+            // belt to that suspenders, then drop the child. The
+            // explicit umount survives the case where the child was
+            // already wedged.
+            let _ = child.start_kill();
+            let _ = unmount(&mountpoint).await;
+            let _ = child.wait().await;
+            eprintln!("\n✓ unmounted");
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::BTreeMap;
+
+    fn make_detail(driver: &str, merged_dir: Option<&str>) -> ContainerDetail {
+        let mut data = BTreeMap::new();
+        if let Some(m) = merged_dir {
+            data.insert("MergedDir".into(), m.into());
+            data.insert("UpperDir".into(), format!("{m}/../upper"));
+        }
+        ContainerDetail {
+            name: "api-aaa".into(),
+            graph_driver: Some(GraphDriverInfo {
+                name: driver.into(),
+                data,
+            }),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn merged_dir_overlay2_returns_path() {
+        let d = make_detail("overlay2", Some("/var/lib/docker/overlay2/abc/merged"));
+        let path = merged_dir(&d, "api-aaa", "host-1").expect("ok");
+        assert_eq!(path, "/var/lib/docker/overlay2/abc/merged");
+    }
+
+    #[test]
+    fn merged_dir_rejects_btrfs() {
+        let d = make_detail("btrfs", None);
+        let err = merged_dir(&d, "api-aaa", "host-1").unwrap_err();
+        let msg = format!("{err}");
+        assert!(msg.contains("btrfs"), "got: {msg}");
+        assert!(msg.contains("overlay2 today"), "got: {msg}");
+    }
+
+    #[test]
+    fn merged_dir_overlay2_without_mergeddir_errors() {
+        let d = make_detail("overlay2", None);
+        let err = merged_dir(&d, "api-aaa", "host-1").unwrap_err();
+        let msg = format!("{err}");
+        assert!(msg.contains("no MergedDir"), "got: {msg}");
+    }
+
+    #[test]
+    fn merged_dir_no_graph_driver_errors() {
+        let d = ContainerDetail {
+            name: "api-aaa".into(),
+            graph_driver: None,
+            ..Default::default()
+        };
+        let err = merged_dir(&d, "api-aaa", "host-1").unwrap_err();
+        let msg = format!("{err}");
+        assert!(msg.contains("no MergedDir"), "got: {msg}");
+    }
+
+    #[test]
+    fn default_mountpoint_under_tmp() {
+        let mp = default_mountpoint("api");
+        assert_eq!(mp, Path::new("/tmp/yoink-fs/api"));
+    }
+
+    #[tokio::test]
+    async fn prepare_mountpoint_creates_missing_dir() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let mp = tmp.path().join("nested/api");
+        prepare_mountpoint(&mp).await.expect("prepare ok");
+        assert!(mp.is_dir());
+    }
+
+    #[tokio::test]
+    async fn prepare_mountpoint_rejects_non_empty_dir() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let mp = tmp.path().join("api");
+        std::fs::create_dir(&mp).unwrap();
+        std::fs::write(mp.join("oops"), b"x").unwrap();
+        let err = prepare_mountpoint(&mp).await.unwrap_err();
+        assert!(matches!(err, FsError::MountpointBusy(_)));
+    }
+
+    fn make_container(name: &str, state: &str) -> crate::docker_ops::ContainerInfo {
+        crate::docker_ops::ContainerInfo {
+            host: "h1".into(),
+            name: name.into(),
+            image: String::new(),
+            state: state.into(),
+            status_text: String::new(),
+            created_unix: None,
+            yoink_service: Some("api".into()),
+            yoink_version: None,
+            yoink_spec_hash: None,
+            yoink_deployed_by: None,
+            yoink_deployed_at: None,
+            networks: Vec::new(),
+            other_labels: BTreeMap::new(),
+        }
+    }
+
+    #[tokio::test]
+    async fn resolve_container_picks_replica_by_sorted_name() {
+        use crate::docker_ops::FakeDockerOps;
+        let ops = FakeDockerOps::new();
+        let host = Host {
+            user: "u".into(),
+            address: "h1".into(),
+        };
+        ops.push_list_containers(Ok(vec![
+            make_container("api-bbb", "running"),
+            make_container("api-aaa", "running"),
+            make_container("api-ccc", "exited"),
+        ]));
+        // Sorted: aaa, bbb (ccc filtered as exited). Replica 0 → aaa.
+        let name = resolve_container(&ops, &host, "api", 0)
+            .await
+            .expect("resolve ok");
+        assert_eq!(name, "api-aaa");
+    }
+
+    #[tokio::test]
+    async fn resolve_container_replica_out_of_range() {
+        use crate::docker_ops::FakeDockerOps;
+        let ops = FakeDockerOps::new();
+        let host = Host {
+            user: "u".into(),
+            address: "h1".into(),
+        };
+        ops.push_list_containers(Ok(vec![make_container("api-aaa", "running")]));
+        let err = resolve_container(&ops, &host, "api", 5).await.unwrap_err();
+        assert!(matches!(err, FsError::ReplicaOutOfRange { .. }));
+    }
+}

--- a/yoink/src/fs.rs
+++ b/yoink/src/fs.rs
@@ -73,7 +73,8 @@ pub enum FsError {
     )]
     NoMergedDir { container: String, host: String },
     #[error(
-        "`sshfs` not found on PATH — install macFUSE / FUSE-T (macOS) or `apt install sshfs` (Linux)"
+        "`sshfs` not found on PATH — `brew install --cask fuse-t-sshfs` on macOS, \
+         `apt install sshfs` (or distro equivalent) on Linux"
     )]
     SshfsMissing,
     #[error("sshfs exited with status {status}{stderr}", stderr = if .stderr.is_empty() { String::new() } else { format!(":\n{}", .stderr) })]

--- a/yoink/src/lib.rs
+++ b/yoink/src/lib.rs
@@ -8,6 +8,7 @@ pub mod docker;
 pub mod docker_ops;
 pub mod doctor;
 pub mod files;
+pub mod fs;
 pub mod git;
 pub mod healthcheck;
 pub mod init;

--- a/yoink/src/main.rs
+++ b/yoink/src/main.rs
@@ -489,6 +489,45 @@ enum Command {
         #[arg(long, value_enum, default_value_t = PfMode::Auto)]
         mode: PfMode,
     },
+    /// Mount a running container's filesystem on your laptop via
+    /// SSH+FUSE. Like `pf` but for files: ctrl-c unmounts cleanly,
+    /// replica selection mirrors `pf`'s.
+    ///
+    /// Read-only by default — writes through the merged-fs view
+    /// race with the running app's writes (file locks, log rotation,
+    /// truncation). Pass `--rw` to opt in (with a loud warning).
+    ///
+    /// Requires `sshfs` on the operator's machine and the host's
+    /// docker storage driver to be `overlay2`. Other storage drivers
+    /// fail loudly — see `yoink doctor` for the install hint.
+    ///
+    /// Examples:
+    ///   yoink fs api                     # /tmp/yoink-fs/api/  (ro)
+    ///   yoink fs api --to ./api-fs       # explicit mountpoint
+    ///   yoink fs api --rw                # rw, with warning
+    ///   yoink fs api -r 1                # replica 1
+    Fs {
+        /// Service name as declared in the config.
+        service: String,
+        /// Pin to a specific host when the service runs on multiple.
+        #[arg(long)]
+        host: Option<String>,
+        /// Replica index (0-based) for services with `replicas: > 1`.
+        #[arg(short = 'r', long, default_value_t = 0)]
+        replica: usize,
+        /// Mountpoint on your laptop. Defaults to
+        /// `/tmp/yoink-fs/<service>/`. Created if missing; must be
+        /// empty if it exists (or contain only a stale FUSE mount,
+        /// which we'll reap before remounting).
+        #[arg(long)]
+        to: Option<std::path::PathBuf>,
+        /// Mount read-write. Default is read-only — writes through
+        /// `merged` mutate the running container's filesystem and
+        /// can corrupt running app state. Yoink prints a warning
+        /// before the mount completes when this is set.
+        #[arg(long)]
+        rw: bool,
+    },
     /// Like `shell` but spawns an `alpine` debug sidecar in the
     /// target's pid+net namespaces — for distroless / shell-less
     /// images. The sidecar is `--rm` and is force-removed on exit.
@@ -1248,6 +1287,28 @@ async fn run(cli: Cli) -> Result<()> {
                 scheme.into(),
                 json,
                 mode.into(),
+            )
+            .await
+        }
+        Command::Fs {
+            service,
+            host,
+            replica,
+            to,
+            rw,
+        } => {
+            let ops: std::sync::Arc<dyn yoink::docker_ops::DockerOps> =
+                std::sync::Arc::new(build_real_ops(&config, None).await?);
+            yoink::fs::cmd_fs(
+                &config,
+                &service,
+                yoink::fs::FsOptions {
+                    host_filter: host,
+                    replica,
+                    to,
+                    rw,
+                },
+                ops,
             )
             .await
         }


### PR DESCRIPTION
## Status: parked — blocked by Docker's storage-driver direction

Opening as a draft PR to preserve the design exploration and code. **Do not merge.** A follow-up PR will pivot to a different mechanism; this branch is the artefact of a useful smoke-test that found a real bug before merge.

## What this branch contains

A first cut at `yoink fs <service>` — operator runs the command, the container's filesystem mounts at `/tmp/yoink-fs/<service>/` via SSH+FUSE, ctrl-c unmounts. Same UX shape as `yoink pf`. Read-only by default; `--rw` opts in.

Mechanism:

1. Inspect the target container; read `GraphDriver.Data["MergedDir"]` (the host overlay2 path that mirrors the container's full rootfs).
2. `sshfs <user>@<host>:<MergedDir> <local-mountpoint>` over the same SSH credentials yoink already uses.
3. Hold the foreground sshfs process until ctrl-c; explicit `fusermount -u` / `umount` on shutdown.

What's done in the branch:

- `yoink/src/fs.rs` (~370 LOC + 9 unit tests): `cmd_fs`, `resolve_container`, `merged_dir`, `prepare_mountpoint`, `spawn_sshfs`, `unmount`, stale-mount detection.
- `ContainerDetail` extended with `graph_driver: Option<GraphDriverInfo>` (additive).
- CLI subcommand wired in `main.rs` next to `Pf`.
- Doctor warns when `sshfs` isn't on operator's PATH (`brew install --cask fuse-t-sshfs` hint on macOS).
- `docs/content/docs/how-to/fs.md` written via the yoink-docs skill.
- Storage-driver guard refusing non-overlay2; `address: local` rejected with an actionable error; per-OS unmount dispatch.
- 448 lib tests green + fmt clean + clippy clean (no new warnings).

## Why blocked

End-to-end smoke against a fresh Hetzner cax11 (Ubuntu 24.04 + Docker 29.4 via Docker's official apt repo — the canonical \"production server\" install) found that the design's foundational assumption no longer holds:

\`\`\`
$ docker info --format 'Driver: {{.Driver}}, Version: {{.ServerVersion}}'
Driver: overlayfs, Version: 29.4.1

$ docker run -d --name probe alpine sleep 60
$ docker inspect probe --format '{{json .GraphDriver}}'
null
\`\`\`

Docker 28+ ships with the **containerd image-store snapshotter** (\`overlayfs\`) as the default. The classic \`overlay2\` graphdriver is still available behind \`{\"features\": {\"containerd-snapshotter\": false}}\` in \`/etc/docker/daemon.json\`, but:

- It's not the default. Vanilla \`apt install docker-ce\` gives you the snapshotter.
- The snapshotter doesn't expose \`GraphDriver.Data.MergedDir\` (containerd snapshots are addressed by content hash, not container id; there's no stable host-side union path).
- Docker is moving in this direction; the legacy graphdriver is on its way out.

Tested on three independent environments — all three returned \`GraphDriver: null\`:

| Environment | Driver | MergedDir? |
|---|---|---|
| Docker Desktop on Mac | \`overlayfs\` | null |
| \`docker:dind\` 29.4 (server-flavour Docker in a container) | \`overlayfs\` | null |
| Fresh Hetzner cax11 + Ubuntu 24.04 + Docker 29.4 from apt | \`overlayfs\` | null |

So the feature on this branch ships a hard runtime dependency on a daemon configuration most users don't have and won't enable just for a debug-time mount.

## What the smoke test paid for

This isn't a wasted branch even though it doesn't merge:

- **Found a real bug before merge.** 9 unit tests + a careful design review didn't catch this; an end-to-end smoke against a real Hetzner box did. Confirmation that smoke tests against the actual target environment beat unit-test depth for design-validation questions.
- **Mapped the design space.** We now know: kernel-FUSE-via-sshfs is dead-end on modern Docker. A Rust FUSE crate doesn't help (it still needs FUSE-T/macFUSE installed and reads the same daemon-side API). A sidecar with \`--volumes-from\` only sees declared volumes, not the rw layer.
- **Identified the path forward** (out of scope for this PR; see below).

## What we'd ship if/when we come back

The pivot the smoke earned us: a **one-way mirror** that doesn't touch host filesystem paths at all.

\`\`\`
yoink fs api
# 1. snapshot the container's fs to /tmp/yoink-fs/api/ via `docker exec tar -c`
# 2. watch the local mirror with the `notify` Rust crate (FSEvents on macOS,
#    inotify on Linux — both userland, no kernel module)
# 3. on save, stream the changed file back via `docker exec sh -c \"cat > /path\"`
# 4. ctrl-c stops watching; files stay on disk for offline reference
\`\`\`

Trade-offs vs the sshfs design on this branch:

- **Storage-driver independent.** \`docker exec tar\` works on overlay2, overlayfs/snapshotter, btrfs, zfs, anything.
- **Zero operator install.** No \`sshfs\`, no FUSE, no kext, no \`brew install\`.
- **Live editing still works** (the \"magical\" property): operator save → \`notify\` event → exec push, ~10ms latency end-to-end.
- **Loses live tail of container-originated changes.** Operator has to re-run \`yoink fs\` to refresh. Acceptable for inspect-and-edit; for live-tail use cases a separate \`yoink tail\` is the answer.
- **Smaller surface.** Drop the doctor sshfs check, the storage-driver guard, the \`address: local\` rejection, the per-OS unmount dispatch.

Implementation cost: ~250-400 LOC, replaces this branch's ~370 LOC roughly 1:1. CLI surface (\`yoink fs <service> [--host] [--replica] [--to] [--rw]\`) and the doc page stay identical from the user's perspective.

## How to pick this back up

Two options:

1. **Reuse this branch's plumbing.** Keep \`ContainerDetail::graph_driver\` (it's still useful for diagnostics), \`resolve_container\`, the CLI variant, the doc page. Replace \`merged_dir\` + \`spawn_sshfs\` + \`unmount\` with the snapshot+notify+push pieces. Roughly 60% of this branch survives.
2. **Start fresh.** Cherry-pick the doc framing and the CLI skeleton; drop the sshfs path and the FUSE-related modules.

I'd lean (1) — the branch's CLI shape, the \`FsOptions\` struct, the host-resolution code, and the doc page all transfer cleanly. The sshfs subprocess and FUSE-specific error paths are the only things that go.

## Test plan (for when this is unblocked)

- Unit tests: keep the existing 9, add tests for the snapshot tar-pipe, the notify-event-to-exec-push round-trip, the path filtering (skip /proc, /sys, /dev).
- Integration: a real Hetzner box again, this time with no special docker config required. \`yoink up\` a container, \`yoink fs\` it, edit a file in the local mirror, observe the change inside the container via \`docker exec\`.