### PR TITLE
fix: soft-fail address_secret resolution when bundle unavailable

### DIFF
--- a/yoink/src/main.rs
+++ b/yoink/src/main.rs
@@ -1988,17 +1988,32 @@ async fn load_secrets_bundle(config: &Config) -> Result<Option<SecretsBundle>> {
 /// If any host has `address_secret:` set, eagerly load the secrets
 /// bundle and populate `host.address` from it. Idempotent — calling
 /// twice is safe. Skipped (no work, no bundle access) when no host
-/// is sealed, so configs that don't use the feature pay nothing.
+/// is sealed.
+///
+/// Best-effort: if the bundle fails to load (sealed file missing,
+/// identity unavailable, decrypt error), the function logs a debug
+/// trace and returns Ok with `host.address` left empty. Bootstrap
+/// commands (`yoink secrets …`, `yoink hosts …`, `yoink init`) need
+/// to run before the bundle exists; making the resolver hard-fail
+/// here would block them. Deploy commands that actually consume
+/// `host.address` surface a clear error when it's empty.
 async fn resolve_sealed_host_addresses(config: &mut Config) -> Result<()> {
     if !config.any_host_address_sealed() {
         return Ok(());
     }
-    let bundle = secrets::load_bundle(config)
-        .await
-        .context("load secrets bundle to resolve hosts[].address_secret")?;
-    config
-        .resolve_host_addresses(bundle.as_ref())
-        .context("resolve hosts[].address_secret against the sealed bundle")?;
+    let bundle = match secrets::load_bundle(config).await {
+        Ok(b) => b,
+        Err(e) => {
+            tracing::debug!(
+                error = %e,
+                "skipping address_secret resolution: secrets bundle unavailable",
+            );
+            return Ok(());
+        }
+    };
+    if let Err(e) = config.resolve_host_addresses(bundle.as_ref()) {
+        tracing::debug!(error = %e, "skipping address_secret resolution");
+    }
     Ok(())
 }
 


### PR DESCRIPTION
## Summary

Bootstrapping a config that uses `hosts[].address_secret:` (PR #60) requires running secret-management commands (e.g. `yoink secrets seal --as YOINK_DOCS_HOST=<ip>`, `yoink secrets ssh-key generate --seal-as DEPLOY_SSH_KEY`) **before** the sealed bundle exists. The eager resolution at the main entry point was hard-failing in that window:

```
$ yoink secrets ssh-key generate --seal-as DEPLOY_SSH_KEY
yoink: load secrets bundle to resolve hosts[].address_secret: read
sealed secrets file secrets.age: No such file or directory (os error 2)
```

→ Operator can't create the very bundle the resolver needs to read. Chicken and egg.

## Fix

Make `resolve_sealed_host_addresses` best-effort: if the bundle fails to load (sealed file missing, identity unavailable, decrypt error), log a debug trace and continue with `host.address` left empty. Deploy commands that actually consume `host.address` already surface clear errors when it's empty (existing `require_hosts` / SSH-connect paths), so the soft-fail doesn't mask real failures — it just lets bootstrap commands run.

Discovered while bootstrapping the docs deploy in PR #61.

## Test plan

- [x] `cargo test --lib` — 450 passed (existing tests unchanged; the strict resolver-method tests still hold because the soft behavior is in the wrapper, not in `Config::resolve_host_addresses`).
- [x] End-to-end bootstrap: `yoink secrets ssh-key generate --seal-as DEPLOY_SSH_KEY` against a yoink.yaml with `address_secret:` succeeds even when secrets.age doesn't exist.
- [x] Deploy with sealed address still resolves correctly when the bundle is decryptable.