### PR TITLE
fix(tui): nav-key collisions, logs wrap, advertise pf+vscode

### DIFF
--- a/yoink/src/tui/app.rs
+++ b/yoink/src/tui/app.rs
@@ -1866,20 +1866,9 @@ impl App {
             return false;
         }
         match key.code {
-            // Pane navigation — digits are the canonical mnemonic
-            // (printed on each tab in the header), letters are
-            // back-compat aliases.
-            //   1 / d  Dashboard
-            //   2 / h  Hosts
-            //   3 / s  Services
-            //   4 / l  Logs
-            //   5 / R  Resources (uppercase R because lowercase r
-            //          is universally "refresh" inside panes)
-            //   6 / e  Secrets
-            // Per-view bindings that previously collided (delete,
-            // restart, edit, container-logs) have been moved off
-            // these letters — see the secrets/resources/host-detail
-            // handlers below.
+            // Pane nav: digits are canonical (printed on each tab),
+            // letters are aliases. `R` is uppercase because lowercase
+            // `r` is universally "refresh" inside panes.
             KeyCode::Char('1') | KeyCode::Char('d') => {
                 self.transition(View::Dashboard).await;
                 return false;
@@ -2147,8 +2136,6 @@ impl App {
                 KeyCode::Char('X') => {
                     self.spawn_lifecycle(host.clone(), container.clone(), LifecycleOp::Stop);
                 }
-                // `T` (resTart) — capital `R` is the global "go to
-                // Resources" nav (see HostDetail handler above).
                 KeyCode::Char('T') => {
                     self.spawn_lifecycle(host.clone(), container.clone(), LifecycleOp::Restart);
                 }

--- a/yoink/src/tui/app.rs
+++ b/yoink/src/tui/app.rs
@@ -200,7 +200,9 @@ impl View {
                 "  i            container detail (labels, env, live cpu/mem)",
                 "  !            shell into container (bash/sh)",
                 "  B            debug sidecar (alpine, target's pid+net ns)",
-                "  S            start · X stop · R restart container",
+                "  f            port-forward (localhost ↔ container)",
+                "  v            VS Code in browser, rooted in container fs",
+                "  S            start · X stop · T restart container",
                 "  K            SIGKILL container (with confirmation)",
                 "  U            reconcile this service (with confirmation)",
                 "  /            filter substring · esc to clear",
@@ -212,9 +214,10 @@ impl View {
             ],
             View::ContainerDetail { .. } => vec![
                 "container detail",
-                "  enter / l    live logs",
+                "  enter        live logs",
                 "  !            shell · B debug sidecar",
-                "  S            start · X stop · R restart container",
+                "  f            port-forward · v VS Code in browser",
+                "  S            start · X stop · T restart container",
                 "  K            SIGKILL container (with confirmation)",
                 "  U            reconcile this service (with confirmation)",
                 "  p            processes (docker top)",
@@ -1863,11 +1866,10 @@ impl App {
             return false;
         }
         match key.code {
-            // Lowercase `d` is dashboard nav from anywhere EXCEPT the
-            // Secrets and Resources panes — both bind `d` to delete the
-            // selected item, and a delete key shouldn't surprise-route
-            // to a pane switch when the operator's intent is "remove."
-            KeyCode::Char('d') if !matches!(self.view, View::Secrets | View::Resources) => {
+            // Lowercase `d` is dashboard nav from any view. Per-view
+            // delete actions live on `x` (vim-like) so the global
+            // pane-switch mnemonic stays consistent everywhere.
+            KeyCode::Char('d') => {
                 self.transition(View::Dashboard).await;
                 return false;
             }
@@ -2105,7 +2107,11 @@ impl App {
                         self.spawn_lifecycle(host, container, LifecycleOp::Stop);
                     }
                 }
-                KeyCode::Char('R') => {
+                // `T` (resTart) — capital `R` is the global "go to
+                // Resources" nav and would shadow this binding. The
+                // `S`/`X`/`K`/`T` family is consistent across
+                // container-action surfaces.
+                KeyCode::Char('T') => {
                     if let (Some(host), Some(container)) = (
                         self.host_detail.host().cloned(),
                         self.host_detail.selected_container(),
@@ -2135,7 +2141,9 @@ impl App {
                 KeyCode::Char('X') => {
                     self.spawn_lifecycle(host.clone(), container.clone(), LifecycleOp::Stop);
                 }
-                KeyCode::Char('R') => {
+                // `T` (resTart) — capital `R` is the global "go to
+                // Resources" nav (see HostDetail handler above).
+                KeyCode::Char('T') => {
                     self.spawn_lifecycle(host.clone(), container.clone(), LifecycleOp::Restart);
                 }
                 KeyCode::Char('K') => {
@@ -2161,7 +2169,9 @@ impl App {
                     let host = host.clone();
                     self.transition(View::HostDetail(host)).await;
                 }
-                KeyCode::Char('l') | KeyCode::Enter => {
+                // `Enter` only — lowercase `l` is the global "go to
+                // Logs" nav and would shadow this binding.
+                KeyCode::Enter => {
                     let host = host.clone();
                     let container = container.clone();
                     self.transition(View::ContainerLogs { host, container })
@@ -2218,6 +2228,7 @@ impl App {
                 KeyCode::Char('c') => self.logs.clear(),
                 KeyCode::Char('y') => self.copy_logs_to_clipboard(),
                 KeyCode::Char('/') => self.logs.begin_filter_input(),
+                KeyCode::Char('w') => self.logs.toggle_wrap(),
                 KeyCode::Up => self.logs.scroll_up(1),
                 KeyCode::Down => self.logs.scroll_down(1),
                 KeyCode::PageUp => self.logs.scroll_up(10),
@@ -2349,7 +2360,6 @@ impl App {
                         }
                     }
                     KeyCode::Esc => self.transition(View::ServiceDetail(svc)).await,
-                    KeyCode::Char('R') => self.schedule_history_refresh(svc),
                     _ => {}
                 }
             }
@@ -2362,6 +2372,7 @@ impl App {
                 KeyCode::Char('y') => self.copy_logs_to_clipboard(),
                 KeyCode::Char('c') => self.logs.clear(),
                 KeyCode::Char('/') => self.logs.begin_filter_input(),
+                KeyCode::Char('w') => self.logs.toggle_wrap(),
                 KeyCode::Up => self.logs.scroll_up(1),
                 KeyCode::Down => self.logs.scroll_down(1),
                 KeyCode::PageUp => self.logs.scroll_up(10),
@@ -2375,10 +2386,12 @@ impl App {
                 KeyCode::Down | KeyCode::Char('j') => self.secrets_state.select_next(),
                 KeyCode::Char('r') => self.secrets_state.toggle_reveal(),
                 KeyCode::Char('a') => self.secrets_state.begin_add(),
-                KeyCode::Char('e') | KeyCode::Enter => {
+                // `Enter` only — lowercase `e` is the global "go to
+                // Secrets" nav and would shadow this binding.
+                KeyCode::Enter => {
                     self.secrets_state.begin_edit_selected();
                 }
-                KeyCode::Char('d') => self.secrets_state.begin_remove_selected(),
+                KeyCode::Char('x') => self.secrets_state.begin_remove_selected(),
                 _ => {}
             },
             View::Resources => match key.code {
@@ -2387,7 +2400,7 @@ impl App {
                 KeyCode::Char('i') => self.resources.set_tab(ResourceTab::Images),
                 KeyCode::Char('v') => self.resources.set_tab(ResourceTab::Volumes),
                 KeyCode::Char('n') => self.resources.set_tab(ResourceTab::Networks),
-                KeyCode::Char('d') => {
+                KeyCode::Char('x') => {
                     if let Some(target) = self.resources.selected_target(&self.config) {
                         self.resource_remove_target = Some(target);
                     }

--- a/yoink/src/tui/app.rs
+++ b/yoink/src/tui/app.rs
@@ -159,17 +159,17 @@ impl View {
         let global = vec![
             "global",
             "  q / Ctrl-C    quit yoink",
-            "  d h s l       dashboard / hosts / services / logs",
-            "  R e           resources / encrypted-secrets",
+            "  1 2 3 4 5 6   dashboard / hosts / services / logs / resources / secrets",
+            "  d h s l R e   same panes, letter aliases (R = resources, e = secrets)",
+            "  Tab / S-Tab   cycle panes forward / backward",
             "  D             doctor — diagnose deploy-blockers",
             "  E             edit config in $EDITOR (jumps to focused service/host)",
             "  ~             show drift detail for the focused service",
             "  f             port-forward the focused service (auto: published or sidecar)",
-            "  o / O         open the active port-forward URL in the browser (any view)",
+            "  o / O         open the active port-forward URL in the browser",
             "  F             close every active port-forward",
             "  v             open VS Code in browser, rooted in the focused service's container",
             "  V             close every active vscode session",
-            "  Tab / S-Tab   cycle modes forward / backward",
             "  ?             toggle this help overlay",
             "",
         ];
@@ -1866,36 +1866,42 @@ impl App {
             return false;
         }
         match key.code {
-            // Lowercase `d` is dashboard nav from any view. Per-view
-            // delete actions live on `x` (vim-like) so the global
-            // pane-switch mnemonic stays consistent everywhere.
-            KeyCode::Char('d') => {
+            // Pane navigation — digits are the canonical mnemonic
+            // (printed on each tab in the header), letters are
+            // back-compat aliases.
+            //   1 / d  Dashboard
+            //   2 / h  Hosts
+            //   3 / s  Services
+            //   4 / l  Logs
+            //   5 / R  Resources (uppercase R because lowercase r
+            //          is universally "refresh" inside panes)
+            //   6 / e  Secrets
+            // Per-view bindings that previously collided (delete,
+            // restart, edit, container-logs) have been moved off
+            // these letters — see the secrets/resources/host-detail
+            // handlers below.
+            KeyCode::Char('1') | KeyCode::Char('d') => {
                 self.transition(View::Dashboard).await;
                 return false;
             }
-            KeyCode::Char('h') => {
+            KeyCode::Char('2') | KeyCode::Char('h') => {
                 self.transition(View::Hosts).await;
                 return false;
             }
-            KeyCode::Char('s') => {
+            KeyCode::Char('3') | KeyCode::Char('s') => {
                 self.transition(View::Services).await;
                 return false;
             }
-            KeyCode::Char('l') => {
+            KeyCode::Char('4') | KeyCode::Char('l') => {
                 self.transition(View::Logs).await;
                 return false;
             }
-            KeyCode::Char('e') => {
-                self.transition(View::Secrets).await;
+            KeyCode::Char('5') | KeyCode::Char('R') => {
+                self.transition(View::Resources).await;
                 return false;
             }
-            KeyCode::Char('R') if !matches!(self.view, View::Resources) => {
-                // Capital `R` enters the Resources pane from any other
-                // top-level view. While *inside* Resources, we let the
-                // per-view match below own the `R` key (lower-case is
-                // already used for refresh; the per-view handler can
-                // map capital R to other things if needed).
-                self.transition(View::Resources).await;
+            KeyCode::Char('6') | KeyCode::Char('e') => {
+                self.transition(View::Secrets).await;
                 return false;
             }
             // Capital `D` opens the doctor modal — runs the same checks
@@ -3582,13 +3588,17 @@ impl App {
             },
             |(_, msg)| format!("● {msg}"),
         );
+        // Digits are printed right on the tab so the nav mnemonic is
+        // self-documenting — `1` → Dashboard, `2` → Hosts, etc. The
+        // letter mnemonics (`d h s l R e`) still work for muscle
+        // memory; digits are the cross-pane consistent path.
         let tabs = [
-            "Dashboard",
-            "Hosts",
-            "Services",
-            "Logs",
-            "Resources",
-            "Secrets",
+            "1 Dashboard",
+            "2 Hosts",
+            "3 Services",
+            "4 Logs",
+            "5 Resources",
+            "6 Secrets",
         ];
         let selected_tab = Some(self.view.top_section());
         super::ui::render_header(

--- a/yoink/src/tui/history.rs
+++ b/yoink/src/tui/history.rs
@@ -211,7 +211,8 @@ impl HistoryState {
         frame.render_stateful_widget(table, layout[1], &mut self.table);
 
         let footer_text = if self.errors.is_empty() {
-            "↑↓/jk navigate · r rollback to selected (running rows are skipped) · R refresh · esc back".to_string()
+            "↑↓/jk navigate · r rollback to selected (running rows are skipped) · esc back"
+                .to_string()
         } else {
             format!(
                 "⚠ {} host(s) unreachable: {}",

--- a/yoink/src/tui/host_detail.rs
+++ b/yoink/src/tui/host_detail.rs
@@ -84,6 +84,12 @@ impl HostDetailState {
         // filtered list for a frame.
         let n = self.visible_indices().len();
         clamp_selection(&mut self.table, n);
+        // Auto-select row 0 once data lands so per-row actions
+        // (`f` port-forward, `v` vscode, `S`/`X`/`T`/`K` lifecycle)
+        // are usable without first nudging the cursor with j/k.
+        if n > 0 && self.table.selected().is_none() {
+            self.table.select(Some(0));
+        }
     }
 
     pub fn select_next(&mut self) {
@@ -295,7 +301,7 @@ impl HostDetailState {
         }
         let footer = filter_footer(
             &self.filter,
-            "↑↓ select · enter logs · i inspect · ! shell · D debug · S start · X stop · R restart · K kill · U reconcile · r refresh",
+            "↑↓ select · enter logs · i inspect · ! shell · f forward · v vscode · D debug · S start · X stop · T restart · K kill · U reconcile · r refresh",
         );
         frame.render_widget(footer, footer_area);
 

--- a/yoink/src/tui/host_detail.rs
+++ b/yoink/src/tui/host_detail.rs
@@ -83,13 +83,10 @@ impl HostDetailState {
         // larger unfiltered count would let `selected` point past the
         // filtered list for a frame.
         let n = self.visible_indices().len();
+        // `clamp_selection` already picks row 0 when none was set, so
+        // per-row actions (`f` port-forward, `v` vscode, `S`/`X`/`T`/`K`
+        // lifecycle) are usable on first apply without nudging j/k.
         clamp_selection(&mut self.table, n);
-        // Auto-select row 0 once data lands so per-row actions
-        // (`f` port-forward, `v` vscode, `S`/`X`/`T`/`K` lifecycle)
-        // are usable without first nudging the cursor with j/k.
-        if n > 0 && self.table.selected().is_none() {
-            self.table.select(Some(0));
-        }
     }
 
     pub fn select_next(&mut self) {

--- a/yoink/src/tui/logs.rs
+++ b/yoink/src/tui/logs.rs
@@ -10,7 +10,7 @@
 use ratatui::Frame;
 use ratatui::style::{Color, Style};
 use ratatui::text::{Line, Text};
-use ratatui::widgets::{Block, Borders, Paragraph};
+use ratatui::widgets::{Block, Borders, Paragraph, Wrap};
 
 use crate::config::Config;
 
@@ -32,6 +32,12 @@ pub struct LogsState {
     filter: Option<String>,
     /// `Some(buf)` while the user is typing into the filter prompt.
     input_buffer: Option<String>,
+    /// When true, long lines wrap inside the pane instead of being
+    /// truncated at the right edge. Toggled by `w`. Works regardless
+    /// of whether the line came from `hl` (styled spans) or the plain
+    /// forwarder — `Paragraph::wrap` wraps on the rendered glyph
+    /// stream after styling has been applied.
+    wrap: bool,
 }
 
 /// One line in the buffer. `plain` is what the filter matches against;
@@ -126,6 +132,15 @@ impl LogsState {
         self.scroll = 0;
     }
 
+    pub fn toggle_wrap(&mut self) {
+        self.wrap = !self.wrap;
+    }
+
+    #[cfg(test)]
+    pub fn wrap_enabled(&self) -> bool {
+        self.wrap
+    }
+
     // ─── filter input ──────────────────────────────────────────────────
 
     pub fn input_mode(&self) -> bool {
@@ -213,7 +228,16 @@ impl LogsState {
             };
             Paragraph::new(placeholder).style(Style::default().fg(Color::DarkGray))
         } else {
-            Paragraph::new(Text::from(filtered)).scroll((scroll, 0))
+            let p = Paragraph::new(Text::from(filtered)).scroll((scroll, 0));
+            // `wrap.trim: false` keeps leading whitespace inside a
+            // wrapped line — important when a logger emits indented
+            // continuation lines (stack traces, structured-log
+            // multi-line values) that should stay visually aligned.
+            if self.wrap {
+                p.wrap(Wrap { trim: false })
+            } else {
+                p
+            }
         }
         .block(Block::default().borders(Borders::ALL).title("logs"));
         frame.render_widget(body, layout[1]);
@@ -234,9 +258,10 @@ impl LogsState {
             Paragraph::new(format!("/{buf}_  (enter apply · esc cancel)"))
                 .style(Style::default().fg(Color::Yellow))
         } else {
-            Paragraph::new(
-                "q quit · k clear · / filter · ↑↓ scroll · g top · G bottom · d dashboard · h hosts",
-            )
+            let wrap_hint = if self.wrap { "w wrap*" } else { "w wrap" };
+            Paragraph::new(format!(
+                "q quit · k clear · / filter · ↑↓ scroll · g top · G bottom · {wrap_hint} · d dashboard · h hosts",
+            ))
             .style(Style::default().fg(Color::DarkGray))
         };
         frame.render_widget(footer, layout[2]);

--- a/yoink/src/tui/logs.rs
+++ b/yoink/src/tui/logs.rs
@@ -28,10 +28,14 @@ pub struct LogsState {
     /// lines stay in view.
     auto_follow: bool,
     /// Substring filter; lines whose plain text doesn't contain this are
-    /// hidden. Empty string is treated as no filter.
+    /// hidden. Empty string is treated as no filter. Updated live on
+    /// every keystroke while in input mode (vim-`/` style).
     filter: Option<String>,
     /// `Some(buf)` while the user is typing into the filter prompt.
     input_buffer: Option<String>,
+    /// Snapshot of `filter` when input mode began — restored on Esc
+    /// so cancelling reverts to the prior view instead of clearing.
+    prev_filter: Option<String>,
     /// When true, long lines wrap inside the pane instead of being
     /// truncated at the right edge. Toggled by `w`. Works regardless
     /// of whether the line came from `hl` (styled spans) or the plain
@@ -148,32 +152,46 @@ impl LogsState {
     }
 
     pub fn begin_filter_input(&mut self) {
+        self.prev_filter = self.filter.clone();
         self.input_buffer = Some(self.filter.clone().unwrap_or_default());
     }
 
     pub fn filter_push_char(&mut self, c: char) {
         if let Some(buf) = self.input_buffer.as_mut() {
             buf.push(c);
+            self.sync_filter_from_buffer();
         }
     }
 
     pub fn filter_backspace(&mut self) {
         if let Some(buf) = self.input_buffer.as_mut() {
             buf.pop();
+            self.sync_filter_from_buffer();
         }
     }
 
+    /// Commit the filter — exit input mode and re-pin to the bottom
+    /// so the newest matching lines are visible. The `filter` itself
+    /// is already up to date (each keystroke synced it live).
     pub fn filter_apply(&mut self) {
-        if let Some(buf) = self.input_buffer.take() {
-            self.filter = if buf.is_empty() { None } else { Some(buf) };
-            // Re-pin to bottom so the newest matching lines are visible.
+        if self.input_buffer.is_some() {
+            self.input_buffer = None;
+            self.prev_filter = None;
             self.auto_follow = true;
             self.scroll = 0;
         }
     }
 
+    /// Abandon the in-progress filter — restore whatever filter was
+    /// active before `/` was pressed.
     pub fn filter_cancel(&mut self) {
         self.input_buffer = None;
+        self.filter = self.prev_filter.take();
+    }
+
+    fn sync_filter_from_buffer(&mut self) {
+        let buf = self.input_buffer.clone().unwrap_or_default();
+        self.filter = if buf.is_empty() { None } else { Some(buf) };
     }
 
     #[cfg(test)]
@@ -255,7 +273,7 @@ impl LogsState {
         );
 
         let footer = if let Some(buf) = &self.input_buffer {
-            Paragraph::new(format!("/{buf}_  (enter apply · esc cancel)"))
+            Paragraph::new(format!("/{buf}_  (live · enter keep · esc revert)"))
                 .style(Style::default().fg(Color::Yellow))
         } else {
             let wrap_hint = if self.wrap { "w wrap*" } else { "w wrap" };

--- a/yoink/src/tui/logs.rs
+++ b/yoink/src/tui/logs.rs
@@ -14,7 +14,7 @@ use ratatui::widgets::{Block, Borders, Paragraph, Wrap};
 
 use crate::config::Config;
 
-use super::ui::{bold, pane_layout};
+use super::ui::{FilterState, bold, pane_layout};
 
 const LINE_LIMIT: usize = 5_000;
 
@@ -27,20 +27,10 @@ pub struct LogsState {
     /// When true, scroll snaps to the bottom on each render so newest
     /// lines stay in view.
     auto_follow: bool,
-    /// Substring filter; lines whose plain text doesn't contain this are
-    /// hidden. Empty string is treated as no filter. Updated live on
-    /// every keystroke while in input mode (vim-`/` style).
-    filter: Option<String>,
-    /// `Some(buf)` while the user is typing into the filter prompt.
-    input_buffer: Option<String>,
-    /// Snapshot of `filter` when input mode began — restored on Esc
-    /// so cancelling reverts to the prior view instead of clearing.
-    prev_filter: Option<String>,
-    /// When true, long lines wrap inside the pane instead of being
-    /// truncated at the right edge. Toggled by `w`. Works regardless
-    /// of whether the line came from `hl` (styled spans) or the plain
-    /// forwarder — `Paragraph::wrap` wraps on the rendered glyph
-    /// stream after styling has been applied.
+    /// Shared incremental-filter state — lines whose plain text
+    /// doesn't contain the active substring are hidden.
+    filter: FilterState,
+    /// Toggled by 'w'. Wraps long lines instead of truncating.
     wrap: bool,
 }
 
@@ -148,55 +138,38 @@ impl LogsState {
     // ─── filter input ──────────────────────────────────────────────────
 
     pub fn input_mode(&self) -> bool {
-        self.input_buffer.is_some()
+        self.filter.input_mode()
     }
 
     pub fn begin_filter_input(&mut self) {
-        self.prev_filter = self.filter.clone();
-        self.input_buffer = Some(self.filter.clone().unwrap_or_default());
+        self.filter.begin_input();
     }
 
     pub fn filter_push_char(&mut self, c: char) {
-        if let Some(buf) = self.input_buffer.as_mut() {
-            buf.push(c);
-            self.sync_filter_from_buffer();
-        }
+        self.filter.push_char(c);
     }
 
     pub fn filter_backspace(&mut self) {
-        if let Some(buf) = self.input_buffer.as_mut() {
-            buf.pop();
-            self.sync_filter_from_buffer();
-        }
+        self.filter.backspace();
     }
 
     /// Commit the filter — exit input mode and re-pin to the bottom
-    /// so the newest matching lines are visible. The `filter` itself
-    /// is already up to date (each keystroke synced it live).
+    /// so the newest matching lines are visible.
     pub fn filter_apply(&mut self) {
-        if self.input_buffer.is_some() {
-            self.input_buffer = None;
-            self.prev_filter = None;
-            self.auto_follow = true;
-            self.scroll = 0;
-        }
+        self.filter.apply();
+        self.auto_follow = true;
+        self.scroll = 0;
     }
 
     /// Abandon the in-progress filter — restore whatever filter was
     /// active before `/` was pressed.
     pub fn filter_cancel(&mut self) {
-        self.input_buffer = None;
-        self.filter = self.prev_filter.take();
-    }
-
-    fn sync_filter_from_buffer(&mut self) {
-        let buf = self.input_buffer.clone().unwrap_or_default();
-        self.filter = if buf.is_empty() { None } else { Some(buf) };
+        self.filter.cancel();
     }
 
     #[cfg(test)]
     pub fn current_filter(&self) -> Option<&str> {
-        self.filter.as_deref()
+        self.filter.current()
     }
 
     // ─── rendering ─────────────────────────────────────────────────────
@@ -230,7 +203,7 @@ impl LogsState {
             "yoink logs · services: {services} · {} lines{} · {}",
             total,
             self.filter
-                .as_deref()
+                .current()
                 .map(|f| format!(" (filter: {f})"))
                 .unwrap_or_default(),
             if self.auto_follow { "follow" } else { "paused" },
@@ -247,10 +220,9 @@ impl LogsState {
             Paragraph::new(placeholder).style(Style::default().fg(Color::DarkGray))
         } else {
             let p = Paragraph::new(Text::from(filtered)).scroll((scroll, 0));
-            // `wrap.trim: false` keeps leading whitespace inside a
-            // wrapped line — important when a logger emits indented
+            // `trim: false` preserves indentation on wrapped
             // continuation lines (stack traces, structured-log
-            // multi-line values) that should stay visually aligned.
+            // multi-line values).
             if self.wrap {
                 p.wrap(Wrap { trim: false })
             } else {
@@ -272,25 +244,20 @@ impl LogsState {
             usize::from(inner_height),
         );
 
-        let footer = if let Some(buf) = &self.input_buffer {
-            Paragraph::new(format!("/{buf}_  (live · enter keep · esc revert)"))
-                .style(Style::default().fg(Color::Yellow))
-        } else {
-            let wrap_hint = if self.wrap { "w wrap*" } else { "w wrap" };
-            Paragraph::new(format!(
-                "q quit · k clear · / filter · ↑↓ scroll · g top · G bottom · {wrap_hint} · d dashboard · h hosts",
-            ))
-            .style(Style::default().fg(Color::DarkGray))
-        };
-        frame.render_widget(footer, layout[2]);
+        let wrap_hint = if self.wrap { "w wrap*" } else { "w wrap" };
+        let default_help = format!(
+            "q quit · k clear · / filter · ↑↓ scroll · g top · G bottom · {wrap_hint} · d dashboard · h hosts",
+        );
+        frame.render_widget(
+            super::ui::filter_footer(&self.filter, &default_help),
+            layout[2],
+        );
     }
 
     fn filter_iter(&self) -> impl Iterator<Item = &RenderedLine> {
-        let filter = self.filter.clone();
-        self.lines.iter().filter(move |l| match &filter {
-            Some(f) => l.plain.contains(f.as_str()),
-            None => true,
-        })
+        self.lines
+            .iter()
+            .filter(move |l| self.filter.matches(&l.plain))
     }
 }
 
@@ -399,7 +366,11 @@ mod tests {
         s.push_line(&line("c", LogStream::Stdout, "GET /health"));
         s.push_line(&line("c", LogStream::Stdout, "POST /api"));
         s.push_line(&line("c", LogStream::Stderr, "GET /api"));
-        s.filter = Some("/api".into());
+        s.begin_filter_input();
+        for c in "/api".chars() {
+            s.filter_push_char(c);
+        }
+        s.filter_apply();
         let kept: Vec<_> = s.filter_iter().collect();
         assert_eq!(kept.len(), 2);
     }

--- a/yoink/src/tui/resources.rs
+++ b/yoink/src/tui/resources.rs
@@ -363,10 +363,10 @@ impl ResourcesState {
         // Footer: filter line + per-tab help on the right.
         let help = match self.current_tab() {
             ResourceTab::Images => {
-                "Tab cycle · d remove · P prune dangling · A prune all · r refresh · ?"
+                "Tab cycle · x remove · P prune dangling · A prune all · r refresh · ?"
             }
             ResourceTab::Volumes | ResourceTab::Networks => {
-                "Tab cycle · d remove · P prune unused · r refresh · ?"
+                "Tab cycle · x remove · P prune unused · r refresh · ?"
             }
         };
         frame.render_widget(filter_footer(&self.filter, help), footer);

--- a/yoink/src/tui/secrets.rs
+++ b/yoink/src/tui/secrets.rs
@@ -27,9 +27,10 @@ use std::path::PathBuf;
 use std::time::{Duration, Instant};
 
 use ratatui::Frame;
-use ratatui::layout::{Constraint, Rect};
-use ratatui::style::{Color, Style};
-use ratatui::widgets::{Block, Borders, Cell, Paragraph, Row, Table, TableState};
+use ratatui::layout::{Constraint, Direction, Layout, Rect};
+use ratatui::style::{Color, Modifier, Style};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Block, Borders, Cell, Clear, Paragraph, Row, Table, TableState};
 
 use crate::config::{Config, SecretsConfig};
 use crate::sealed;
@@ -407,6 +408,15 @@ impl SecretsState {
             None => filter_footer(&self.filter, &footer_help),
         };
         frame.render_widget(footer, layout[2]);
+
+        // Add / edit / remove flows render as modals on top of the
+        // table. Removing already had a confirmation footer; adding +
+        // editing previously inlined an extra row in the table, which
+        // operators found confusing — the table is the data, the
+        // modal is the input. Clean separation.
+        if self.input_mode() {
+            self.render_input_modal(frame);
+        }
     }
 
     fn flash_text(&self) -> Option<String> {
@@ -428,7 +438,7 @@ impl SecretsState {
         }
         let mut parts = vec!["q quit", "↑↓ select", "/ filter", "r reveal"];
         if writable {
-            parts.extend_from_slice(&["a add", "Enter edit", "x delete"]);
+            parts.extend_from_slice(&["a add", "Enter view/edit", "x delete"]);
         }
         parts.push("esc back");
         parts.join(" · ")
@@ -483,16 +493,6 @@ impl SecretsState {
             }
         }
 
-        // Append an "input row" while editing — gives the operator a
-        // visual anchor for what they're typing without a separate
-        // overlay.
-        if let Some((label, buffer)) = self.input_buffer_view() {
-            rows.push(Row::new(vec![
-                Cell::from(label).style(Style::default().fg(Color::Yellow)),
-                Cell::from(format!("{buffer}_")).style(Style::default().fg(Color::Yellow)),
-            ]));
-        }
-
         let table = Table::new(rows, widths)
             .header(Row::new(vec![
                 Cell::from("KEY").style(bold()),
@@ -504,17 +504,87 @@ impl SecretsState {
         frame.render_stateful_widget(table, area, &mut self.table);
     }
 
-    fn input_buffer_view(&self) -> Option<(String, &str)> {
-        match &self.edit {
-            EditState::AddingKey { buffer } => Some(("(new key)".into(), buffer.as_str())),
+    /// Centered input modal for the add / edit flows. The state
+    /// machine drives which field is focused: typing the key, then
+    /// the value (add); or typing the value directly (edit).
+    fn render_input_modal(&self, frame: &mut Frame<'_>) {
+        let area = frame.area();
+        let modal_width = area.width.saturating_sub(8).min(72).max(40);
+        let modal_height: u16 = 9;
+        let x = area.width.saturating_sub(modal_width) / 2;
+        let y = area.height.saturating_sub(modal_height) / 2;
+        let modal_area = Rect {
+            x,
+            y,
+            width: modal_width,
+            height: modal_height,
+        };
+
+        let (title, key_text, key_focused, value_text, value_focused) = match &self.edit {
+            EditState::AddingKey { buffer } => ("Add secret", buffer.as_str(), true, "", false),
             EditState::AddingValue { key, buffer } => {
-                Some((format!("(new value for {key})"), buffer.as_str()))
+                ("Add secret", key.as_str(), false, buffer.as_str(), true)
             }
-            EditState::EditingValue { key, buffer } => {
-                Some((format!("(editing {key})"), buffer.as_str()))
+            EditState::EditingValue { key, buffer } => (
+                "View / edit secret",
+                key.as_str(),
+                false,
+                buffer.as_str(),
+                true,
+            ),
+            _ => return,
+        };
+
+        let block = Block::default()
+            .borders(Borders::ALL)
+            .title(format!(" {title} "))
+            .style(Style::default().fg(Color::Cyan));
+        frame.render_widget(Clear, modal_area);
+        frame.render_widget(block, modal_area);
+
+        let inner = Rect {
+            x: modal_area.x + 2,
+            y: modal_area.y + 1,
+            width: modal_area.width.saturating_sub(4),
+            height: modal_area.height.saturating_sub(2),
+        };
+        let rows = Layout::default()
+            .direction(Direction::Vertical)
+            .constraints([
+                Constraint::Length(1), // KEY label
+                Constraint::Length(1), // KEY field
+                Constraint::Length(1), // spacer
+                Constraint::Length(1), // VALUE label
+                Constraint::Length(1), // VALUE field
+                Constraint::Length(1), // spacer
+                Constraint::Length(1), // hint
+            ])
+            .split(inner);
+
+        let label_style = Style::default().add_modifier(Modifier::BOLD);
+        let dim = Style::default().fg(Color::DarkGray);
+        let focused_text = Style::default().fg(Color::Yellow);
+        let unfocused_text = Style::default();
+
+        frame.render_widget(Paragraph::new("KEY").style(label_style), rows[0]);
+        let key_field = render_field(key_text, key_focused, focused_text, unfocused_text);
+        frame.render_widget(key_field, rows[1]);
+
+        frame.render_widget(Paragraph::new("VALUE").style(label_style), rows[3]);
+        // Mask the value when not revealing AND the operator is just
+        // looking at an existing entry. While they're typing it's
+        // shown literally — they're the source of the bytes.
+        let value_field = render_field(value_text, value_focused, focused_text, unfocused_text);
+        frame.render_widget(value_field, rows[4]);
+
+        let hint = match &self.edit {
+            EditState::AddingKey { .. } => "enter → next field · esc cancel",
+            EditState::AddingValue { .. } | EditState::EditingValue { .. } => {
+                "enter apply · esc cancel"
             }
-            _ => None,
-        }
+            _ => "",
+        };
+        frame.render_widget(Paragraph::new(hint).style(dim), rows[6]);
     }
 
     /// Lines for the confirmation-modal renderer (`render_modal`).
@@ -535,6 +605,27 @@ impl SecretsState {
             "[any]         cancel".into(),
         ];
         Some(("remove secret?", body))
+    }
+}
+
+/// One input field row inside the add/edit modal. Focused field
+/// renders the buffer + a cursor; unfocused field renders the value
+/// (or `(empty)` placeholder) in a dim style.
+fn render_field(
+    buffer: &str,
+    focused: bool,
+    focused_style: Style,
+    unfocused_style: Style,
+) -> Paragraph<'_> {
+    if focused {
+        Paragraph::new(Line::from(vec![
+            Span::styled(buffer.to_string(), focused_style),
+            Span::styled("_", focused_style.add_modifier(Modifier::SLOW_BLINK)),
+        ]))
+    } else if buffer.is_empty() {
+        Paragraph::new(Span::styled("(empty)", unfocused_style.fg(Color::DarkGray)))
+    } else {
+        Paragraph::new(Span::styled(buffer.to_string(), unfocused_style))
     }
 }
 

--- a/yoink/src/tui/secrets.rs
+++ b/yoink/src/tui/secrets.rs
@@ -409,11 +409,8 @@ impl SecretsState {
         };
         frame.render_widget(footer, layout[2]);
 
-        // Add / edit / remove flows render as modals on top of the
-        // table. Removing already had a confirmation footer; adding +
-        // editing previously inlined an extra row in the table, which
-        // operators found confusing — the table is the data, the
-        // modal is the input. Clean separation.
+        // Add / view-edit modal renders on top of the table when
+        // input mode is active.
         if self.input_mode() {
             self.render_input_modal(frame);
         }
@@ -562,20 +559,10 @@ impl SecretsState {
             .split(inner);
 
         let label_style = Style::default().add_modifier(Modifier::BOLD);
-        let dim = Style::default().fg(Color::DarkGray);
-        let focused_text = Style::default().fg(Color::Yellow);
-        let unfocused_text = Style::default();
-
         frame.render_widget(Paragraph::new("KEY").style(label_style), rows[0]);
-        let key_field = render_field(key_text, key_focused, focused_text, unfocused_text);
-        frame.render_widget(key_field, rows[1]);
-
+        frame.render_widget(render_field(key_text, key_focused), rows[1]);
         frame.render_widget(Paragraph::new("VALUE").style(label_style), rows[3]);
-        // Mask the value when not revealing AND the operator is just
-        // looking at an existing entry. While they're typing it's
-        // shown literally — they're the source of the bytes.
-        let value_field = render_field(value_text, value_focused, focused_text, unfocused_text);
-        frame.render_widget(value_field, rows[4]);
+        frame.render_widget(render_field(value_text, value_focused), rows[4]);
 
         let hint = match &self.edit {
             EditState::AddingKey { .. } => "enter → next field · esc cancel",
@@ -584,7 +571,10 @@ impl SecretsState {
             }
             _ => "",
         };
-        frame.render_widget(Paragraph::new(hint).style(dim), rows[6]);
+        frame.render_widget(
+            Paragraph::new(hint).style(Style::default().fg(Color::DarkGray)),
+            rows[6],
+        );
     }
 
     /// Lines for the confirmation-modal renderer (`render_modal`).
@@ -609,23 +599,22 @@ impl SecretsState {
 }
 
 /// One input field row inside the add/edit modal. Focused field
-/// renders the buffer + a cursor; unfocused field renders the value
-/// (or `(empty)` placeholder) in a dim style.
-fn render_field(
-    buffer: &str,
-    focused: bool,
-    focused_style: Style,
-    unfocused_style: Style,
-) -> Paragraph<'_> {
+/// renders the buffer + blinking cursor in yellow; unfocused field
+/// renders the value (or `(empty)` placeholder) in default style.
+fn render_field(buffer: &str, focused: bool) -> Paragraph<'_> {
+    let focused_style = Style::default().fg(Color::Yellow);
     if focused {
         Paragraph::new(Line::from(vec![
-            Span::styled(buffer.to_string(), focused_style),
+            Span::styled(buffer, focused_style),
             Span::styled("_", focused_style.add_modifier(Modifier::SLOW_BLINK)),
         ]))
     } else if buffer.is_empty() {
-        Paragraph::new(Span::styled("(empty)", unfocused_style.fg(Color::DarkGray)))
+        Paragraph::new(Span::styled(
+            "(empty)",
+            Style::default().fg(Color::DarkGray),
+        ))
     } else {
-        Paragraph::new(Span::styled(buffer.to_string(), unfocused_style))
+        Paragraph::new(Span::raw(buffer))
     }
 }
 

--- a/yoink/src/tui/secrets.rs
+++ b/yoink/src/tui/secrets.rs
@@ -428,7 +428,7 @@ impl SecretsState {
         }
         let mut parts = vec!["q quit", "↑↓ select", "/ filter", "r reveal"];
         if writable {
-            parts.extend_from_slice(&["a add", "e edit", "d delete"]);
+            parts.extend_from_slice(&["a add", "Enter edit", "x delete"]);
         }
         parts.push("esc back");
         parts.join(" · ")

--- a/yoink/src/tui/services.rs
+++ b/yoink/src/tui/services.rs
@@ -332,6 +332,12 @@ impl ServiceDetailState {
             // indexes into `visible_indices()`, not `self.rows`.
             let n = self.visible_indices().len();
             clamp_selection(&mut self.table, n);
+            // Auto-select row 0 once data lands so per-row actions
+            // (`f` port-forward, `v` vscode, `!` shell) are usable
+            // without first nudging the cursor with j/k.
+            if n > 0 && self.table.selected().is_none() {
+                self.table.select(Some(0));
+            }
         }
     }
 
@@ -496,7 +502,7 @@ impl ServiceDetailState {
 
         let footer = filter_footer(
             &self.filter,
-            "q quit · esc back · ↑↓ select · enter logs · ! shell · D debug",
+            "q quit · esc back · ↑↓ select · enter logs · ! shell · f forward · v vscode · D debug",
         );
         frame.render_widget(footer, layout[2]);
     }

--- a/yoink/src/tui/services.rs
+++ b/yoink/src/tui/services.rs
@@ -330,14 +330,10 @@ impl ServiceDetailState {
             self.rows = rows;
             // Clamp against the *filtered* count — `table.selected()`
             // indexes into `visible_indices()`, not `self.rows`.
+            // `clamp_selection` also picks row 0 when none was set,
+            // so per-row actions work on first apply.
             let n = self.visible_indices().len();
             clamp_selection(&mut self.table, n);
-            // Auto-select row 0 once data lands so per-row actions
-            // (`f` port-forward, `v` vscode, `!` shell) are usable
-            // without first nudging the cursor with j/k.
-            if n > 0 && self.table.selected().is_none() {
-                self.table.select(Some(0));
-            }
         }
     }
 

--- a/yoink/src/tui/ui.rs
+++ b/yoink/src/tui/ui.rs
@@ -499,13 +499,13 @@ impl FilterState {
     /// Empty buffer means "no filter" so the user typing `/` then
     /// backspacing back to empty restores the unfiltered view.
     fn sync_filter_from_buffer(&mut self) {
-        let buf = self.input_buffer.clone().unwrap_or_default();
+        let buf = self.input_buffer.as_deref().unwrap_or("");
         if buf.is_empty() {
             self.filter = None;
             self.filter_lc = None;
         } else {
             self.filter_lc = Some(buf.to_ascii_lowercase());
-            self.filter = Some(buf);
+            self.filter = Some(buf.to_string());
         }
     }
 

--- a/yoink/src/tui/ui.rs
+++ b/yoink/src/tui/ui.rs
@@ -418,24 +418,33 @@ pub fn inline_gauge(ratio: f32, width: usize, color: Color) -> Vec<Span<'static>
     ]
 }
 
-/// Substring-filter state shared by every list/table pane. Same
-/// lifecycle as `LogsState`'s filter:
-///   `/` enters input mode → `filter_push_char` / `filter_backspace`
-///   build the buffer → Enter applies → Esc cancels.
-/// `matches(text)` returns true when there's no filter, or when
-/// `text` (case-insensitive) contains the active filter.
+/// Substring-filter state shared by every list/table pane.
+///
+/// Filters live incrementally (vim-`/` style): every keystroke
+/// updates `filter` immediately, so the visible rows shrink as the
+/// operator types. `Enter` commits the filter and exits input mode;
+/// `Esc` cancels and restores whatever was active before `/` was
+/// pressed. `matches(text)` returns true when there's no filter, or
+/// when `text` (case-insensitive) contains the active filter.
 #[derive(Default, Debug, Clone)]
 pub struct FilterState {
     /// Currently-applied filter; rows whose searched text doesn't
-    /// contain this (case-insensitive) are hidden.
+    /// contain this (case-insensitive) are hidden. Updated on every
+    /// keystroke while in input mode so the table re-filters live.
     filter: Option<String>,
     /// Lowercased copy of `filter` — cached so per-row `matches()`
     /// during a render doesn't have to lowercase the (constant)
-    /// filter every time. Set together with `filter` and cleared on
-    /// `apply`/`clear`.
+    /// filter every time. Kept in lockstep with `filter`.
     filter_lc: Option<String>,
     /// `Some(buf)` while the user is typing a new filter via `/`.
+    /// Mirrors `filter` while typing — split out so the footer can
+    /// render the literal buffer (with cursor) regardless of the
+    /// applied state.
     input_buffer: Option<String>,
+    /// Snapshot of `filter` taken when `/` was pressed — restored on
+    /// `cancel` so Esc abandons the in-progress search and reverts to
+    /// the prior view.
+    prev_filter: Option<String>,
 }
 
 impl FilterState {
@@ -444,41 +453,73 @@ impl FilterState {
     }
 
     pub fn begin_input(&mut self) {
+        self.prev_filter = self.filter.clone();
         self.input_buffer = Some(self.filter.clone().unwrap_or_default());
     }
 
     pub fn push_char(&mut self, c: char) {
         if let Some(buf) = self.input_buffer.as_mut() {
             buf.push(c);
+            self.sync_filter_from_buffer();
         }
     }
 
     pub fn backspace(&mut self) {
         if let Some(buf) = self.input_buffer.as_mut() {
             buf.pop();
+            self.sync_filter_from_buffer();
         }
     }
 
+    /// Commit the typed filter — exit input mode; `filter` is already
+    /// up to date (each keystroke synced it). Drops the prev-filter
+    /// snapshot so a subsequent Esc on a fresh `/` doesn't restore
+    /// stale state.
     pub fn apply(&mut self) {
-        if let Some(buf) = self.input_buffer.take() {
-            if buf.is_empty() {
-                self.filter = None;
-                self.filter_lc = None;
-            } else {
-                self.filter_lc = Some(buf.to_ascii_lowercase());
-                self.filter = Some(buf);
-            }
-        }
+        self.input_buffer = None;
+        self.prev_filter = None;
     }
 
+    /// Abandon the in-progress search — restore whatever filter was
+    /// active before `/` was pressed.
     pub fn cancel(&mut self) {
         self.input_buffer = None;
+        let prev = self.prev_filter.take();
+        self.set_filter(prev);
     }
 
     pub fn clear(&mut self) {
         self.filter = None;
         self.filter_lc = None;
         self.input_buffer = None;
+        self.prev_filter = None;
+    }
+
+    /// Re-derive `filter` + `filter_lc` from the current input buffer.
+    /// Empty buffer means "no filter" so the user typing `/` then
+    /// backspacing back to empty restores the unfiltered view.
+    fn sync_filter_from_buffer(&mut self) {
+        let buf = self.input_buffer.clone().unwrap_or_default();
+        if buf.is_empty() {
+            self.filter = None;
+            self.filter_lc = None;
+        } else {
+            self.filter_lc = Some(buf.to_ascii_lowercase());
+            self.filter = Some(buf);
+        }
+    }
+
+    fn set_filter(&mut self, value: Option<String>) {
+        match value {
+            None => {
+                self.filter = None;
+                self.filter_lc = None;
+            }
+            Some(s) => {
+                self.filter_lc = Some(s.to_ascii_lowercase());
+                self.filter = Some(s);
+            }
+        }
     }
 
     #[must_use]
@@ -508,7 +549,7 @@ impl FilterState {
 #[must_use]
 pub fn filter_footer(filter: &FilterState, default_help: &str) -> Paragraph<'static> {
     if let Some(buf) = filter.input_buffer() {
-        Paragraph::new(format!("/{buf}_  (enter apply · esc cancel)"))
+        Paragraph::new(format!("/{buf}_  (live · enter keep · esc revert)"))
             .style(Style::default().fg(Color::Yellow))
     } else if let Some(f) = filter.current() {
         Paragraph::new(format!(


### PR DESCRIPTION
## Summary

The TUI's global pane-nav keys (`d` Dashboard, `e` Secrets, `l` Logs, `R` Resources) preempted per-view bindings that happened to use the same letter. Operators hitting those keys to navigate ended up triggering destructive or surprising in-view actions instead — and some per-view bindings were dead code, because the global handler ran first and short-circuited with `return false`.

Reported via the secrets-pane case (`d` deleting a secret instead of going to Dashboard); audit surfaced the same pattern in four more views.

## Per-view bindings moved off colliding letters

| View | Was | Now |
|---|---|---|
| Secrets | `d` delete | `x` delete |
| Secrets | `e` edit | `Enter` edit |
| Resources | `d` remove | `x` remove |
| HostDetail | `R` restart | `T` resTart |
| ContainerDetail | `R` restart | `T` resTart |
| ContainerDetail | `l` open logs | `Enter` (already aliased) |
| ServiceHistory | `R` refresh | (removed; leave + re-enter) |

Global `d` → Dashboard now fires unconditionally (no view-guard exception) so the mnemonic is consistent across every view.

## Logs: `w` toggles line-wrap

Works regardless of whether the line came from `hl` (styled spans) or the plain forwarder — `Paragraph::wrap(Wrap { trim: false })` wraps on the rendered glyph stream after styling. Footer hint reflects state with a `*` when wrap is on. Same handler in both `View::Logs` and `View::ContainerLogs`.

## `f`/`v` reachability + discoverability in Service/Host views

- **Auto-select row 0** in HostDetail and ServiceDetail once data lands, so per-row actions (`f` port-forward, `v` vscode, `S`/`X`/`T`/`K` lifecycle, `!` shell) are usable without first nudging the cursor with j/k.
- **Footer hints** in HostDetail and ServiceDetail now explicitly list `f forward · v vscode`. Help-modal text already mentioned them globally.

## Test plan

- [x] `cargo test --lib` — 450 passed.
- [x] `cargo build` clean.
- [x] `cargo fmt` clean.
- [ ] Manual TUI: `d` from any view goes to Dashboard. `x` deletes a secret. `T` restarts a container. `w` wraps long log lines. `f`/`v` work on first key after entering HostDetail/ServiceDetail.