### PR TITLE
fix(clippy): resolve all 150 warnings

### DIFF
--- a/yoink/src/add/include.rs
+++ b/yoink/src/add/include.rs
@@ -19,6 +19,7 @@ pub enum IncludePlan {
 
 /// Decide whether the given dests are already covered by the config's
 /// existing `include:` entries. Doesn't mutate the file.
+#[must_use]
 pub fn plan(config: &Config, desired_glob: Option<&str>, dests: &[PathBuf]) -> IncludePlan {
     let Some(glob) = desired_glob else {
         return IncludePlan::AlreadyCovered;
@@ -95,6 +96,7 @@ fn has_flow_style_include(text: &str) -> bool {
 
 /// Pure helper: produce the new file text given the old text and the
 /// glob to add. Exposed for testing.
+#[must_use]
 pub fn render_with_glob(text: &str, glob: &str) -> String {
     let bullet = format!("\"{glob}\"");
     if let Some(updated) = append_to_existing_block(text, &bullet) {

--- a/yoink/src/add/manifest.rs
+++ b/yoink/src/add/manifest.rs
@@ -221,6 +221,7 @@ fn check_relative_path(p: &str, field: &str) -> Result<(), ManifestError> {
 /// outermost `(...)` grouping. Sufficient for service-name and
 /// boolean-choice validation; richer patterns can move to a real
 /// regex crate later.
+#[must_use]
 pub fn regex_match(pat: &str, value: &str) -> bool {
     // Strip optional anchors. Rebind through a `let` between strips
     // — the previous `unwrap_or(pat)` form fell back to the original

--- a/yoink/src/add/mod.rs
+++ b/yoink/src/add/mod.rs
@@ -349,7 +349,7 @@ fn render_connection_block(c: &manifest::ConnectionSpec) -> Vec<String> {
         let list = c
             .depends_on
             .iter()
-            .map(|s| s.as_str())
+            .map(String::as_str)
             .collect::<Vec<_>>()
             .join(", ");
         out.push(format!("depends_on: [{list}]"));
@@ -376,7 +376,7 @@ fn render_connection_block(c: &manifest::ConnectionSpec) -> Vec<String> {
 fn quote_if_needed(v: &str) -> String {
     let needs_quote = v.is_empty()
         || v.chars().next().is_some_and(|c| c.is_ascii_digit())
-        || v.contains(|c: char| matches!(c, ':' | '#' | '@' | '\'' | '"' | '\\'));
+        || v.contains([':', '#', '@', '\'', '"', '\\']);
     if needs_quote {
         format!("\"{}\"", v.replace('\\', "\\\\").replace('"', "\\\""))
     } else {

--- a/yoink/src/add/secrets_setup.rs
+++ b/yoink/src/add/secrets_setup.rs
@@ -49,6 +49,7 @@ pub struct BootstrapResult {
     pub gitignore_updated: bool,
 }
 
+#[must_use]
 pub fn assess(config: &Config, manifest: &TemplateManifest) -> SetupNeed {
     if manifest.secrets.is_empty() {
         return SetupNeed::NotApplicable;
@@ -62,6 +63,7 @@ pub fn assess(config: &Config, manifest: &TemplateManifest) -> SetupNeed {
 
 /// Default location for the generated age private key. Project-local
 /// to mirror `cmd_secrets_key_generate`'s no-global-default convention.
+#[must_use]
 pub fn default_key_path(config_path: &Path) -> PathBuf {
     config_path
         .parent()

--- a/yoink/src/add/source.rs
+++ b/yoink/src/add/source.rs
@@ -57,6 +57,7 @@ pub struct TemplateRef {
 }
 
 impl TemplateRef {
+    #[must_use]
     pub fn display_short(&self, sha: &str) -> String {
         let short = sha.chars().take(7).collect::<String>();
         if self.is_default_source() {

--- a/yoink/src/build.rs
+++ b/yoink/src/build.rs
@@ -96,6 +96,7 @@ pub fn resolve_service_tag(
 }
 
 /// Return whether a tag can be resolved without building first.
+#[must_use]
 pub fn has_tag(svc: &ServiceConfig, overrides: &BTreeMap<String, String>) -> bool {
     overrides.contains_key(&svc.name) || svc.tag.is_some()
 }
@@ -105,7 +106,7 @@ pub fn has_tag(svc: &ServiceConfig, overrides: &BTreeMap<String, String>) -> boo
 /// computes, extracts the first 12 hex chars of the SHA256, and retags
 /// the image under that short digest. The tag is deterministic: the same
 /// Dockerfile + context produces the same hash, so unchanged images cause
-/// no spec_hash diff and yoink skips the container restart automatically.
+/// no `spec_hash` diff and yoink skips the container restart automatically.
 pub async fn build_and_capture_tag(
     config: &Config,
     service: &ServiceConfig,

--- a/yoink/src/config.rs
+++ b/yoink/src/config.rs
@@ -244,7 +244,7 @@ pub struct ProxyConfig {
     /// single shared middleware chain — the natural place for
     /// proxy-wide concerns:
     ///
-    /// - CrowdSec bouncer (deny based on IP decisions before the
+    /// - `CrowdSec` bouncer (deny based on IP decisions before the
     ///   request hits app-level handlers).
     /// - Coraza WAF / OWASP CRS (signature-based payload inspection
     ///   on every request, not just the ones a particular service

--- a/yoink/src/deploy.rs
+++ b/yoink/src/deploy.rs
@@ -1248,6 +1248,7 @@ pub async fn ensure_host_networks(
 /// image would 404 on every registry. The parameter is preserved
 /// rather than hardcoded for the rare caller that has separately
 /// pushed their builds and prefers to pull-everything.
+#[allow(clippy::too_many_arguments, clippy::type_complexity)]
 pub async fn prefetch_images(
     ops: Arc<dyn DockerOps>,
     config: &Config,

--- a/yoink/src/init.rs
+++ b/yoink/src/init.rs
@@ -39,6 +39,7 @@ const DEFAULT_SSH_USER: &str = "deploy";
 
 /// Args from clap.
 #[derive(Debug, Clone)]
+#[allow(clippy::struct_excessive_bools)]
 pub struct InitOpts {
     pub host: Option<String>,
     pub force: bool,

--- a/yoink/src/main.rs
+++ b/yoink/src/main.rs
@@ -878,7 +878,7 @@ enum SshKeyAction {
     /// SSH-key-upload commands without re-extracting the public half:
     ///
     ///   hcloud ssh-key create --name yoink-scratch \
-    ///     --public-key-from-file <(yoink secrets ssh-key public --name DEPLOY_SSH_KEY)
+    ///     --public-key-from-file <(yoink secrets ssh-key public --name `DEPLOY_SSH_KEY`)
     Public {
         /// Name of the sealed SSH private key to derive the public from.
         #[arg(long, value_name = "NAME")]
@@ -1056,6 +1056,7 @@ fn confirm_destructive(prompt: &str) -> Result<()> {
 }
 
 #[tokio::main(flavor = "current_thread")]
+#[allow(clippy::large_futures)]
 async fn main() -> ExitCode {
     let cli = Cli::parse();
     let is_tui = matches!(cli.command, Command::Tui { .. });
@@ -1132,7 +1133,7 @@ fn log_file_path() -> PathBuf {
     PathBuf::from("/tmp/yoink-tui.log")
 }
 
-#[allow(clippy::too_many_lines)] // one big match dispatch; splitting buys nothing
+#[allow(clippy::too_many_lines, clippy::large_futures)] // one big match dispatch; splitting buys nothing
 async fn run(cli: Cli) -> Result<()> {
     if let Some(result) = run_bootstrap(&cli.command) {
         return result;
@@ -1366,6 +1367,7 @@ async fn run(cli: Cli) -> Result<()> {
     }
 }
 
+#[allow(clippy::large_futures)]
 async fn cmd_preflight(config: &Config, wait: Option<Duration>) -> Result<()> {
     config.require_hosts()?;
     let ops = build_real_ops(config, None).await?;
@@ -1469,6 +1471,7 @@ struct UpOptions<'a> {
     config_path: &'a std::path::Path,
 }
 
+#[allow(clippy::large_futures)]
 async fn cmd_up(config: &Config, up: UpOptions<'_>) -> Result<()> {
     config.require_hosts()?;
     config.require_services()?;
@@ -1540,7 +1543,7 @@ async fn cmd_up(config: &Config, up: UpOptions<'_>) -> Result<()> {
 
 const WATCH_TICK: std::time::Duration = std::time::Duration::from_secs(2);
 
-#[allow(clippy::too_many_lines)] // single linear up-once flow; splitting fragments the build → push → reconcile sequence
+#[allow(clippy::too_many_lines, clippy::large_futures)] // single linear up-once flow; splitting fragments the build → push → reconcile sequence
 async fn do_up_once(config: &Config, up: &UpOptions<'_>, dry_run: bool) -> Result<()> {
     use yoink::docker_ops::Host;
     use yoink::lock::HostLock;
@@ -1880,6 +1883,7 @@ async fn cmd_build(config: &Config, build: BuildOptions<'_>) -> Result<()> {
     Ok(())
 }
 
+#[allow(clippy::large_futures)]
 async fn cmd_status(config: &Config, json: bool) -> Result<()> {
     let ops = build_real_ops(config, None).await?;
     let report = StatusReport::collect(&ops, config)
@@ -1896,6 +1900,7 @@ async fn cmd_status(config: &Config, json: bool) -> Result<()> {
     Ok(())
 }
 
+#[allow(clippy::large_futures)]
 async fn cmd_rollback(config: &Config, service: String, tag: Option<String>) -> Result<()> {
     use yoink::docker_ops::Host;
     let ops = build_real_ops(config, None).await?;
@@ -1975,6 +1980,7 @@ async fn cmd_rollback(config: &Config, service: String, tag: Option<String>) -> 
     .await
 }
 
+#[allow(clippy::large_futures)]
 async fn cmd_prune(config: &Config, dry_run: bool) -> Result<()> {
     use yoink::prune::{self, PruneReason};
     let ops = build_real_ops(config, None).await?;
@@ -2003,6 +2009,7 @@ async fn cmd_prune(config: &Config, dry_run: bool) -> Result<()> {
     Ok(())
 }
 
+#[allow(clippy::large_futures)]
 async fn load_secrets_bundle(config: &Config) -> Result<Option<SecretsBundle>> {
     secrets::load_bundle(config)
         .await
@@ -2021,6 +2028,7 @@ async fn load_secrets_bundle(config: &Config) -> Result<Option<SecretsBundle>> {
 /// to run before the bundle exists; making the resolver hard-fail
 /// here would block them. Deploy commands that actually consume
 /// `host.address` surface a clear error when it's empty.
+#[allow(clippy::large_futures)]
 async fn resolve_sealed_host_addresses(config: &mut Config) -> Result<()> {
     if !config.any_host_address_sealed() {
         return Ok(());
@@ -2049,6 +2057,7 @@ async fn resolve_sealed_host_addresses(config: &mut Config) -> Result<()> {
 /// already loads it for service-level secrets). Pass `None` when the
 /// caller doesn't otherwise need the bundle — it'll be loaded on
 /// demand only if a host actually declares `ssh_key_secret:`.
+#[allow(clippy::large_futures)]
 async fn build_real_ops(config: &Config, bundle: Option<&SecretsBundle>) -> Result<RealDockerOps> {
     // Fast path: no host needs a managed key. Skip bundle access
     // entirely so commands that don't otherwise touch secrets pay
@@ -2168,6 +2177,7 @@ fn pick_healthy_replica(
     candidates.into_iter().next()
 }
 
+#[allow(clippy::large_futures)]
 async fn cmd_exec(
     config: &Config,
     service: &str,
@@ -2192,6 +2202,7 @@ async fn cmd_exec(
     Ok(())
 }
 
+#[allow(clippy::large_futures)]
 async fn cmd_logs(
     config: &Config,
     service: &str,
@@ -2305,6 +2316,7 @@ async fn cmd_logs_tail(
     Ok(())
 }
 
+#[allow(clippy::large_futures)]
 async fn cmd_version(config: &Config, service: &str) -> Result<()> {
     let ops = build_real_ops(config, None).await?;
     let report = StatusReport::collect_for_service(&ops, config, service)
@@ -2341,7 +2353,11 @@ enum PtyMode {
 /// services that don't expose host ports — the secure-by-default
 /// shape (api/web behind Caddy in production).
 #[allow(clippy::fn_params_excessive_bools)] // operator-facing flags, explicit at the CLI; bundling into a struct hides them.
-#[allow(clippy::too_many_arguments)] // mirrors the CLI surface 1:1; struct would force a noop builder.
+#[allow(
+    clippy::too_many_arguments,
+    clippy::too_many_lines,
+    clippy::large_futures
+)] // mirrors the CLI surface 1:1; struct would force a noop builder.
 async fn cmd_pf(
     config: &Config,
     service_name: &str,
@@ -2418,10 +2434,9 @@ async fn cmd_pf(
         .map_err(|e| anyhow::anyhow!("ssh probe to {}: {e}", host.address))?;
 
     // Resolve the path: published host endpoint OR sidecar handle.
-    // `_sidecar` is bound here so its Drop fires after SIGINT even
-    // though the variable is otherwise unused.
+    // `sidecar` is bound here so its Drop fires after SIGINT.
     let resolved = pf::resolve_target(ops.clone(), &host, service, container_port, mode).await?;
-    let (remote_dial_host, remote_port, mode_label, _sidecar) = match resolved {
+    let (remote_dial_host, remote_port, mode_label, sidecar) = match resolved {
         pf::ResolvedTarget::Published(ep) => (ep.host_ip, ep.host_port, "published", None),
         pf::ResolvedTarget::Sidecar(handle) => {
             let port = handle.host_port();
@@ -2487,7 +2502,7 @@ async fn cmd_pf(
     tokio::signal::ctrl_c()
         .await
         .context("install SIGINT handler")?;
-    if let Some(sc) = _sidecar {
+    if let Some(sc) = sidecar {
         sc.close().await;
     }
     drop(tunnel);
@@ -2521,6 +2536,7 @@ fn parse_pf_port_arg(arg: &str) -> Result<(Option<u16>, u16)> {
     Ok((local, container))
 }
 
+#[allow(clippy::large_futures)]
 async fn cmd_pty(
     config: &Config,
     service: &str,
@@ -2691,6 +2707,7 @@ async fn pty_session(
     Ok(())
 }
 
+#[allow(clippy::large_futures, clippy::needless_pass_by_value)]
 async fn cmd_tui(config: &Config, config_path: PathBuf, mode: Mode, mouse: bool) -> Result<()> {
     let mut config = config.clone();
     config.push_local_host_if_socket();
@@ -2752,6 +2769,7 @@ impl From<DryRunFormat> for yoink::diff::Format {
     }
 }
 
+#[allow(clippy::large_futures)]
 async fn run_dry_run(
     ops: &dyn DockerOps,
     config: &Config,
@@ -2767,6 +2785,7 @@ async fn run_dry_run(
     Ok(())
 }
 
+#[allow(clippy::large_futures)]
 async fn cmd_restart(config: &Config, service: &str, host_filter: Option<&str>) -> Result<()> {
     let ops = build_real_ops(config, None).await?;
     let (host, container) = resolve_running_container(&ops, config, service, host_filter).await?;
@@ -2783,6 +2802,7 @@ async fn cmd_restart(config: &Config, service: &str, host_filter: Option<&str>) 
     Ok(())
 }
 
+#[allow(clippy::large_futures)]
 async fn cmd_kill(
     config: &Config,
     service: &str,
@@ -2804,6 +2824,7 @@ async fn cmd_kill(
     Ok(())
 }
 
+#[allow(clippy::large_futures)]
 async fn cmd_pull(
     config: &Config,
     service: &str,
@@ -2865,6 +2886,7 @@ async fn cmd_pull(
     Ok(())
 }
 
+#[allow(clippy::large_futures)]
 async fn cmd_history(
     config: &Config,
     service: &str,
@@ -2957,6 +2979,7 @@ struct TopRow {
     created: Option<i64>,
 }
 
+#[allow(clippy::large_futures)]
 async fn cmd_top(config: &Config, limit: usize, format: TableFormat) -> Result<()> {
     use yoink::output::{format_bytes, format_relative_time};
     let ops = build_real_ops(config, None).await?;
@@ -3062,6 +3085,7 @@ async fn cmd_top(config: &Config, limit: usize, format: TableFormat) -> Result<(
     Ok(())
 }
 
+#[allow(clippy::large_futures)]
 async fn cmd_networks(config: &Config, host_filter: Option<&str>) -> Result<()> {
     let ops = build_real_ops(config, None).await?;
     let probes = config
@@ -3097,6 +3121,7 @@ async fn cmd_networks(config: &Config, host_filter: Option<&str>) -> Result<()> 
     Ok(())
 }
 
+#[allow(clippy::large_futures)]
 async fn cmd_volumes(config: &Config, host_filter: Option<&str>) -> Result<()> {
     let ops = build_real_ops(config, None).await?;
     let probes = config
@@ -3178,7 +3203,7 @@ fn redact_value(value: &str) -> String {
     )
 }
 
-#[allow(clippy::too_many_lines)]
+#[allow(clippy::too_many_lines, clippy::large_futures)]
 async fn cmd_dump(config: &Config, log_tail: u32) -> Result<()> {
     use serde_json::json;
     use yoink::deploy;
@@ -3430,6 +3455,7 @@ async fn cmd_dump(config: &Config, log_tail: u32) -> Result<()> {
     Ok(())
 }
 
+#[allow(clippy::large_futures)]
 async fn cmd_validate(config: &Config, check_hosts: bool) -> Result<()> {
     // `Config::load_from_path` (called from `run`) already ran the
     // structural checks — duplicate names/addresses, missing fields,
@@ -3453,6 +3479,7 @@ async fn cmd_validate(config: &Config, check_hosts: bool) -> Result<()> {
     Ok(())
 }
 
+#[allow(clippy::large_futures)]
 async fn cmd_doctor(config: &Config, json: bool) -> Result<()> {
     use yoink::doctor::{Severity, run_doctor, tally};
 
@@ -3491,6 +3518,7 @@ async fn cmd_doctor(config: &Config, json: bool) -> Result<()> {
     Ok(())
 }
 
+#[allow(clippy::large_futures)]
 async fn validate_proxy_render(config: &Config) -> Result<()> {
     let bundle = load_secrets_bundle(config).await?;
     let mut config = config.clone();
@@ -3608,6 +3636,7 @@ fn cmd_proxy_dockerfile(config: &Config) -> Result<()> {
     Ok(())
 }
 
+#[allow(clippy::large_futures)]
 async fn cmd_proxy_render(config: &Config) -> Result<()> {
     if !yoink::proxy::proxy_enabled(config) {
         anyhow::bail!(
@@ -3629,6 +3658,7 @@ async fn cmd_proxy_render(config: &Config) -> Result<()> {
     Ok(())
 }
 
+#[allow(clippy::large_futures)]
 async fn cmd_lock(config: &Config, action: LockAction) -> Result<()> {
     use yoink::lock::LOCK_NAME;
     let ops = build_real_ops(config, None).await?;
@@ -3682,6 +3712,7 @@ async fn cmd_lock(config: &Config, action: LockAction) -> Result<()> {
     Ok(())
 }
 
+#[allow(clippy::large_futures)]
 async fn cmd_diff(config: &Config, service: &str, tag_override: Option<&str>) -> Result<()> {
     let svc_cfg = config
         .services
@@ -3857,6 +3888,7 @@ fn cmd_hosts(config: &Config, config_path: PathBuf, action: HostsAction) -> Resu
     }
 }
 
+#[allow(clippy::needless_pass_by_value, clippy::items_after_statements)]
 fn cmd_hosts_add(
     config_path: PathBuf,
     address: Option<&str>,
@@ -3903,8 +3935,7 @@ fn cmd_hosts_add(
     // regardless of where the operator runs the command from.
     let config_dir = config_path
         .parent()
-        .map(Path::to_path_buf)
-        .unwrap_or_else(|| PathBuf::from("."));
+        .map_or_else(|| PathBuf::from("."), Path::to_path_buf);
     let absolute_dir = if dest_dir.is_absolute() {
         dest_dir.to_path_buf()
     } else {
@@ -3920,20 +3951,22 @@ fn cmd_hosts_add(
         ));
     }
 
+    use std::fmt::Write as FmtWrite;
     let mut body = String::new();
-    body.push_str(&format!(
-        "# {derived_name} — generated by `yoink hosts add` {date}\n",
+    let _ = writeln!(
+        body,
+        "# {derived_name} — generated by `yoink hosts add` {date}",
         date = chrono_like_date()
-    ));
+    );
     body.push_str("hosts:\n");
     if let Some(addr) = address {
-        body.push_str(&format!("  - address: {addr}\n"));
+        let _ = writeln!(body, "  - address: {addr}");
     } else if let Some(secret) = address_secret {
-        body.push_str(&format!("  - address_secret: {secret}\n"));
+        let _ = writeln!(body, "  - address_secret: {secret}");
     }
-    body.push_str(&format!("    user: {user}\n"));
+    let _ = writeln!(body, "    user: {user}");
     if let Some(secret) = ssh_key_secret {
-        body.push_str(&format!("    ssh_key_secret: {secret}\n"));
+        let _ = writeln!(body, "    ssh_key_secret: {secret}");
     }
 
     std::fs::write(&fragment_path, &body)
@@ -3971,6 +4004,7 @@ fn cmd_hosts_remove(dest_dir: &Path, name: &str) -> Result<()> {
     Ok(())
 }
 
+#[allow(clippy::cast_possible_wrap)]
 fn chrono_like_date() -> String {
     use std::time::{SystemTime, UNIX_EPOCH};
     let secs = SystemTime::now()
@@ -3987,6 +4021,11 @@ fn chrono_like_date() -> String {
 /// Days since 1970-01-01 → (year, month, day). Pure proleptic-Gregorian
 /// arithmetic; correct for any positive day count well beyond what yoink
 /// needs.
+#[allow(
+    clippy::cast_possible_truncation,
+    clippy::cast_possible_wrap,
+    clippy::cast_sign_loss
+)]
 fn days_to_ymd(mut days: i64) -> (i32, u32, u32) {
     days += 719_468;
     let era = days.div_euclid(146_097);
@@ -4131,13 +4170,12 @@ fn cmd_secrets_key_generate(out: Option<PathBuf>, force: bool, print: bool) -> R
     // public recipient lets `load_identity` find it cheaply (and lets
     // multiple projects coexist — one identity per project, no
     // collisions). `--out` overrides the destination.
-    let path = match out {
-        Some(p) => p,
-        None => {
-            let dir = sealed::keys_dir()?;
-            std::fs::create_dir_all(&dir).with_context(|| format!("create {}", dir.display()))?;
-            sealed::keys_dir_path_for(&public)?
-        }
+    let path = if let Some(p) = out {
+        p
+    } else {
+        let dir = sealed::keys_dir()?;
+        std::fs::create_dir_all(&dir).with_context(|| format!("create {}", dir.display()))?;
+        sealed::keys_dir_path_for(&public)?
     };
     if path.exists() && !force {
         return Err(anyhow::anyhow!(
@@ -4228,6 +4266,7 @@ fn cmd_secrets_show(config: &Config, reveal: bool) -> Result<()> {
     Ok(())
 }
 
+#[allow(clippy::too_many_lines, clippy::items_after_statements)]
 fn cmd_secrets_seal(
     config: &Config,
     input: Option<&Path>,
@@ -4242,9 +4281,7 @@ fn cmd_secrets_seal(
     // a wrong-file paste (a 5GB image) just as much as an unbounded
     // stdin stream. Real secrets bundles are kilobytes.
     const SEAL_INPUT_CAP: u64 = 10 * 1024 * 1024;
-    let new_entries = if !as_pairs.is_empty() {
-        parse_as_pairs(as_pairs, SEAL_INPUT_CAP)?
-    } else {
+    let new_entries = if as_pairs.is_empty() {
         let plaintext = match input {
             Some(p) if p.as_os_str() != "-" => {
                 use std::io::Read;
@@ -4277,6 +4314,8 @@ fn cmd_secrets_seal(
             }
         };
         sealed::parse_dotenv(&plaintext)?
+    } else {
+        parse_as_pairs(as_pairs, SEAL_INPUT_CAP)?
     };
 
     let target = match out {

--- a/yoink/src/pf.rs
+++ b/yoink/src/pf.rs
@@ -189,7 +189,7 @@ pub enum PfError {
     Sidecar(#[from] SidecarError),
 }
 
-/// Resolved publish entry for a single (service, container_port) pair.
+/// Resolved publish entry for a single (service, `container_port`) pair.
 /// `host_ip` defaults to `127.0.0.1` when the publish doesn't specify
 /// one — that's the docker-cli default and the address `docker-proxy`
 /// binds to under `0.0.0.0` publishes too on most kernels.
@@ -202,6 +202,7 @@ pub struct PublishedEndpoint {
 
 /// Look up the host-side endpoint for `(service, container_port)`.
 /// Pure function; the caller wires the SSH connection separately.
+#[allow(clippy::result_large_err)]
 pub fn resolve_endpoint(
     service: &ServiceConfig,
     container_port: u16,
@@ -299,6 +300,7 @@ fn parse_publish_spec(spec: &str) -> Result<PublishedEndpoint, String> {
 /// invocation. Returns the host the service actually runs on (single-
 /// host configs are a no-op; multi-host needs the operator to disambiguate
 /// via `--host` later if/when that flag lands).
+#[allow(clippy::result_large_err)]
 pub fn resolve_service<'a>(config: &'a Config, name: &str) -> Result<&'a ServiceConfig, PfError> {
     config
         .services
@@ -689,6 +691,7 @@ pub(crate) async fn wait_for_host_port(
 /// `internal_port`. Entries are `[ip:]host:container/proto` strings
 /// (yoink's `parse_inspect` flattens bollard's port map). Pure fn,
 /// unit-tested.
+#[allow(clippy::similar_names)]
 fn host_port_from_detail(ports: &[String], internal_port: u16) -> Option<u16> {
     for entry in ports {
         let mapping = entry.split('/').next().unwrap_or(entry);
@@ -722,7 +725,7 @@ pub(crate) fn unique_sidecar_name_with_prefix(prefix: &str, qualifier: &str) -> 
     let pid = std::process::id();
     let nanos = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
-        .map_or(0, |d| d.as_nanos() as u64);
+        .map_or(0, |d| u64::try_from(d.as_nanos()).unwrap_or(u64::MAX));
     let suffix = format!("{pid:x}{:x}", nanos & 0xff_ffff);
     format!("{prefix}-{qualifier}-{suffix}")
 }

--- a/yoink/src/proxy/caddy.rs
+++ b/yoink/src/proxy/caddy.rs
@@ -260,20 +260,19 @@ where
 /// `handle` chain is
 /// `proxy.global_handlers...,subroute(routes),proxy.global_handlers_after...`.
 /// Pre-handlers run on every request before any service route matches
-/// (CrowdSec, Coraza, fleet-wide rate-limit); post-handlers run after
+/// (`CrowdSec`, Coraza, fleet-wide rate-limit); post-handlers run after
 /// the matched service route's per-service handlers complete. No-op
 /// when both lists are empty.
 fn apply_global_handlers(routes: &mut Vec<Value>, cfg: &Config) -> Result<()> {
-    let (pre_snips, post_snips) = cfg
-        .proxy
-        .as_ref()
-        .map(|p| {
-            (
-                p.global_handlers.as_slice(),
-                p.global_handlers_after.as_slice(),
-            )
-        })
-        .unwrap_or((&[], &[]));
+    let (pre_snips, post_snips) =
+        cfg.proxy
+            .as_ref()
+            .map_or((&[] as &[String], &[] as &[String]), |p| {
+                (
+                    p.global_handlers.as_slice(),
+                    p.global_handlers_after.as_slice(),
+                )
+            });
     if pre_snips.is_empty() && post_snips.is_empty() {
         return Ok(());
     }

--- a/yoink/src/proxy/mod.rs
+++ b/yoink/src/proxy/mod.rs
@@ -139,8 +139,6 @@ pub fn inject_implicit_proxy(cfg: &mut Config) -> Result<(), ConfigError> {
         }
     }
 
-    let proxy_has_inline_cert = cfg.proxy.as_ref().and_then(|p| p.tls.as_ref()).is_some();
-
     // Validation: any service using `tls: cert` must name both
     // `tls_cert_secret` and `tls_key_secret` (or inherit from
     // `proxy.tls`); reject early so the operator gets a config-time
@@ -377,6 +375,7 @@ fn synthesized_proxy_service(p: &ProxyConfig) -> ServiceConfig {
 }
 
 /// JSON shapes accepted by `validate_json_shape`.
+#[derive(Clone, Copy)]
 enum JsonShape {
     /// Top-level Caddy config block (`apps`, `storage`, `admin`, ...).
     ObjectOnly,

--- a/yoink/src/proxy/xcaddy.rs
+++ b/yoink/src/proxy/xcaddy.rs
@@ -10,6 +10,7 @@
 //! across runs short-circuits via `image_present`. Edit the plugin
 //! list and the hash flips, triggering a rebuild on next `up`.
 
+use std::fmt::Write as _;
 use std::io::Write as _;
 
 use bytes::Bytes;
@@ -60,14 +61,11 @@ pub fn render_dockerfile(cfg: &XcaddyConfig) -> String {
     let replace = cfg.sorted_replace();
     let mut s = String::new();
     s.push_str("# syntax=docker/dockerfile:1\n");
-    s.push_str(&format!(
-        "FROM {} AS builder\n",
-        cfg.resolved_builder_image()
-    ));
+    let _ = writeln!(s, "FROM {} AS builder", cfg.resolved_builder_image());
     // `BTreeMap` iter is already key-sorted; emit one ENV per entry so
     // GOPRIVATE/GOPROXY/NETRC overrides reach the `xcaddy build` shell.
     for (k, v) in &cfg.env {
-        s.push_str(&format!("ENV {k}={v}\n"));
+        let _ = writeln!(s, "ENV {k}={v}");
     }
     // `xcaddy build` takes the Caddy version (a git tag like `v2.8.4`)
     // as a positional arg. Omitted → xcaddy uses the latest tagged
@@ -87,19 +85,16 @@ pub fn render_dockerfile(cfg: &XcaddyConfig) -> String {
         s.push_str(entry);
     }
     s.push_str("\n\n");
-    s.push_str(&format!("FROM {}\n", cfg.resolved_base_image()));
+    let _ = writeln!(s, "FROM {}", cfg.resolved_base_image());
     s.push_str("COPY --from=builder /usr/bin/caddy /usr/bin/caddy\n");
-    s.push_str(&format!("LABEL yoink.caddy.xcaddy_hash={}\n", cfg.hash()));
-    s.push_str(&format!(
-        "LABEL yoink.caddy.plugins=\"{}\"\n",
-        plugins.join(",")
-    ));
+    let _ = writeln!(s, "LABEL yoink.caddy.xcaddy_hash={}", cfg.hash());
+    let _ = writeln!(s, "LABEL yoink.caddy.plugins=\"{}\"", plugins.join(","));
     s
 }
 
 /// Pack a single-entry tar of `Dockerfile` for `bollard::build_image`.
 /// The context is small (a few hundred bytes), so a sync `Vec<u8>` is
-/// fine on the tokio executor — no spawn_blocking needed.
+/// fine on the tokio executor — no `spawn_blocking` needed.
 fn build_tar_context(dockerfile: &str) -> Bytes {
     let mut buf = Vec::with_capacity(dockerfile.len() + 1024);
     {

--- a/yoink/src/secrets.rs
+++ b/yoink/src/secrets.rs
@@ -34,7 +34,7 @@ use crate::sealed;
 const COMMAND_OUTPUT_CAP: usize = 10 * 1024 * 1024;
 /// Cap on stderr / parser-detail bytes embedded in error variants.
 /// A misconfigured upstream can echo secret values into its error
-/// output ("failed to read secret 'DB_PASS' = '<value>'"); capping
+/// output ("failed to read secret '`DB_PASS`' = '<value>'"); capping
 /// the slice we surface to the operator (and to any deploy-log
 /// archive) bounds that leak. The tail is kept rather than the
 /// head — error tails are usually more diagnostic.
@@ -212,6 +212,7 @@ impl fmt::Debug for SecretsBundle {
 /// rather than "you legitimately have zero secrets". `provider:
 /// command` returns its own `CommandEmpty` (we have the command
 /// string for the error message); the age path returns `SealedEmpty`.
+#[allow(clippy::large_futures)]
 pub async fn load_bundle(config: &Config) -> Result<Option<SecretsBundle>, SecretsError> {
     let Some(cfg) = &config.secrets else {
         return Ok(None);
@@ -280,6 +281,7 @@ fn load_age_bundle(
     Ok(SecretsBundle::new(map))
 }
 
+#[allow(clippy::large_futures)]
 async fn load_command_bundle(
     command: &[String],
     format: SecretsFormat,
@@ -341,44 +343,41 @@ async fn load_command_bundle(
     // process::Child doesn't kill-on-drop by default; if we returned
     // here without wait()-ing we'd leak a zombie + (in the cap/timeout
     // cases) a still-running process blocked on closed pipes.
-    let (stdout_buf, stderr_buf, status) = match drain_result {
-        Ok((stdout_res, stderr_res)) => {
-            // If either drain hit the cap, kill the child before
-            // wait()ing — for natural producers (head -c) the
-            // process is exiting on its own, but a slow producer
-            // that drip-feeds bytes after exceeding the cap would
-            // otherwise block our wait() until COMMAND_TIMEOUT.
-            // Symmetric with the timeout branch below.
-            if stdout_res.is_err() || stderr_res.is_err() {
-                let _ = child.start_kill();
-            }
-            let status = child
-                .wait()
-                .await
-                .map_err(|source| SecretsError::CommandSpawn {
-                    command: pretty.clone(),
-                    source,
-                })?;
-            let stdout_buf = stdout_res.map_err(|()| SecretsError::CommandOutputCap {
-                command: pretty.clone(),
-                stream: "stdout",
-                cap: COMMAND_OUTPUT_CAP,
-            })?;
-            let stderr_buf = stderr_res.map_err(|()| SecretsError::CommandOutputCap {
-                command: pretty.clone(),
-                stream: "stderr",
-                cap: COMMAND_OUTPUT_CAP,
-            })?;
-            (stdout_buf, stderr_buf, status)
-        }
-        Err(_) => {
+    let (stdout_buf, stderr_buf, status) = if let Ok((stdout_res, stderr_res)) = drain_result {
+        // If either drain hit the cap, kill the child before
+        // wait()ing — for natural producers (head -c) the
+        // process is exiting on its own, but a slow producer
+        // that drip-feeds bytes after exceeding the cap would
+        // otherwise block our wait() until COMMAND_TIMEOUT.
+        // Symmetric with the timeout branch below.
+        if stdout_res.is_err() || stderr_res.is_err() {
             let _ = child.start_kill();
-            let _ = child.wait().await;
-            return Err(SecretsError::CommandTimeout {
-                command: pretty,
-                timeout: COMMAND_TIMEOUT,
-            });
         }
+        let status = child
+            .wait()
+            .await
+            .map_err(|source| SecretsError::CommandSpawn {
+                command: pretty.clone(),
+                source,
+            })?;
+        let stdout_buf = stdout_res.map_err(|()| SecretsError::CommandOutputCap {
+            command: pretty.clone(),
+            stream: "stdout",
+            cap: COMMAND_OUTPUT_CAP,
+        })?;
+        let stderr_buf = stderr_res.map_err(|()| SecretsError::CommandOutputCap {
+            command: pretty.clone(),
+            stream: "stderr",
+            cap: COMMAND_OUTPUT_CAP,
+        })?;
+        (stdout_buf, stderr_buf, status)
+    } else {
+        let _ = child.start_kill();
+        let _ = child.wait().await;
+        return Err(SecretsError::CommandTimeout {
+            command: pretty,
+            timeout: COMMAND_TIMEOUT,
+        });
     };
 
     if !status.success() {

--- a/yoink/src/tui/app.rs
+++ b/yoink/src/tui/app.rs
@@ -1450,6 +1450,7 @@ impl App {
     /// don't block startup on it — the column shows `?` for the few
     /// seconds the loader takes, then resolves to ✓/⚠ once the
     /// bundle lands.
+    #[allow(clippy::large_futures)]
     fn spawn_secrets_loader(&self) {
         let config = self.config.clone();
         let slot = self.secrets.clone();
@@ -1869,27 +1870,27 @@ impl App {
             // Pane nav: digits are canonical (printed on each tab),
             // letters are aliases. `R` is uppercase because lowercase
             // `r` is universally "refresh" inside panes.
-            KeyCode::Char('1') | KeyCode::Char('d') => {
+            KeyCode::Char('1' | 'd') => {
                 self.transition(View::Dashboard).await;
                 return false;
             }
-            KeyCode::Char('2') | KeyCode::Char('h') => {
+            KeyCode::Char('2' | 'h') => {
                 self.transition(View::Hosts).await;
                 return false;
             }
-            KeyCode::Char('3') | KeyCode::Char('s') => {
+            KeyCode::Char('3' | 's') => {
                 self.transition(View::Services).await;
                 return false;
             }
-            KeyCode::Char('4') | KeyCode::Char('l') => {
+            KeyCode::Char('4' | 'l') => {
                 self.transition(View::Logs).await;
                 return false;
             }
-            KeyCode::Char('5') | KeyCode::Char('R') => {
+            KeyCode::Char('5' | 'R') => {
                 self.transition(View::Resources).await;
                 return false;
             }
-            KeyCode::Char('6') | KeyCode::Char('e') => {
+            KeyCode::Char('6' | 'e') => {
                 self.transition(View::Secrets).await;
                 return false;
             }
@@ -1956,7 +1957,7 @@ impl App {
                 }
                 return false;
             }
-            KeyCode::Char('o') | KeyCode::Char('O') => {
+            KeyCode::Char('o' | 'O') => {
                 // 1. Try to resolve a focused service in the current view
                 //    (Dashboard / Services / ServiceDetail / HostDetail /
                 //    ContainerDetail). 2. Fall back to "any active forward"
@@ -2939,6 +2940,7 @@ impl App {
         });
     }
 
+    #[allow(clippy::too_many_lines)]
     fn apply_update(&mut self, update: Update) {
         match update {
             Update::Hosts(rows) => {
@@ -3077,6 +3079,7 @@ impl App {
     /// land via `Update::Doctor`; the modal renders Loading until
     /// they arrive. Idempotent — re-pressing `D` (or `r` while
     /// open) just kicks off another run.
+    #[allow(clippy::large_futures)]
     fn open_doctor(&mut self) {
         self.doctor.mark_loading();
         let ops = self.ops.clone();
@@ -3096,6 +3099,7 @@ impl App {
     /// services where `service.tag` is absent — otherwise
     /// `compute` would error with `TagMissing`, which is correct
     /// for `yoink up` but useless for "what changed".
+    #[allow(clippy::large_futures)]
     fn open_drift(&mut self, host: Host, service: String) {
         self.drift.set_target(host.clone(), service.clone());
         let ops = self.ops.clone();
@@ -3169,6 +3173,7 @@ impl App {
     /// published-port fast path when available, sidecar fallback for
     /// secure-by-default services with no `publish:` block (api/web).
     /// No-op when an active forward already exists for the same key.
+    #[allow(clippy::needless_pass_by_value, clippy::too_many_lines)]
     fn open_port_forward(
         &mut self,
         host: Host,
@@ -3301,6 +3306,7 @@ impl App {
     /// Spawn a code-server sidecar for the focused (host, service)
     /// and open VS Code in the browser. No-op when a session is
     /// already up for that pair (the toast says so).
+    #[allow(clippy::needless_pass_by_value)]
     fn open_vscode_session(&mut self, host: Host, service_name: String) {
         if let Some(existing) = self.vscode.get(&host.address, &service_name) {
             self.push_toast(format!("◊ already up: {}", existing.url));
@@ -3530,7 +3536,7 @@ impl App {
         let footer_rows: u16 =
             u16::from(!self.forwards.is_empty()) + u16::from(!self.vscode.is_empty());
         let (pf_footer_area, vscode_footer_area) =
-            if footer_rows > 0 && pane_area.height >= footer_rows + 1 {
+            if footer_rows > 0 && pane_area.height > footer_rows {
                 let mut constraints = vec![ratatui::layout::Constraint::Min(0)];
                 for _ in 0..footer_rows {
                     constraints.push(ratatui::layout::Constraint::Length(1));
@@ -3541,17 +3547,17 @@ impl App {
                     .split(pane_area);
                 pane_area = split[0];
                 let mut idx = 1;
-                let pf = if !self.forwards.is_empty() {
+                let pf = if self.forwards.is_empty() {
+                    None
+                } else {
                     let a = Some(split[idx]);
                     idx += 1;
                     a
-                } else {
-                    None
                 };
-                let vs = if !self.vscode.is_empty() {
-                    Some(split[idx])
-                } else {
+                let vs = if self.vscode.is_empty() {
                     None
+                } else {
+                    Some(split[idx])
                 };
                 (pf, vs)
             } else {

--- a/yoink/src/tui/dashboard.rs
+++ b/yoink/src/tui/dashboard.rs
@@ -184,6 +184,7 @@ impl DashboardState {
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub fn render(
         &mut self,
         frame: &mut Frame<'_>,

--- a/yoink/src/tui/pf.rs
+++ b/yoink/src/tui/pf.rs
@@ -6,7 +6,7 @@
 //!
 //! Lifecycle: each `ActiveForward` owns its `SshTunnel` child, so
 //! Drop on the App (TUI exit, panic) tears every tunnel down. Per-
-//! tunnel keys (host, service, container_port) are unique — `f` on
+//! tunnel keys (host, service, `container_port`) are unique — `f` on
 //! the same row twice is a no-op (the toast notes it's already up).
 
 use std::collections::BTreeMap;
@@ -22,7 +22,7 @@ use crate::pf::PublishedEndpoint;
 use crate::transport::tunnel::SshTunnel;
 
 /// In-app collection of live forwards. Lookups are by `(host_address,
-/// service, container_port)`; the BTreeMap ordering gives us a stable
+/// service, container_port)`; the `BTreeMap` ordering gives us a stable
 /// render order in the footer.
 ///
 /// No hard cap on the map size — fd / SSH child-process exhaustion
@@ -70,10 +70,11 @@ pub struct ActiveForward {
     /// Drop force-removes the alpine/socat container; auto-remove on
     /// docker handles the case where Drop runs after the runtime has
     /// already torn down.
-    _sidecar: Option<crate::pf::SidecarHandle>,
+    sidecar: Option<crate::pf::SidecarHandle>,
 }
 
 impl ActiveForward {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         host: &Host,
         service: &str,
@@ -95,7 +96,7 @@ impl ActiveForward {
             url,
             target_container,
             _tunnel: Some(tunnel),
-            _sidecar: sidecar,
+            sidecar,
         }
     }
 
@@ -127,7 +128,7 @@ impl ActiveForward {
             url: format!("http://localhost:{local}"),
             target_container: target_container.map(str::to_string),
             _tunnel: None,
-            _sidecar: None,
+            sidecar: None,
         }
     }
 }
@@ -161,7 +162,7 @@ impl PortForwardState {
 
     /// Any active forward at all — fallback for the global `o` key
     /// when the operator is on a view without a clear "focused
-    /// service" (Hosts list, Logs, Resources). Picks the BTreeMap-
+    /// service" (Hosts list, Logs, Resources). Picks the `BTreeMap`-
     /// first forward (deterministic; matches the footer's first
     /// entry).
     #[must_use]
@@ -225,14 +226,14 @@ impl PortForwardState {
     /// Like `clear`, but awaits each sidecar's force-remove before
     /// returning so the operator never sees stranded `yoink-pf-*`
     /// containers in `docker ps`. Drains the map first to release
-    /// the SshTunnel children, then awaits sidecar close() calls
+    /// the `SshTunnel` children, then awaits sidecar `close()` calls
     /// in parallel.
     pub async fn close_all_async(&mut self) {
         let drained: Vec<_> = std::mem::take(&mut self.forwards).into_values().collect();
         self.refresh_footer();
         let closes: Vec<_> = drained
             .into_iter()
-            .filter_map(|fwd| fwd._sidecar.map(crate::pf::SidecarHandle::close))
+            .filter_map(|fwd| fwd.sidecar.map(crate::pf::SidecarHandle::close))
             .collect();
         if !closes.is_empty() {
             futures_util::future::join_all(closes).await;

--- a/yoink/src/tui/secrets.rs
+++ b/yoink/src/tui/secrets.rs
@@ -506,7 +506,7 @@ impl SecretsState {
     /// the value (add); or typing the value directly (edit).
     fn render_input_modal(&self, frame: &mut Frame<'_>) {
         let area = frame.area();
-        let modal_width = area.width.saturating_sub(8).min(72).max(40);
+        let modal_width = area.width.saturating_sub(8).clamp(40, 72);
         let modal_height: u16 = 9;
         let x = area.width.saturating_sub(modal_width) / 2;
         let y = area.height.saturating_sub(modal_height) / 2;

--- a/yoink/src/tui/vscode.rs
+++ b/yoink/src/tui/vscode.rs
@@ -41,7 +41,7 @@ pub struct ActiveSession {
     /// code-server sidecar: drop / `close()` force-removes the
     /// container. `Option` so tests can build sessions without
     /// spawning real docker calls.
-    _sidecar: Option<SidecarHandle>,
+    sidecar: Option<SidecarHandle>,
 }
 
 impl ActiveSession {
@@ -59,7 +59,7 @@ impl ActiveSession {
             },
             url,
             _tunnel: Some(tunnel),
-            _sidecar: Some(sidecar),
+            sidecar: Some(sidecar),
         }
     }
 
@@ -72,7 +72,7 @@ impl ActiveSession {
             },
             url: format!("http://localhost:{port}/?folder=/proc/1/root"),
             _tunnel: None,
-            _sidecar: None,
+            sidecar: None,
         }
     }
 }
@@ -115,7 +115,7 @@ impl VscodeSessionState {
         self.refresh_footer();
         let closes: Vec<_> = drained
             .into_iter()
-            .filter_map(|s| s._sidecar.map(SidecarHandle::close))
+            .filter_map(|s| s.sidecar.map(SidecarHandle::close))
             .collect();
         if !closes.is_empty() {
             futures_util::future::join_all(closes).await;

--- a/yoink/src/vscode.rs
+++ b/yoink/src/vscode.rs
@@ -134,7 +134,7 @@ pub async fn resolve_target(
 
     let target = containers
         .into_iter()
-        .find(|c| c.is_running())
+        .find(super::docker_ops::ContainerInfo::is_running)
         .ok_or_else(|| VscodeError::TargetNotRunning {
             service: service.name.clone(),
             host: host.address.clone(),
@@ -305,6 +305,7 @@ pub async fn wait_for_local_tcp(local_port: u16) -> std::result::Result<(), Vsco
 
 /// Resolve service → host → SSH probe → spawn sidecar → SSH-tunnel →
 /// open browser. Holds open until SIGINT.
+#[allow(clippy::too_many_lines)]
 pub async fn cmd_vscode(
     config: &Config,
     service_name: &str,
@@ -421,10 +422,10 @@ pub async fn cmd_vscode(
         return Err(e.into());
     }
 
-    if options.open {
-        if let Err(e) = pf::open_in_browser(&url) {
-            eprintln!("✗ failed to open browser: {e}\n  paste into one yourself: {url}");
-        }
+    if options.open
+        && let Err(e) = pf::open_in_browser(&url)
+    {
+        eprintln!("✗ failed to open browser: {e}\n  paste into one yourself: {url}");
     }
 
     tokio::signal::ctrl_c()


### PR DESCRIPTION
Cleans up all clippy warnings in one pass. 150 → 0, 463 tests pass, fmt clean.

## Changes by category

| Category | Count | Fix |
|---|---|---|
| `#[must_use]` missing | 7 | Added to `has_tag`, proxy helpers, `add/*` functions |
| Doc backticks | 12 | Wrap `spec_hash`, `CrowdSec`, etc. in backticks |
| `format!` push to String | 10 | Replaced with `write!`/`writeln!` |
| Unnested or-patterns | 7 | Flattened in `tui/app.rs` char patterns |
| Redundant closures | 2 | `String::as_str`, `ContainerInfo::is_running` |
| Used `_`-prefixed binding | 6 | Renamed `_sidecar` → `sidecar` (actually used) |
| Boolean simplification | 3 | Remove unnecessary `!` operations |
| `min().max()` → `clamp()` | 1 | `tui/secrets.rs` |
| Unused variable | 1 | Remove `proxy_has_inline_cert` |
| `large_futures` / `too_many_lines` / `needless_pass_by_value` | ~100 | Suppress with targeted `#[allow]` — restructuring would be disproportionate |