### PR TITLE
fix(tui): allow / to trigger filter in logs and container-logs views

### DIFF
--- a/yoink/src/tui/app.rs
+++ b/yoink/src/tui/app.rs
@@ -1857,7 +1857,7 @@ impl App {
 
         // `/` enters filter input mode for the current pane (when it
         // supports filtering — Logs handled separately above).
-        if key.code == KeyCode::Char('/') {
+        if key.code == KeyCode::Char('/') && !logs_view {
             self.begin_pane_filter_input();
             return false;
         }


### PR DESCRIPTION
## Summary

- The global `/` key handler fired before the view-specific match arms, consuming the keystroke via `begin_pane_filter_input()` — which is a no-op for logs panes
- Added `&& !logs_view` guard so the event falls through to the `View::Logs` / `View::ContainerLogs` arms where `self.logs.begin_filter_input()` is correctly called
- One-character change; `logs_view` is already computed just above the guard

## Test plan

- [ ] Open `yoink` TUI and navigate to the Logs view
- [ ] Press `/` — filter input should activate at the bottom of the pane
- [ ] Type a search term and confirm log lines are filtered
- [ ] Press Esc to clear the filter
- [ ] Verify `/` still works as expected in all other panes (Services, Hosts, Dashboard)