### PR TITLE
feat(docs): add Aptabase analytics

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -12,6 +12,7 @@
     "types:check": "fumadocs-mdx && tsc --noEmit"
   },
   "dependencies": {
+    "@aptabase/web": "^0.5.0",
     "@orama/orama": "^3.1.18",
     "@tanstack/react-router": "1.168.25",
     "@tanstack/react-router-devtools": "1.166.13",

--- a/docs/pnpm-lock.yaml
+++ b/docs/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@aptabase/web':
+        specifier: ^0.5.0
+        version: 0.5.0
       '@orama/orama':
         specifier: ^3.1.18
         version: 3.1.18
@@ -104,6 +107,9 @@ importers:
         version: 5.1.0
 
 packages:
+
+  '@aptabase/web@0.5.0':
+    resolution: {integrity: sha512-+RFdaS0bLJtqTZyB1uG32S7tuTfJTGbG2bkdVMs3AT7yG7DP2yb6JY5rZoBf3UyW9sigFHGRkbXoAXdCMZibWA==}
 
   '@babel/code-frame@7.27.1':
     resolution: {integrity: sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==}
@@ -3232,6 +3238,8 @@ packages:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
 snapshots:
+
+  '@aptabase/web@0.5.0': {}
 
   '@babel/code-frame@7.27.1':
     dependencies:

--- a/docs/src/routes/__root.tsx
+++ b/docs/src/routes/__root.tsx
@@ -1,8 +1,11 @@
-import { createRootRoute, HeadContent, Outlet, Scripts } from '@tanstack/react-router';
+import { createRootRoute, HeadContent, Outlet, Scripts, useRouterState } from '@tanstack/react-router';
 import * as React from 'react';
 import appCss from '@/styles/app.css?url';
 import { RootProvider } from 'fumadocs-ui/provider/tanstack';
 import SearchDialog from '@/components/search';
+import { init, trackEvent } from '@aptabase/web';
+
+const APTABASE_KEY = 'A-EU-6868521188';
 
 export const Route = createRootRoute({
   head: () => ({
@@ -33,6 +36,20 @@ export const Route = createRootRoute({
   component: RootComponent,
 });
 
+function Analytics() {
+  const location = useRouterState({ select: (s) => s.location });
+
+  React.useEffect(() => {
+    init(APTABASE_KEY);
+  }, []);
+
+  React.useEffect(() => {
+    trackEvent('page_view', { path: location.pathname });
+  }, [location.pathname]);
+
+  return null;
+}
+
 function RootComponent() {
   return (
     <html lang="en" suppressHydrationWarning>
@@ -44,6 +61,7 @@ function RootComponent() {
           search={{ SearchDialog }}
           theme={{ attribute: 'class', defaultTheme: 'system', disableTransitionOnChange: true }}
         >
+          <Analytics />
           <Outlet />
         </RootProvider>
         <Scripts />


### PR DESCRIPTION
## Summary

- Installs `@aptabase/web` and initialises with app key `A-EU-6868521188`
- `Analytics` component in the root layout tracks `page_view` on every route change via `useRouterState`
- Client-only (both effects in `useEffect`) — no impact on prerendering

## Test plan

- [ ] Deploy and open https://yoink.is — verify events appear in the Aptabase dashboard
- [ ] Navigate between pages — each should fire a `page_view` event with the correct `path`