### PR TITLE
docs: move site to https://yoink.is custom domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,15 +11,15 @@ yoink history api         # who deployed what, when
 yoink rollback api        # roll back to the previous version
 ```
 
-## 📚 Full docs: <https://oddur.github.io/yoink/>
+## 📚 Full docs: <https://yoink.is/>
 
-The README is a pointer; the [docs site](https://oddur.github.io/yoink/) is canonical.
+The README is a pointer; the [docs site](https://yoink.is/) is canonical.
 
-- [Is this for me?](https://oddur.github.io/yoink/docs/intro/compared) — vs. Kamal, Kubernetes, plain compose
-- [Five-minute first deploy](https://oddur.github.io/yoink/docs/start/first-deploy) — install + run
-- [Three deploy modes](https://oddur.github.io/yoink/docs/guide/deploy-modes), [Secure by default](https://oddur.github.io/yoink/docs/guide/security), [Pairing with Tailscale + caddy](https://oddur.github.io/yoink/docs/guide/networking)
-- [Recipes](https://oddur.github.io/yoink/docs/recipes) — staging alongside prod, self-hosted registry, external secrets via CLI, PR-comment dry-run
-- [Reference](https://oddur.github.io/yoink/docs/reference) — CLI / config schema / TUI keybinds
+- [Is this for me?](https://yoink.is/docs/intro/compared) — vs. Kamal, Kubernetes, plain compose
+- [Five-minute first deploy](https://yoink.is/docs/start/first-deploy) — install + run
+- [Three deploy modes](https://yoink.is/docs/guide/deploy-modes), [Secure by default](https://yoink.is/docs/guide/security), [Pairing with Tailscale + caddy](https://yoink.is/docs/guide/networking)
+- [Recipes](https://yoink.is/docs/recipes) — staging alongside prod, self-hosted registry, external secrets via CLI, PR-comment dry-run
+- [Reference](https://yoink.is/docs/reference) — CLI / config schema / TUI keybinds
 
 ## Install
 
@@ -29,7 +29,7 @@ brew install oddur/yoink/yoink
 
 Or `cargo install --git https://github.com/oddur/yoink yoink`. Or curl-pipe-sh: `curl -LsSf https://github.com/oddur/yoink/releases/latest/download/yoink-installer.sh | sh`.
 
-See the [install page](https://oddur.github.io/yoink/docs/start/install) for the full list and prerequisites.
+See the [install page](https://yoink.is/docs/start/install) for the full list and prerequisites.
 
 ## License
 

--- a/docs/hugo.yaml
+++ b/docs/hugo.yaml
@@ -2,7 +2,7 @@
 # GitHub Pages off the `oddur/yoink` repo (no custom domain). The
 # Hextra theme is pulled in as a Hugo module — `hugo mod tidy` resolves
 # it from the registry; `hugo --gc --minify` builds for prod.
-baseURL: "https://oddur.github.io/yoink/"
+baseURL: "https://yoink.is/"
 title: 🪝 yoink
 languageCode: en-us
 

--- a/docs/layouts/_partials/shortcodes/card.html
+++ b/docs/layouts/_partials/shortcodes/card.html
@@ -21,11 +21,11 @@
 {{/*
   Override of Hextra's upstream `card.html`. The upstream calls
   `relURL "/docs/foo"`, but Hugo treats a leading slash as "from
-  origin" and skips the baseURL's path component — on a project page
-  at `https://oddur.github.io/yoink/` it yields `/docs/foo` (404)
-  instead of `/yoink/docs/foo`. The fix Hextra itself uses for
-  images is to trim the leading slash before `relURL`, which then
-  prepends the full baseURL path. Mirror that here.
+  origin" and skips the baseURL's path component. Harmless on a
+  root-domain like `https://yoink.is/`, but breaks on any
+  project-page subpath. The fix Hextra itself uses for images is to
+  trim the leading slash before `relURL`, which then prepends the
+  full baseURL path. Mirror that here.
 */}}
 {{- $href := cond
     (strings.HasPrefix $link "/")

--- a/docs/static/CNAME
+++ b/docs/static/CNAME
@@ -1,0 +1,1 @@
+yoink.is


### PR DESCRIPTION
## Summary

Wires the Hugo + Hextra docs site to the new **yoink.is** GitHub Pages custom domain.

- `baseURL` in `docs/hugo.yaml` → `https://yoink.is/`
- New `docs/static/CNAME` containing `yoink.is`. Hugo copies `static/` verbatim into `public/`, and GitHub Pages reads `CNAME` on every deploy — without this file, the first push after enabling the custom domain in repo settings would strip it.
- `README.md` absolute links rewritten from `oddur.github.io/yoink` to `yoink.is`.
- `card.html` shortcode comment updated — the project-page subpath workaround is no longer load-bearing on a root domain (still harmless, kept for forwards-compatibility).

## What you still need to do (outside this PR)

1. **DNS**: point `yoink.is` at GitHub Pages
   - Apex (`yoink.is` → 4 GitHub A records: `185.199.108.153`, `185.199.109.153`, `185.199.110.153`, `185.199.111.153`), or
   - CNAME on `www.yoink.is` → `oddur.github.io` if you'd rather use a subdomain.
2. **Repo settings → Pages → Custom domain**: enter `yoink.is`. GitHub validates DNS, then ticks "Enforce HTTPS" once the LE cert lands (a few minutes after DNS propagates).

After that, this PR's `CNAME` file ensures every subsequent docs deploy preserves the custom-domain binding.

## Test plan

- [x] `hugo --gc` builds clean.
- [x] Built `public/CNAME` contains `yoink.is`.
- [x] Built `og:url` resolves to `https://yoink.is/`.
- [ ] After merge + DNS, the GitHub Pages deploy at `yoink.is` serves with valid HTTPS.