### PR TITLE
feat(config): hosts[].address_secret for sealed host addresses

### DIFF
--- a/docs/content/docs/reference/config.md
+++ b/docs/content/docs/reference/config.md
@@ -21,9 +21,12 @@ Full schema for `yoink.yaml`. Canonical source: [`yoink/src/config.rs`](https://
 
 ## Host
 
+Each host needs an address; that can be either a literal `address:` or, for cases where the address itself is sensitive (a public IP that you front through Cloudflare, a tailnet hostname you'd rather not commit), a sealed-secret reference via `address_secret:`. Set exactly one — neither or both is rejected at config load.
+
 | Field | Type | Notes |
 |---|---|---|
-| `address` | string | Hostname or IP. Anything your local SSH client accepts: a raw IP, a DNS name, a `~/.ssh/config` alias, or a tailnet hostname. |
+| `address` | string | Hostname or IP. Anything your local SSH client accepts: a raw IP, a DNS name, a `~/.ssh/config` alias, or a tailnet hostname. Mutually exclusive with `address_secret`. |
+| `address_secret` | string (optional) | Name of an entry in your sealed-secrets bundle holding the host's address (IP or hostname). Resolved at config-load time after the bundle decrypts. Use this when the deploy config sits in a public repo and the host's address is sensitive. Mutually exclusive with `address`. |
 | `user` | string | SSH user. Must be in the `docker` group on the host (or be `root`). |
 | `ssh_key_secret` | string (optional) | Name of an entry in your sealed-secrets bundle holding a PEM-formatted SSH private key. When set, yoink decrypts the key into a per-process tempfile (mode `0o600`) and uses it for this host's SSH connections — both the docker daemon connection and the pre-flight ssh probe. Lets you ship the deploy key with the repo (encrypted at rest in `secrets.age`) instead of relying on every operator's personal `ssh-agent`. |
 
@@ -37,7 +40,15 @@ hosts:
   - address: 1.2.3.4
     user: root
     ssh_key_secret: PROD_HOST_SSH_KEY
+
+  # Address-in-repo-too flavour: the IP lives in `secrets.age`,
+  # never in the committed yaml. Resolved at deploy time.
+  - address_secret: DOCS_HOST_IP
+    user: deploy
+    ssh_key_secret: DOCS_DEPLOY_SSH_KEY
 ```
+
+`yoink hosts add --address-secret <KEY> --user <USER> --name <NAME>` writes the sealed-address fragment shape. `--name` is required (no literal address to derive a fragment filename from).
 
 ## Deploy
 

--- a/docs/content/docs/reference/glossary.md
+++ b/docs/content/docs/reference/glossary.md
@@ -73,6 +73,8 @@ Cross-cutting terms. Each entry is one paragraph with a link to the page that co
 
 **`ssh_key_secret:`.** A field on a host entry naming a sealed-secret entry holding a PEM SSH private key. Yoink decrypts the key into a per-process tempfile for SSH instead of using the operator's ssh-agent. Pair with `yoink secrets ssh-key generate --seal-as <NAME>`.
 
+**`address_secret:`.** A field on a host entry naming a sealed-secret entry holding the host's address (IP or hostname). Resolved at config-load time from the same sealed bundle that feeds `ssh_key_secret:`. Use when the deploy config sits in a public repo and the host's address itself is sensitive. Mutually exclusive with `address:`. Pair with `yoink hosts add --address-secret <KEY> --user <USER> --name <NAME>`.
+
 **`include:` glob.** Top-level list of file globs relative to `yoink.yaml`. Each matched file is parsed as a fragment and its `services:`, `hosts:`, and `hooks.pre_deploy:` lists merge into the main config.
 
 ## Templates

--- a/yoink/src/config.rs
+++ b/yoink/src/config.rs
@@ -135,7 +135,21 @@ pub enum OnFailure {
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct HostConfig {
+    /// Literal address (IP or hostname). Mutually exclusive with
+    /// `address_secret`. Empty until populated either by the parsed
+    /// YAML or by `Config::resolve_host_addresses` after the sealed
+    /// bundle loads.
+    #[serde(default)]
     pub address: String,
+    /// Optional: name of a sealed-secret entry holding the host's
+    /// address (IP or hostname). Resolved at config-load time after
+    /// the secrets bundle is decrypted. Use this when the deploy
+    /// config sits in a public repo and the host's address itself is
+    /// sensitive (e.g. a Hetzner box with an exposed public IP that
+    /// you front through Cloudflare). Mutually exclusive with the
+    /// literal `address:` field — set exactly one.
+    #[serde(default)]
+    pub address_secret: Option<String>,
     pub user: String,
     /// Optional: name of a sealed-secret entry holding an SSH private
     /// key (PEM format) to use when connecting to this host. When set,
@@ -1264,6 +1278,54 @@ impl Config {
         Ok(())
     }
 
+    /// `true` when at least one host declares `address_secret:`.
+    /// Used by the secrets loader to know it must decrypt the bundle
+    /// even if no service-level secret keys are referenced.
+    #[must_use]
+    pub fn any_host_address_sealed(&self) -> bool {
+        self.hosts.iter().any(|h| h.address_secret.is_some())
+    }
+
+    /// Walk hosts and populate `host.address` from the sealed bundle
+    /// for any host that declared `address_secret:`. Idempotent —
+    /// calling twice is safe (the second call sees `address_secret`
+    /// still set but the field already populated; we re-resolve and
+    /// overwrite).
+    ///
+    /// Errors:
+    ///
+    /// - `address_secret` set but no bundle was loaded (caller must
+    ///   pass `Some(bundle)` whenever `any_host_address_sealed()` is
+    ///   true).
+    /// - `address_secret` references a key not present in the bundle.
+    pub fn resolve_host_addresses(
+        &mut self,
+        bundle: Option<&crate::secrets::SecretsBundle>,
+    ) -> Result<(), ConfigError> {
+        for (i, host) in self.hosts.iter_mut().enumerate() {
+            let Some(key) = host.address_secret.as_deref() else {
+                continue;
+            };
+            let Some(bundle) = bundle else {
+                return Err(ConfigError::Invalid(format!(
+                    "hosts[{i}].address_secret = {key:?} requires a sealed-secrets bundle, but no `secrets:` block is configured"
+                )));
+            };
+            let value = bundle.get(key).ok_or_else(|| {
+                ConfigError::Invalid(format!(
+                    "hosts[{i}].address_secret = {key:?} not found in the sealed bundle"
+                ))
+            })?;
+            if value.trim().is_empty() {
+                return Err(ConfigError::Invalid(format!(
+                    "hosts[{i}].address_secret = {key:?} resolved to an empty value"
+                )));
+            }
+            host.address = value.to_string();
+        }
+        Ok(())
+    }
+
     /// Walk `self.services` filtered by an optional name list. `None`
     /// returns every service in topo order; `Some(&[…])` keeps only
     /// the named ones (in topo order, not in the order the operator
@@ -1428,6 +1490,7 @@ impl Config {
         }
         self.hosts.push(HostConfig {
             address: local.to_string(),
+            address_secret: None,
             user: local.to_string(),
             ssh_key_secret: None,
         });
@@ -1494,10 +1557,23 @@ impl Config {
         // empty for a moment. Commands that need a host call
         // `Config::require_hosts` at their own boundary.
         for (i, host) in self.hosts.iter().enumerate() {
-            if host.address.trim().is_empty() {
-                return Err(ConfigError::Invalid(format!(
-                    "hosts[{i}].address must not be empty"
-                )));
+            let has_literal = !host.address.trim().is_empty();
+            let has_secret = host
+                .address_secret
+                .as_deref()
+                .is_some_and(|s| !s.trim().is_empty());
+            match (has_literal, has_secret) {
+                (false, false) => {
+                    return Err(ConfigError::Invalid(format!(
+                        "hosts[{i}]: set either `address:` or `address_secret:`"
+                    )));
+                }
+                (true, true) => {
+                    return Err(ConfigError::Invalid(format!(
+                        "hosts[{i}]: `address:` and `address_secret:` are mutually exclusive"
+                    )));
+                }
+                _ => {}
             }
             if host.user.trim().is_empty() {
                 return Err(ConfigError::Invalid(format!(
@@ -1505,15 +1581,39 @@ impl Config {
                 )));
             }
         }
-        let mut host_addresses: std::collections::HashSet<&str> = std::collections::HashSet::new();
+        // Duplicate detection runs against whatever identifier is
+        // present in the unresolved config — literal addresses are
+        // compared directly; sealed addresses are compared by
+        // secret-key name (two hosts naming the same address_secret
+        // would resolve to the same address). Address resolution
+        // happens later via `resolve_host_addresses`.
+        let mut host_keys: std::collections::HashSet<String> = std::collections::HashSet::new();
         for host in &self.hosts {
-            if !host_addresses.insert(host.address.as_str()) {
-                return Err(ConfigError::Invalid(format!(
-                    "duplicate hosts.address {:?}",
-                    host.address
-                )));
+            let key = if !host.address.trim().is_empty() {
+                format!("addr:{}", host.address)
+            } else if let Some(s) = host.address_secret.as_deref() {
+                format!("secret:{s}")
+            } else {
+                continue; // already errored above
+            };
+            if !host_keys.insert(key.clone()) {
+                let display = key
+                    .strip_prefix("addr:")
+                    .map(|a| format!("address {a:?}"))
+                    .or_else(|| {
+                        key.strip_prefix("secret:")
+                            .map(|s| format!("address_secret {s:?}"))
+                    })
+                    .unwrap_or(key);
+                return Err(ConfigError::Invalid(format!("duplicate host {display}")));
             }
         }
+        let host_addresses: std::collections::HashSet<&str> = self
+            .hosts
+            .iter()
+            .filter(|h| !h.address.trim().is_empty())
+            .map(|h| h.address.as_str())
+            .collect();
 
         // Top-level network declarations: each entry must be unique
         // and non-empty. Services can only attach to networks
@@ -2104,9 +2204,177 @@ hosts:
         ]);
         let err = Config::load_from_path(&dir.join("yoink.yaml")).unwrap_err();
         assert!(
-            format!("{err}").contains("duplicate hosts.address"),
+            format!("{err}").contains("duplicate host address"),
             "got: {err}"
         );
+    }
+
+    #[test]
+    fn host_address_secret_only_loads_ok() {
+        let dir = write_temp_tree(&[(
+            "yoink.yaml",
+            r#"
+deploy:
+  networks: [main]
+hosts:
+  - { address_secret: PROD_HOST_IP, user: deploy }
+secrets:
+  provider: age
+  recipients: [age1example]
+"#,
+        )]);
+        let cfg = Config::load_from_path(&dir.join("yoink.yaml")).expect("loads");
+        assert_eq!(cfg.hosts.len(), 1);
+        assert_eq!(cfg.hosts[0].address_secret.as_deref(), Some("PROD_HOST_IP"));
+        assert!(cfg.hosts[0].address.is_empty());
+        assert!(cfg.any_host_address_sealed());
+    }
+
+    #[test]
+    fn host_with_neither_address_nor_secret_is_rejected() {
+        let dir = write_temp_tree(&[(
+            "yoink.yaml",
+            r#"
+deploy:
+  networks: [main]
+hosts:
+  - { user: deploy }
+"#,
+        )]);
+        let err = Config::load_from_path(&dir.join("yoink.yaml")).unwrap_err();
+        let msg = format!("{err}");
+        assert!(
+            msg.contains("hosts[0]") && msg.contains("address") && msg.contains("address_secret"),
+            "got: {err}"
+        );
+    }
+
+    #[test]
+    fn host_with_both_address_and_secret_is_rejected() {
+        let dir = write_temp_tree(&[(
+            "yoink.yaml",
+            r#"
+deploy:
+  networks: [main]
+hosts:
+  - { address: 1.2.3.4, address_secret: PROD_HOST_IP, user: deploy }
+secrets:
+  provider: age
+  recipients: [age1example]
+"#,
+        )]);
+        let err = Config::load_from_path(&dir.join("yoink.yaml")).unwrap_err();
+        let msg = format!("{err}");
+        assert!(msg.contains("mutually exclusive"), "got: {err}");
+    }
+
+    #[test]
+    fn duplicate_address_secret_across_hosts_is_rejected() {
+        let dir = write_temp_tree(&[(
+            "yoink.yaml",
+            r#"
+deploy:
+  networks: [main]
+hosts:
+  - { address_secret: SHARED_KEY, user: deploy }
+  - { address_secret: SHARED_KEY, user: deploy }
+secrets:
+  provider: age
+  recipients: [age1example]
+"#,
+        )]);
+        let err = Config::load_from_path(&dir.join("yoink.yaml")).unwrap_err();
+        let msg = format!("{err}");
+        assert!(msg.contains("duplicate"), "got: {err}");
+    }
+
+    #[test]
+    fn resolve_host_addresses_populates_from_bundle() {
+        use crate::secrets::SecretsBundle;
+        let dir = write_temp_tree(&[(
+            "yoink.yaml",
+            r#"
+deploy:
+  networks: [main]
+hosts:
+  - { address_secret: PROD_HOST_IP, user: deploy }
+secrets:
+  provider: age
+  recipients: [age1example]
+"#,
+        )]);
+        let mut cfg = Config::load_from_path(&dir.join("yoink.yaml")).unwrap();
+        let mut values = std::collections::BTreeMap::new();
+        values.insert("PROD_HOST_IP".to_string(), "10.0.0.42".to_string());
+        let bundle = SecretsBundle::new(values);
+        cfg.resolve_host_addresses(Some(&bundle)).expect("resolves");
+        assert_eq!(cfg.hosts[0].address, "10.0.0.42");
+    }
+
+    #[test]
+    fn resolve_host_addresses_errors_on_missing_key() {
+        use crate::secrets::SecretsBundle;
+        let dir = write_temp_tree(&[(
+            "yoink.yaml",
+            r#"
+deploy:
+  networks: [main]
+hosts:
+  - { address_secret: NOT_IN_BUNDLE, user: deploy }
+secrets:
+  provider: age
+  recipients: [age1example]
+"#,
+        )]);
+        let mut cfg = Config::load_from_path(&dir.join("yoink.yaml")).unwrap();
+        let bundle = SecretsBundle::default();
+        let err = cfg.resolve_host_addresses(Some(&bundle)).unwrap_err();
+        let msg = format!("{err}");
+        assert!(
+            msg.contains("NOT_IN_BUNDLE") && msg.contains("not found"),
+            "got: {err}"
+        );
+    }
+
+    #[test]
+    fn resolve_host_addresses_errors_when_no_bundle_available() {
+        let dir = write_temp_tree(&[(
+            "yoink.yaml",
+            r#"
+deploy:
+  networks: [main]
+hosts:
+  - { address_secret: PROD_HOST_IP, user: deploy }
+secrets:
+  provider: age
+  recipients: [age1example]
+"#,
+        )]);
+        let mut cfg = Config::load_from_path(&dir.join("yoink.yaml")).unwrap();
+        let err = cfg.resolve_host_addresses(None).unwrap_err();
+        let msg = format!("{err}");
+        assert!(
+            msg.contains("PROD_HOST_IP") && msg.contains("requires a sealed-secrets bundle"),
+            "got: {err}"
+        );
+    }
+
+    #[test]
+    fn resolve_host_addresses_is_noop_for_literal_hosts() {
+        let dir = write_temp_tree(&[(
+            "yoink.yaml",
+            r#"
+deploy:
+  networks: [main]
+hosts:
+  - { address: 1.2.3.4, user: root }
+"#,
+        )]);
+        let mut cfg = Config::load_from_path(&dir.join("yoink.yaml")).unwrap();
+        // Literal-only fleet — resolve should be a no-op even with no bundle.
+        cfg.resolve_host_addresses(None).expect("noop ok");
+        assert_eq!(cfg.hosts[0].address, "1.2.3.4");
+        assert!(!cfg.any_host_address_sealed());
     }
 
     #[test]

--- a/yoink/src/main.rs
+++ b/yoink/src/main.rs
@@ -911,9 +911,16 @@ enum HostsAction {
     /// confirm the new host doesn't collide with an existing address;
     /// if it does, the fragment is removed and the command errors.
     Add {
-        /// Hostname or IP yoink will SSH into.
-        #[arg(long, value_name = "ADDR")]
-        address: String,
+        /// Hostname or IP yoink will SSH into. Mutually exclusive with
+        /// `--address-secret`.
+        #[arg(long, value_name = "ADDR", conflicts_with = "address_secret")]
+        address: Option<String>,
+        /// Name of a sealed-secret entry holding the host address (IP
+        /// or hostname). Resolved at deploy time. Use this when the
+        /// deploy config sits in a public repo and the host's address
+        /// itself is sensitive. Mutually exclusive with `--address`.
+        #[arg(long = "address-secret", value_name = "NAME")]
+        address_secret: Option<String>,
         /// SSH user. Must be in the host's `docker` group, or be `root`.
         #[arg(long, value_name = "USER", default_value = "root")]
         user: String,
@@ -922,8 +929,10 @@ enum HostsAction {
         /// and uses it instead of the operator's ssh-agent.
         #[arg(long = "ssh-key-secret", value_name = "NAME")]
         ssh_key_secret: Option<String>,
-        /// Logical name; becomes the fragment filename. Default: derived
-        /// from the address with `:` and `.` swapped for `-`.
+        /// Logical name; becomes the fragment filename. Required when
+        /// the address is sealed (no literal value to derive from).
+        /// Default: derived from the address with `:` and `.` swapped
+        /// for `-`.
         #[arg(long, value_name = "NAME")]
         name: Option<String>,
         /// Directory to write the fragment into. The directory is
@@ -1095,12 +1104,14 @@ async fn run(cli: Cli) -> Result<()> {
     // `yoink add postgres` ran), so it loads through the relaxed
     // path that skips cross-service validation. Every other command
     // assumes a deployable config.
-    let config = if matches!(cli.command, Command::Add { .. }) {
+    let mut config = if matches!(cli.command, Command::Add { .. }) {
         Config::load_from_path_relaxed(&cli.config)
     } else {
         Config::load_from_path(&cli.config)
     }
     .with_context(|| format!("loading {}", cli.config.display()))?;
+
+    resolve_sealed_host_addresses(&mut config).await?;
 
     match cli.command {
         Command::Add {
@@ -1128,8 +1139,9 @@ async fn run(cli: Cli) -> Result<()> {
                 // include: edits + new fragment files mean the in-memory
                 // config we loaded above is now stale. Reload before
                 // running up so the freshly-added service is included.
-                let reloaded = Config::load_from_path(&cli.config)
+                let mut reloaded = Config::load_from_path(&cli.config)
                     .with_context(|| format!("reloading {}", cli.config.display()))?;
+                resolve_sealed_host_addresses(&mut reloaded).await?;
                 let no_services: Vec<String> = Vec::new();
                 let no_tags: Vec<String> = Vec::new();
                 cmd_up(
@@ -1924,6 +1936,23 @@ async fn load_secrets_bundle(config: &Config) -> Result<Option<SecretsBundle>> {
     secrets::load_bundle(config)
         .await
         .context("load secrets bundle")
+}
+
+/// If any host has `address_secret:` set, eagerly load the secrets
+/// bundle and populate `host.address` from it. Idempotent — calling
+/// twice is safe. Skipped (no work, no bundle access) when no host
+/// is sealed, so configs that don't use the feature pay nothing.
+async fn resolve_sealed_host_addresses(config: &mut Config) -> Result<()> {
+    if !config.any_host_address_sealed() {
+        return Ok(());
+    }
+    let bundle = secrets::load_bundle(config)
+        .await
+        .context("load secrets bundle to resolve hosts[].address_secret")?;
+    config
+        .resolve_host_addresses(bundle.as_ref())
+        .context("resolve hosts[].address_secret against the sealed bundle")?;
+    Ok(())
 }
 
 /// Build a `RealDockerOps` aware of any `hosts[].ssh_key_secret`
@@ -3706,19 +3735,33 @@ fn cmd_hosts(config: &Config, config_path: PathBuf, action: HostsAction) -> Resu
                     .as_deref()
                     .map(|n| format!("  ssh_key_secret={n}"))
                     .unwrap_or_default();
-                println!("{}@{}{}", host.user, host.address, key_note);
+                // Prefer the resolved literal when available; fall
+                // back to `<address_secret:KEY>` only when resolution
+                // hasn't populated `address` yet (no bundle, or
+                // running this command before the eager resolve in
+                // `run`).
+                let display_address = if !host.address.is_empty() {
+                    host.address.clone()
+                } else if let Some(secret) = host.address_secret.as_deref() {
+                    format!("<address_secret:{secret}>")
+                } else {
+                    String::new()
+                };
+                println!("{}@{}{}", host.user, display_address, key_note);
             }
             Ok(())
         }
         HostsAction::Add {
             address,
+            address_secret,
             user,
             ssh_key_secret,
             name,
             dest_dir,
         } => cmd_hosts_add(
             config_path,
-            &address,
+            address.as_deref(),
+            address_secret.as_deref(),
             &user,
             ssh_key_secret.as_deref(),
             name.as_deref(),
@@ -3730,18 +3773,37 @@ fn cmd_hosts(config: &Config, config_path: PathBuf, action: HostsAction) -> Resu
 
 fn cmd_hosts_add(
     config_path: PathBuf,
-    address: &str,
+    address: Option<&str>,
+    address_secret: Option<&str>,
     user: &str,
     ssh_key_secret: Option<&str>,
     name: Option<&str>,
     dest_dir: &Path,
 ) -> Result<()> {
-    if address.trim().is_empty() {
-        return Err(anyhow::anyhow!("--address must not be empty"));
+    let address = address.map(str::trim).filter(|s| !s.is_empty());
+    let address_secret = address_secret.map(str::trim).filter(|s| !s.is_empty());
+    match (address, address_secret) {
+        (None, None) => {
+            return Err(anyhow::anyhow!(
+                "set either --address or --address-secret"
+            ));
+        }
+        (Some(_), Some(_)) => {
+            return Err(anyhow::anyhow!(
+                "--address and --address-secret are mutually exclusive"
+            ));
+        }
+        _ => {}
     }
-    let derived_name = name
-        .map(str::to_string)
-        .unwrap_or_else(|| address.replace([':', '.'], "-"));
+    let derived_name = match (name, address) {
+        (Some(n), _) => n.to_string(),
+        (None, Some(addr)) => addr.replace([':', '.'], "-"),
+        (None, None) => {
+            return Err(anyhow::anyhow!(
+                "--name is required when --address-secret is used (no literal address to derive a name from)"
+            ));
+        }
+    };
     if derived_name.is_empty()
         || !derived_name
             .chars()
@@ -3780,7 +3842,11 @@ fn cmd_hosts_add(
         date = chrono_like_date()
     ));
     body.push_str("hosts:\n");
-    body.push_str(&format!("  - address: {address}\n"));
+    if let Some(addr) = address {
+        body.push_str(&format!("  - address: {addr}\n"));
+    } else if let Some(secret) = address_secret {
+        body.push_str(&format!("  - address_secret: {secret}\n"));
+    }
     body.push_str(&format!("    user: {user}\n"));
     if let Some(secret) = ssh_key_secret {
         body.push_str(&format!("    ssh_key_secret: {secret}\n"));
@@ -3797,8 +3863,12 @@ fn cmd_hosts_add(
             "config failed to reload after adding host {derived_name:?}: {e}"
         ));
     }
+    let display_address = address
+        .map(str::to_string)
+        .or_else(|| address_secret.map(|s| format!("<address_secret:{s}>")))
+        .unwrap_or_default();
     eprintln!(
-        "✓ added host {derived_name} ({user}@{address}) to {}",
+        "✓ added host {derived_name} ({user}@{display_address}) to {}",
         fragment_path.display()
     );
     Ok(())

--- a/yoink/src/main.rs
+++ b/yoink/src/main.rs
@@ -3784,9 +3784,7 @@ fn cmd_hosts_add(
     let address_secret = address_secret.map(str::trim).filter(|s| !s.is_empty());
     match (address, address_secret) {
         (None, None) => {
-            return Err(anyhow::anyhow!(
-                "set either --address or --address-secret"
-            ));
+            return Err(anyhow::anyhow!("set either --address or --address-secret"));
         }
         (Some(_), Some(_)) => {
             return Err(anyhow::anyhow!(

--- a/yoink/src/secrets.rs
+++ b/yoink/src/secrets.rs
@@ -241,6 +241,13 @@ fn config_references_secrets(config: &Config) -> bool {
     {
         return true;
     }
+    if config
+        .hosts
+        .iter()
+        .any(|h| h.address_secret.is_some() || h.ssh_key_secret.is_some())
+    {
+        return true;
+    }
     config
         .hooks
         .pre_deploy

--- a/yoink/src/ssh_keys.rs
+++ b/yoink/src/ssh_keys.rs
@@ -153,6 +153,7 @@ services:
     fn prepare_returns_none_when_no_host_declares_secret() {
         let cfg = config_with_hosts(vec![HostConfig {
             address: "h1".into(),
+            address_secret: None,
             user: "deploy".into(),
             ssh_key_secret: None,
         }]);
@@ -164,6 +165,7 @@ services:
     fn prepare_errors_when_secret_missing_from_bundle() {
         let cfg = config_with_hosts(vec![HostConfig {
             address: "h1".into(),
+            address_secret: None,
             user: "deploy".into(),
             ssh_key_secret: Some("h1_key".into()),
         }]);
@@ -180,6 +182,7 @@ services:
     fn prepare_errors_when_no_secrets_block() {
         let cfg = config_with_hosts(vec![HostConfig {
             address: "h1".into(),
+            address_secret: None,
             user: "deploy".into(),
             ssh_key_secret: Some("h1_key".into()),
         }]);
@@ -193,11 +196,13 @@ services:
         let cfg = config_with_hosts(vec![
             HostConfig {
                 address: "h1".into(),
+                address_secret: None,
                 user: "deploy".into(),
                 ssh_key_secret: Some("h1_key".into()),
             },
             HostConfig {
                 address: "h2".into(),
+                address_secret: None,
                 user: "deploy".into(),
                 ssh_key_secret: None,
             },

--- a/yoink/src/tui/app.rs
+++ b/yoink/src/tui/app.rs
@@ -1162,6 +1162,19 @@ impl App {
         // it, so without this the synthetic `local` host disappears
         // every CONFIG_RELOAD_TICK.
         new_config.push_local_host_if_socket();
+        // If the config has any `address_secret:` hosts, resolve them
+        // against the cached secrets bundle. The TUI loads the bundle
+        // asynchronously via the `secrets` Arc; until that bundle
+        // lands, sealed-address hosts will render with empty
+        // addresses — which is a strong visual signal that the bundle
+        // hasn't loaded yet. Once the bundle is cached, every reload
+        // tick re-applies the resolution and the hosts populate.
+        if new_config.any_host_address_sealed()
+            && let Some(bundle) = self.secrets.try_read().ok().and_then(|g| g.clone())
+            && let Err(e) = new_config.resolve_host_addresses(Some(bundle.as_ref()))
+        {
+            tracing::debug!(error = %e, "tui: resolve_host_addresses failed");
+        }
         if new_config == *self.config {
             return;
         }


### PR DESCRIPTION
## Summary

Adds a first-class way to source `hosts[].address:` from a sealed secret, parallel to the existing `ssh_key_secret:` field on `HostConfig`. The motivation is keeping the host's address out of git when the deploy config sits in a public repo (e.g. a Hetzner box that's fronted through Cloudflare — the public IP itself is sensitive).

This is **Phase 1** of the dogfood-the-docs plan. Phase 2 (deploy yoink.is via yoink itself) consumes this feature.

### Schema

```yaml
hosts:
  - address_secret: PROD_HOST_IP   # mutually exclusive with `address:`
    user: deploy
    ssh_key_secret: PROD_HOST_SSH_KEY
```

Exactly one of `{address, address_secret}` per host. Both unset, or both set, is rejected at config-load.

### CLI

```sh
yoink hosts add --address-secret PROD_HOST_IP --user deploy --name docs-1
```

`--name` is required when `--address-secret` is used (no literal address to derive a fragment filename from). `yoink hosts list` shows the resolved literal IP when the bundle is decryptable, falls back to `<address_secret:KEY>` when not.

### Resolution

Eagerly at the `main` entry point, immediately after `Config::load_from_path`: if any host has `address_secret:` set, the secrets bundle is loaded and the addresses populated. After that, all downstream code reading `host.address` works unchanged. The TUI's reload tick re-runs the resolution against its cached bundle.

`secrets::config_references_secrets` now treats hosts with `address_secret:` as a "needs the bundle loaded" signal, so configs that only seal addresses (no service-level `secrets:`) still trigger decryption.

### Tests

8 new lib tests in `config::tests`:

- `host_address_secret_only_loads_ok`
- `host_with_neither_address_nor_secret_is_rejected`
- `host_with_both_address_and_secret_is_rejected`
- `duplicate_address_secret_across_hosts_is_rejected`
- `resolve_host_addresses_populates_from_bundle`
- `resolve_host_addresses_errors_on_missing_key`
- `resolve_host_addresses_errors_when_no_bundle_available`
- `resolve_host_addresses_is_noop_for_literal_hosts`

Plus an end-to-end hand fixture: `yoink hosts add --address-secret`, `yoink hosts list` with/without `YOINK_AGE_KEY`, `yoink validate` on missing-key error case — all behave as expected.

## Test plan

- [x] `cargo test --workspace` — 460 passed.
- [x] `cargo build --release` clean.
- [x] `cargo clippy --workspace --all-targets` (CI's invocation) — no new lints.
- [x] Hugo docs build clean (`cd docs && hugo --gc`).
- [x] End-to-end hand fixture exercises the happy path and error path.