### PR TITLE
blog: deploying without SSH keys — yoink + Tailscale

### DIFF
--- a/docs/content/blog/2026-04-30-hello.mdx
+++ b/docs/content/blog/2026-04-30-hello.mdx
@@ -1,6 +1,7 @@
 ---
 title: Hello from yoink
 date: 2026-04-30
+author: Oddur Magnusson
 description: Introducing the yoink docs site, now running on Fumadocs + TanStack Start — and still serving off a $4/mo VPS.
 ---
 

--- a/docs/content/blog/2026-05-01-yoink-and-tailscale.mdx
+++ b/docs/content/blog/2026-05-01-yoink-and-tailscale.mdx
@@ -13,7 +13,7 @@ Yoink does the secret distribution part well. Sealed secrets live in the repo, g
 
 ## How Tailscale changes it
 
-Tailscale is how I got rid of them. Instead of giving every machine a credential, you give every machine an identity. My laptop is on the tailnet because I logged in with SSO. The host is on the tailnet because I ran `tailscale up` on it once at provisioning. The CI runner is on the tailnet because it auth'd as an ephemeral device for the duration of the job. Nobody is holding a static key.
+[Tailscale](https://tailscale.com) is how I got rid of them. Instead of giving every machine a credential, you give every machine an identity. My laptop is on the tailnet because I logged in with SSO. The host is on the tailnet because I ran `tailscale up` on it once at provisioning. The CI runner is on the tailnet because it auth'd as an ephemeral device for the duration of the job. Nobody is holding a static key.
 
 The pre-flight on a fresh laptop, in full:
 

--- a/docs/content/blog/2026-05-01-yoink-and-tailscale.mdx
+++ b/docs/content/blog/2026-05-01-yoink-and-tailscale.mdx
@@ -57,4 +57,4 @@ This works across providers and across continents, and it works for the box in m
 
 Each tool stays small by leaning on the other. Yoink hands off identity to Tailscale, Tailscale hands off orchestration to yoink, and neither has to grow features to cover what the other already does. Sealed secrets still earn their keep, because there are plenty of secrets in any deploy that aren't SSH keys, but the credential that used to sit at the center of the whole pipeline isn't there to manage anymore.
 
-This is a hobby setup, and that's the whole point. The combination takes a class of fiddly, low-grade headache off the table so I can spend my evenings on the actual project instead of on key hygiene.
+The whole combination takes a class of fiddly, low-grade headache off the table, and that's most of why I like it. Less friction between me and getting back to the actual project.

--- a/docs/content/blog/2026-05-01-yoink-and-tailscale.mdx
+++ b/docs/content/blog/2026-05-01-yoink-and-tailscale.mdx
@@ -6,7 +6,7 @@ description: How putting yoink behind Tailscale let me stop managing SSH keys fo
 
 I don't like managing SSH keys. New host, new keypair, paste the pubkey into `authorized_keys`, commit it somewhere, deploy. Six months later I rotate my laptop and have to remember which boxes still trust the old key. Bring up a second host and the dance starts over. The trust list on every machine grows like a junk drawer and nobody is keeping a real inventory.
 
-CI is where this gets actively bad. CI has to deploy, so CI has a key, and that key is long-lived and machine-held and one of the more attractive credentials in the whole setup. Rotating it is annoying enough that I put it off, revoking it during an incident is annoying enough that I'd hesitate, and auditing what reads it requires me to actually go look.
+CI is where this gets actively annoying. CI has to deploy, so CI has a key, and that key is long-lived and machine-held and the most attractive credential in the whole setup. Rotating it is annoying enough that I put it off, and the longer it sits there the worse the eventual cleanup feels.
 
 Yoink does the secret distribution part well. Sealed secrets live in the repo, get decrypted at deploy time from whatever store you point them at, and never sit on disk in plaintext. That solves the "private key in a GitHub Actions secret" problem cleanly, and for a while I thought that was the answer. Sealed secrets are still secrets, though, and the right number of secrets to manage for a thing like this is zero.
 
@@ -57,4 +57,4 @@ This works across providers and across continents, and it works for the box in m
 
 Each tool stays small by leaning on the other. Yoink hands off identity to Tailscale, Tailscale hands off orchestration to yoink, and neither has to grow features to cover what the other already does. Sealed secrets still earn their keep, because there are plenty of secrets in any deploy that aren't SSH keys, but the credential that used to sit at the center of the whole pipeline isn't there to manage anymore.
 
-When I sat down to write the SSH section of my runbook for this setup, I didn't have anything to put in it.
+This is a hobby setup, and that's the whole point. The combination takes a class of fiddly, low-grade headache off the table so I can spend my evenings on the actual project instead of on key hygiene.

--- a/docs/content/blog/2026-05-01-yoink-and-tailscale.mdx
+++ b/docs/content/blog/2026-05-01-yoink-and-tailscale.mdx
@@ -1,6 +1,7 @@
 ---
 title: Deploying without SSH keys, with yoink and Tailscale
 date: 2026-05-01
+author: Oddur Magnusson
 description: How putting yoink behind Tailscale let me stop managing SSH keys for deploys, drop port 22 from the public internet, and end up with a backplane network across providers as a side effect.
 ---
 

--- a/docs/content/blog/2026-05-01-yoink-and-tailscale.mdx
+++ b/docs/content/blog/2026-05-01-yoink-and-tailscale.mdx
@@ -1,5 +1,5 @@
 ---
-title: Deploying without SSH keys, with yoink and Tailscale
+title: Keyless deploys and a private backplane, with yoink and Tailscale
 date: 2026-05-01
 author: Oddur Magnusson
 description: How putting yoink behind Tailscale let me stop managing SSH keys for deploys, drop port 22 from the public internet, and end up with a backplane network across providers as a side effect.
@@ -9,11 +9,11 @@ I don't like managing SSH keys. New host, new keypair, paste the pubkey into `au
 
 CI is where this gets actively annoying. CI has to deploy, so CI has a key, and that key is long-lived and machine-held and the most attractive credential in the whole setup. Rotating it is annoying enough that I put it off, and the longer it sits there the worse the eventual cleanup feels.
 
-Yoink does the secret distribution part well. Sealed secrets live in the repo, get decrypted at deploy time from whatever store you point them at, and never sit on disk in plaintext. That solves the "private key in a GitHub Actions secret" problem cleanly, and for a while I thought that was the answer. Sealed secrets are still secrets, though, and the right number of secrets to manage for a thing like this is zero.
+Yoink does the secret distribution part well. Sealed secrets live in the repo, get decrypted at deploy time from whatever store you point them at, and don't get written to disk in plaintext along the way. That solves the "private key in a GitHub Actions secret" problem cleanly, and for a while I thought that was the answer. But sealed secrets are still secrets, and what I actually wanted was to stop managing the one credential that opens a shell on every host.
 
 ## How Tailscale changes it
 
-[Tailscale](https://tailscale.com) is how I got rid of them. Instead of giving every machine a credential, you give every machine an identity. My laptop is on the tailnet because I logged in with SSO. The host is on the tailnet because I ran `tailscale up` on it once at provisioning. The CI runner is on the tailnet because it auth'd as an ephemeral device for the duration of the job. Nobody is holding a static key.
+[Tailscale](https://tailscale.com) is how I got rid of them. Instead of giving every machine a credential I have to track, you give every machine an identity. My laptop is on the tailnet because I logged in with SSO. The host is on the tailnet because I ran `tailscale up` on it once at provisioning. The CI runner is on the tailnet because it auth'd as an ephemeral device for the duration of the job. Tailscale's own keys exist, of course, but they live inside Tailscale and rotate on their own. There's nothing in `authorized_keys` for me to babysit.
 
 The pre-flight on a fresh laptop, in full:
 
@@ -32,9 +32,9 @@ Port 22 isn't open on the public IP. The provider firewall blocks it, the host f
 
 If I want to retire a device I remove it from the tailnet and it can't reach anything. If I want to rotate CI's auth I rotate the OAuth client and old tokens die on next use. I haven't had to open an `authorized_keys` file since.
 
-## A shout-out to Depot
+## Depot makes the CI side easy
 
-The CI side of this is much nicer if your runners join the tailnet without you wiring it up by hand. I run CI on [Depot](https://depot.dev/docs/integrations/tailscale), which has native Tailscale integration. Connect Depot to your tailnet once in organization settings (an OAuth client + a tag, both standard Tailscale primitives) and every runner joins the tailnet for the duration of a job as an ephemeral device, then leaves when the job ends. There's no bootstrap auth key to plumb through, no `tailscaled` install step in a workflow, no auth keys hanging around in a secret store waiting to be forgotten about.
+You can wire Tailscale into any CI runner with a `tailscale up` step and an auth key, but it's the kind of glue I'd rather not own. I use [Depot](https://depot.dev/docs/integrations/tailscale) for CI, which has the integration built in. Connect Depot to your tailnet once in organization settings (an OAuth client + a tag, both standard Tailscale primitives) and every runner joins the tailnet for the duration of a job as an ephemeral device, then leaves when the job ends. No bootstrap auth key to inject, no `tailscaled` install step, no leftover secret to rotate later.
 
 Runners come up tagged `tag:ci`, and one line in my tailnet ACLs lets `tag:ci` SSH into hosts tagged `tag:prod`. That's the whole authorization model. With yoink the deploy step is:
 
@@ -52,7 +52,7 @@ Suppose I want a second host in another region. Call it `app-us-1`, on a differe
 
 It also means I don't have to keep cramming everything onto one box just to keep the wiring sane. I can put Postgres on a host with fast disk, Redis on a smaller memory-optimized one, and the app on a third sized for CPU. Each is a yoink target on the same tailnet, and the app dials `pg-1:5432` and `redis-1:6379` by name. None of the datastores need a public IP. Splitting services across hosts stops being a networking project, so I actually do it.
 
-This works across providers and across continents, and it works for the box in my closet. Provider compromise also stops being load-bearing for network trust, because the provider isn't in the trust path anymore. Tailscale's coordination plane is, and that's a much smaller thing to worry about.
+This works across providers and across continents, and it works for the box in my closet. Provider compromise stops being load-bearing for network trust, because the provider isn't in the trust path anymore. Trust now concentrates in two places: my SSO and Tailscale's coordination plane. That's a real tradeoff, not a free win — phish my SSO and an attacker has the same access I do. The bet I'm making is that those two are easier to defend well than a fleet of `authorized_keys` files I'd otherwise be re-pasting by hand.
 
 ## How it fits together
 

--- a/docs/content/blog/2026-05-01-yoink-and-tailscale.mdx
+++ b/docs/content/blog/2026-05-01-yoink-and-tailscale.mdx
@@ -44,9 +44,9 @@ Runners come up tagged `tag:ci`, and one line in my tailnet ACLs lets `tag:ci` S
 
 The runner is on the tailnet, the host trusts `tag:ci`, yoink dials the host by name, and there is nothing else to set up.
 
-## A backplane I wasn't planning for
+## The backplane
 
-The same tailnet that carries deploy traffic works fine as a backplane for the services themselves, which I didn't really expect when I started.
+The same tailnet that carries deploy traffic is also a backplane for the services themselves. That was the point from day one, not a happy accident — keyless SSH was the appetizer, this is the main course.
 
 Suppose I want a second host in another region. Call it `app-us-1`, on a different provider. Normally that's a real piece of work: VPC peering, transit gateways, route tables, a bastion, egress costs, a meeting about who owns the bill. With Tailscale it's `tailscale up` on the new box. Both hosts are now on the same flat, authenticated network, and if `app-eu-1` needs to talk to a Postgres replica on `app-us-1` it just dials `app-us-1:5432`. Encrypted, authenticated, and neither side has anything listening on the public internet.
 

--- a/docs/content/blog/2026-05-01-yoink-and-tailscale.mdx
+++ b/docs/content/blog/2026-05-01-yoink-and-tailscale.mdx
@@ -1,64 +1,60 @@
 ---
-title: Deploying without SSH keys — yoink + Tailscale
+title: Deploying without SSH keys, with yoink and Tailscale
 date: 2026-05-01
-description: Why pairing yoink with Tailscale lets you take SSH keys out of the deploy pipeline entirely, drop port 22 from the public internet, and get a free cross-provider service backplane in the bargain.
+description: How putting yoink behind Tailscale let me stop managing SSH keys for deploys, drop port 22 from the public internet, and end up with a backplane network across providers as a side effect.
 ---
 
-There's a particular kind of operational tax that nobody puts on a roadmap, but everyone pays. It's the SSH key tax. You spin up a new host; you generate a keypair, paste a public key into `authorized_keys`, commit the change to your config repo, deploy. Six months later you rotate your laptop, or you bring up a second host, or you decide to retire the old key, and the same dance runs in reverse — except half the time it doesn't, because nobody's tracking which keys are still in use, and the trust list on every box grows like a junk drawer.
+I don't like managing SSH keys. New host, new keypair, paste the pubkey into `authorized_keys`, commit it somewhere, deploy. Six months later I rotate my laptop and have to remember which boxes still trust the old key. Bring up a second host and the dance starts over. The trust list on every machine grows like a junk drawer and nobody is keeping a real inventory.
 
-CI is worse. CI needs to deploy, so CI needs a key. That key lives in a secrets manager somewhere, gets injected into the runner at job start, and is, by virtue of being long-lived and machine-held, the most attractive credential in the entire system. Rotating it is a project. Revoking it during an incident is a project. Auditing who can read it is a project.
+CI is where this gets actively bad. CI has to deploy, so CI has a key, and that key is long-lived and machine-held and one of the more attractive credentials in the whole setup. Rotating it is annoying enough that I put it off, revoking it during an incident is annoying enough that I'd hesitate, and auditing what reads it requires me to actually go look.
 
-Yoink is opinionated about secrets: it has a clean sealed-secrets workflow, so the keys you do have are encrypted at rest in the repo, fetched at deploy time from your secret store of choice, and never sit around in plaintext on a developer's laptop. That's already a real upgrade over the "paste your private key into a GitHub secret" pattern.
+Yoink does the secret distribution part well. Sealed secrets live in the repo, get decrypted at deploy time from whatever store you point them at, and never sit on disk in plaintext. That solves the "private key in a GitHub Actions secret" problem cleanly, and for a while I thought that was the answer. Sealed secrets are still secrets, though, and the right number of secrets to manage for a thing like this is zero.
 
-But the more I used it, the more I noticed that the sealed-secrets machinery — as elegant as it is — was solving a problem I'd rather not have at all. The best key is no key.
+## How Tailscale changes it
 
-## The shift
+Tailscale is how I got rid of them. Instead of giving every machine a credential, you give every machine an identity. My laptop is on the tailnet because I logged in with SSO. The host is on the tailnet because I ran `tailscale up` on it once at provisioning. The CI runner is on the tailnet because it auth'd as an ephemeral device for the duration of the job. Nobody is holding a static key.
 
-Tailscale is how I got rid of the keys. Not most of them — all of them.
-
-The idea is simple. Instead of distributing a credential to every machine that might want to talk to your hosts, you distribute *identity*. My laptop is on the tailnet because I logged into it with my SSO. The CI runner is on the tailnet because it authenticated with an OAuth client and was tagged ephemeral, so it'll evaporate when the job ends. The host is on the tailnet because it ran `tailscale up` once at provisioning time. Everybody has an identity; nobody is holding a static key that opens a door.
-
-What does deploying look like with this in place? Here's the entire pre-flight on a fresh laptop:
+The pre-flight on a fresh laptop, in full:
 
 ```sh
 tailscale up
 yoink up --config yoink.yaml
 ```
 
-That's it. Yoink reaches the target host by its MagicDNS name — `app-eu-1`, say — over the WireGuard mesh. There's no `~/.ssh/config` entry. There's no `IdentityFile` line. There's no key on disk. The host's `sshd` is running, but it's bound to the tailscale interface:
+Yoink dials the host by its MagicDNS name (`app-eu-1`, say) over the mesh. There is no `~/.ssh/config` entry, no `IdentityFile`, no key file. `sshd` is running on the host but it's bound to the tailscale interface:
 
 ```
 ListenAddress 100.64.0.0/10
 ```
 
-The public interface doesn't even have port 22 open. The provider firewall blocks it; the host firewall blocks it; the daemon doesn't listen on it. The brute-force traffic that used to fill `/var/log/auth.log` is just gone, because there's nothing to brute-force against.
+Port 22 isn't open on the public IP. The provider firewall blocks it, the host firewall blocks it, and `sshd` isn't listening on it anyway. The constant brute-force noise that used to fill `auth.log` stops, because there's nothing on the public internet to attack.
 
-If I want to retire a device, I remove it from the tailnet and it loses access to every host at once. When CI's OAuth client gets rotated, every old token dies the next time it's used. None of this requires touching a single `authorized_keys` file. The keys that used to be the connective tissue of the deploy system simply aren't there anymore.
+If I want to retire a device I remove it from the tailnet and it can't reach anything. If I want to rotate CI's auth I rotate the OAuth client and old tokens die on next use. I haven't touched an `authorized_keys` file in months.
 
-## A quick shout-out to Depot
+## A shout-out to Depot
 
-The CI side of this story is dramatically easier if your runners can join the tailnet without you having to babysit it. I run my CI on [Depot](https://depot.dev), which has native Tailscale integration — flip a switch in the project settings and every Depot runner joins my tailnet on job start as an ephemeral device, then leaves when the job ends. No bootstrap secrets to plumb through, no `tailscaled` install step in a workflow, no half-leaked auth keys lying around.
+The CI side of this is much nicer if your runners join the tailnet without you wiring it up by hand. I run CI on [Depot](https://depot.dev), which has native Tailscale integration. Flip a switch in project settings and every runner joins the tailnet for the duration of a job as an ephemeral device, then leaves when the job ends. There's no bootstrap auth key to plumb through, no `tailscaled` install step in a workflow, no auth keys to forget about and find lying around six months later.
 
-The runners come up with `tag:ci`, and a single line in my tailnet ACLs grants `tag:ci` permission to SSH into hosts tagged `tag:prod`. That's the entire authorization model: tag-to-tag. No per-runner provisioning, no per-host updates when the runner pool churns, no static credentials to revoke. Combined with yoink, the deploy job is, in full:
+Runners come up tagged `tag:ci`, and one line in my tailnet ACLs lets `tag:ci` SSH into hosts tagged `tag:prod`. That's the whole authorization model. With yoink the deploy step is:
 
 ```yaml
 - run: yoink up --config yoink.yaml
 ```
 
-The runner is on the tailnet, the host trusts `tag:ci`, yoink dials the host by name. There's nothing else to set up.
+The runner is on the tailnet, the host trusts `tag:ci`, yoink dials the host by name, and there is nothing else to set up.
 
-## The backplane falls out for free
+## A backplane I wasn't planning for
 
-Here's the part I didn't expect. The same tailnet that carries my deploy traffic is also a perfectly good backplane network for the services themselves.
+The same tailnet that carries deploy traffic works fine as a backplane for the services themselves, which I didn't really expect when I started.
 
-Suppose I want a second host in another region — `app-us-1` on a different provider entirely. With a traditional setup that's a real project: VPC peering, transit gateways, NAT, route tables, a bastion or two, and probably a meeting about who pays for the egress. With Tailscale it's `tailscale up` again. The two hosts are now on the same flat network, addressable by name, mutually authenticated. If `app-eu-1` needs to talk to a Postgres replica running on `app-us-1`, it just dials `app-us-1:5432`. The traffic is encrypted, the endpoints are authenticated, and neither host has anything listening on the public internet.
+Suppose I want a second host in another region. Call it `app-us-1`, on a different provider. Normally that's a real piece of work: VPC peering, transit gateways, route tables, a bastion, egress costs, a meeting about who owns the bill. With Tailscale it's `tailscale up` on the new box. Both hosts are now on the same flat, authenticated network, and if `app-eu-1` needs to talk to a Postgres replica on `app-us-1` it just dials `app-us-1:5432`. Encrypted, authenticated, and neither side has anything listening on the public internet.
 
-It also means you don't have to colocate every service on a single box just to keep the wiring sane. If I want Postgres on a host with fast local disk, Redis on a small memory-optimized box, and the application tier on a third host sized for CPU, I can. Each one is a yoink target on the same tailnet; the app dials `pg-1:5432` and `redis-1:6379` by name, with traffic encrypted and authenticated end to end, and none of those datastores need a public IP at all. The "everything on one big VM" pattern stops being the path of least resistance, because splitting things up no longer costs you a networking project.
+It also means I don't have to keep cramming everything onto one box just to keep the wiring sane. I can put Postgres on a host with fast disk, Redis on a smaller memory-optimized one, and the app on a third sized for CPU. Each is a yoink target on the same tailnet, and the app dials `pg-1:5432` and `redis-1:6379` by name. None of the datastores need a public IP. Splitting services across hosts stops being a networking project, so I actually do it.
 
-This works across providers. It works across continents. It works for hosts I run on a closet machine at home, if I want. The blast radius of a compromised provider account is dramatically smaller because the provider isn't in the trust path of the network — Tailscale's coordination plane is, and that's a small, well-scoped thing to reason about.
+This works across providers and across continents, and it works for the box in my closet. Provider compromise also stops being load-bearing for network trust, because the provider isn't in the trust path anymore. Tailscale's coordination plane is, and that's a much smaller thing to worry about.
 
-## Why the combination
+## Why the two together
 
-The reason I keep coming back to this pairing is that each tool stays simple by leaning on the other. Yoink doesn't have to solve identity, because Tailscale already did. Tailscale doesn't have to solve orchestration, because yoink already did. Yoink's sealed secrets are still pulling their weight — there are plenty of real secrets in any deploy that aren't SSH keys, and you want those encrypted in the repo and fetched fresh each time. But the credential that used to sit at the center of the whole pipeline, the one you used to lose sleep over, is gone.
+Each tool stays small by leaning on the other. Yoink hands off identity to Tailscale, Tailscale hands off orchestration to yoink, and neither has to grow features to cover what the other already does. Sealed secrets still earn their keep, because there are plenty of secrets in any deploy that aren't SSH keys, but the credential that used to sit at the center of the whole pipeline isn't there to manage anymore.
 
-The first time you delete the SSH section of your runbook, it feels like cheating. It isn't. It's just what happens when identity moves up the stack and stops pretending to be a file on disk.
+I noticed this when I went to update the SSH section of my runbook and realized I'd deleted it months ago and hadn't missed it.

--- a/docs/content/blog/2026-05-01-yoink-and-tailscale.mdx
+++ b/docs/content/blog/2026-05-01-yoink-and-tailscale.mdx
@@ -34,7 +34,7 @@ If I want to retire a device I remove it from the tailnet and it can't reach any
 
 ## A shout-out to Depot
 
-The CI side of this is much nicer if your runners join the tailnet without you wiring it up by hand. I run CI on [Depot](https://depot.dev), which has native Tailscale integration. Flip a switch in project settings and every runner joins the tailnet for the duration of a job as an ephemeral device, then leaves when the job ends. There's no bootstrap auth key to plumb through, no `tailscaled` install step in a workflow, no auth keys hanging around in a secret store waiting to be forgotten about.
+The CI side of this is much nicer if your runners join the tailnet without you wiring it up by hand. I run CI on [Depot](https://depot.dev/docs/integrations/tailscale), which has native Tailscale integration. Flip a switch in project settings and every runner joins the tailnet for the duration of a job as an ephemeral device, then leaves when the job ends. There's no bootstrap auth key to plumb through, no `tailscaled` install step in a workflow, no auth keys hanging around in a secret store waiting to be forgotten about.
 
 Runners come up tagged `tag:ci`, and one line in my tailnet ACLs lets `tag:ci` SSH into hosts tagged `tag:prod`. That's the whole authorization model. With yoink the deploy step is:
 

--- a/docs/content/blog/2026-05-01-yoink-and-tailscale.mdx
+++ b/docs/content/blog/2026-05-01-yoink-and-tailscale.mdx
@@ -36,25 +36,25 @@ If I want to retire a device I remove it from the tailnet and it can't reach any
 
 You can wire Tailscale into any CI runner with a `tailscale up` step and an auth key, but it's the kind of glue I'd rather not own. I use [Depot](https://depot.dev/docs/integrations/tailscale) for CI, which has the integration built in. Connect Depot to your tailnet once in organization settings (an OAuth client + a tag, both standard Tailscale primitives) and every runner joins the tailnet for the duration of a job as an ephemeral device, then leaves when the job ends. No bootstrap auth key to inject, no `tailscaled` install step, no leftover secret to rotate later.
 
-Runners come up tagged `tag:ci`, and one line in my tailnet ACLs lets `tag:ci` SSH into hosts tagged `tag:prod`. That's the whole authorization model. With yoink the deploy step is:
+Runners come up tagged `tag:ci`, and a single line in my tailnet ACLs grants `tag:ci` SSH access to hosts tagged `tag:prod`. With yoink the deploy step is:
 
 ```yaml
 - run: yoink up --config yoink.yaml
 ```
 
-The runner is on the tailnet, the host trusts `tag:ci`, yoink dials the host by name, and there is nothing else to set up.
+The runner is on the tailnet, the host trusts `tag:ci`, and yoink dials the host by name.
 
 ## The backplane
 
-The same tailnet that carries deploy traffic is also a backplane for the services themselves. That was the point from day one, not a happy accident — keyless SSH was the appetizer, this is the main course.
+The same tailnet that carries deploy traffic is also a backplane for the services themselves, and that was the point from day one. Keyless SSH falls out of the same setup, but the reason I went looking for this in the first place was to stop treating cross-host networking as its own project.
 
-Suppose I want a second host in another region. Call it `app-us-1`, on a different provider. Normally that's a real piece of work: VPC peering, transit gateways, route tables, a bastion, egress costs, a meeting about who owns the bill. With Tailscale it's `tailscale up` on the new box. Both hosts are now on the same flat, authenticated network, and if `app-eu-1` needs to talk to a Postgres replica on `app-us-1` it just dials `app-us-1:5432`. Encrypted, authenticated, and neither side has anything listening on the public internet.
+Suppose I want a second host in another region. Call it `app-us-1`, on a different provider. Normally that's real work: VPC peering, transit gateways, route tables, a bastion, egress costs, a meeting about who owns the bill. With Tailscale it's `tailscale up` on the new box. Both hosts are now on the same flat, authenticated network, and if `app-eu-1` needs to talk to a Postgres replica on `app-us-1` it just dials `app-us-1:5432`. The traffic is encrypted, both endpoints are authenticated, and neither side has anything listening on the public internet.
 
 It also means I don't have to keep cramming everything onto one box just to keep the wiring sane. I can put Postgres on a host with fast disk, Redis on a smaller memory-optimized one, and the app on a third sized for CPU. Each is a yoink target on the same tailnet, and the app dials `pg-1:5432` and `redis-1:6379` by name. None of the datastores need a public IP. Splitting services across hosts stops being a networking project, so I actually do it.
 
-The same tailnet ACLs that gate SSH also gate this east-west traffic. A few lines say only `tag:app` can reach `pg-1:5432`, only `tag:app` can reach `redis-1:6379`, and the app hosts can't reach each other on anything other than the ports they need. The result is a flat-looking network that isn't actually flat — closer to per-service security groups than the "everything on the LAN" feel a hobby tailnet usually has, and without the cloud console clicking that gets you there.
+The same tailnet ACLs that gate SSH also gate this east-west traffic. A few lines say only `tag:app` can reach `pg-1:5432`, only `tag:app` can reach `redis-1:6379`, and the app hosts can't reach each other on anything other than the ports they actually need. The network looks flat from the outside but behaves closer to per-service security groups, without the cloud-console clicking that normally gets you there.
 
-This works across providers and across continents, and it works for the box in my closet. Provider compromise stops being load-bearing for network trust, because the provider isn't in the trust path anymore. Trust now concentrates in two places: my SSO and Tailscale's coordination plane. That's a real tradeoff, not a free win — phish my SSO and an attacker has the same access I do. The bet I'm making is that those two are easier to defend well than a fleet of `authorized_keys` files I'd otherwise be re-pasting by hand.
+This works across providers and across continents, and it works for the box in my closet. Provider compromise stops being load-bearing for network trust, because the provider isn't in the trust path anymore. Trust now concentrates in two places: my SSO and Tailscale's coordination plane. That's a real tradeoff rather than a free win, because phishing my SSO gets an attacker the same access I have. The bet I'm making is that those two are easier to defend well than a fleet of `authorized_keys` files I'd otherwise be re-pasting by hand.
 
 ## How it fits together
 
@@ -76,6 +76,4 @@ Identity at the top, tailnet in the middle, hosts at the bottom. Nothing in this
 
 ## Why the two together
 
-Each tool stays small by leaning on the other. Yoink hands off identity to Tailscale, Tailscale hands off orchestration to yoink, and neither has to grow features to cover what the other already does. Sealed secrets still earn their keep, because there are plenty of secrets in any deploy that aren't SSH keys, but the credential that used to sit at the center of the whole pipeline isn't there to manage anymore.
-
-The whole combination takes a class of fiddly, low-grade headache off the table, and that's most of why I like it. Less friction between me and getting back to the actual project.
+The split between the two tools is clean. Yoink owns the orchestration and leans on Tailscale for identity, so neither has to grow features to cover the other's territory. Sealed secrets still earn their keep for the things that actually need to be secrets, but the credential that used to sit at the center of the whole pipeline isn't part of the daily story anymore. Most of why I like the combination is that it takes a class of fiddly, low-grade headache off the table.

--- a/docs/content/blog/2026-05-01-yoink-and-tailscale.mdx
+++ b/docs/content/blog/2026-05-01-yoink-and-tailscale.mdx
@@ -4,7 +4,7 @@ date: 2026-05-01
 description: Why pairing yoink with Tailscale lets you take SSH keys out of the deploy pipeline entirely, drop port 22 from the public internet, and get a free cross-provider service backplane in the bargain.
 ---
 
-There's a particular kind of small-team operational tax that nobody puts on a roadmap, but everyone pays. It's the SSH key tax. A new engineer joins; someone generates a keypair, pastes a public key into `authorized_keys` on every host, commits the change, opens a PR, merges it. Six months later that engineer rotates laptops, or leaves, and the same dance runs in reverse — except half the time it doesn't, because nobody's tracking which keys are still in use, and the trust list grows like a junk drawer.
+There's a particular kind of operational tax that nobody puts on a roadmap, but everyone pays. It's the SSH key tax. You spin up a new host; you generate a keypair, paste a public key into `authorized_keys`, commit the change to your config repo, deploy. Six months later you rotate your laptop, or you bring up a second host, or you decide to retire the old key, and the same dance runs in reverse — except half the time it doesn't, because nobody's tracking which keys are still in use, and the trust list on every box grows like a junk drawer.
 
 CI is worse. CI needs to deploy, so CI needs a key. That key lives in a secrets manager somewhere, gets injected into the runner at job start, and is, by virtue of being long-lived and machine-held, the most attractive credential in the entire system. Rotating it is a project. Revoking it during an incident is a project. Auditing who can read it is a project.
 
@@ -33,7 +33,7 @@ ListenAddress 100.64.0.0/10
 
 The public interface doesn't even have port 22 open. The provider firewall blocks it; the host firewall blocks it; the daemon doesn't listen on it. The brute-force traffic that used to fill `/var/log/auth.log` is just gone, because there's nothing to brute-force against.
 
-When someone leaves the team, I remove them from the tailnet ACL and they lose access to every host at once. When CI's OAuth client gets rotated, every old token dies the next time it's used. None of this requires touching a single `authorized_keys` file. The keys that used to be the connective tissue of the deploy system simply aren't there anymore.
+If I want to retire a device, I remove it from the tailnet and it loses access to every host at once. When CI's OAuth client gets rotated, every old token dies the next time it's used. None of this requires touching a single `authorized_keys` file. The keys that used to be the connective tissue of the deploy system simply aren't there anymore.
 
 ## A quick shout-out to Depot
 

--- a/docs/content/blog/2026-05-01-yoink-and-tailscale.mdx
+++ b/docs/content/blog/2026-05-01-yoink-and-tailscale.mdx
@@ -35,6 +35,18 @@ The public interface doesn't even have port 22 open. The provider firewall block
 
 When someone leaves the team, I remove them from the tailnet ACL and they lose access to every host at once. When CI's OAuth client gets rotated, every old token dies the next time it's used. None of this requires touching a single `authorized_keys` file. The keys that used to be the connective tissue of the deploy system simply aren't there anymore.
 
+## A quick shout-out to Depot
+
+The CI side of this story is dramatically easier if your runners can join the tailnet without you having to babysit it. I run my CI on [Depot](https://depot.dev), which has native Tailscale integration — flip a switch in the project settings and every Depot runner joins my tailnet on job start as an ephemeral device, then leaves when the job ends. No bootstrap secrets to plumb through, no `tailscaled` install step in a workflow, no half-leaked auth keys lying around.
+
+The runners come up with `tag:ci`, and a single line in my tailnet ACLs grants `tag:ci` permission to SSH into hosts tagged `tag:prod`. That's the entire authorization model: tag-to-tag. No per-runner provisioning, no per-host updates when the runner pool churns, no static credentials to revoke. Combined with yoink, the deploy job is, in full:
+
+```yaml
+- run: yoink up --config yoink.yaml
+```
+
+The runner is on the tailnet, the host trusts `tag:ci`, yoink dials the host by name. There's nothing else to set up.
+
 ## The backplane falls out for free
 
 Here's the part I didn't expect. The same tailnet that carries my deploy traffic is also a perfectly good backplane network for the services themselves.

--- a/docs/content/blog/2026-05-01-yoink-and-tailscale.mdx
+++ b/docs/content/blog/2026-05-01-yoink-and-tailscale.mdx
@@ -1,0 +1,52 @@
+---
+title: Deploying without SSH keys — yoink + Tailscale
+date: 2026-05-01
+description: Why pairing yoink with Tailscale lets you take SSH keys out of the deploy pipeline entirely, drop port 22 from the public internet, and get a free cross-provider service backplane in the bargain.
+---
+
+There's a particular kind of small-team operational tax that nobody puts on a roadmap, but everyone pays. It's the SSH key tax. A new engineer joins; someone generates a keypair, pastes a public key into `authorized_keys` on every host, commits the change, opens a PR, merges it. Six months later that engineer rotates laptops, or leaves, and the same dance runs in reverse — except half the time it doesn't, because nobody's tracking which keys are still in use, and the trust list grows like a junk drawer.
+
+CI is worse. CI needs to deploy, so CI needs a key. That key lives in a secrets manager somewhere, gets injected into the runner at job start, and is, by virtue of being long-lived and machine-held, the most attractive credential in the entire system. Rotating it is a project. Revoking it during an incident is a project. Auditing who can read it is a project.
+
+Yoink is opinionated about secrets: it has a clean sealed-secrets workflow, so the keys you do have are encrypted at rest in the repo, fetched at deploy time from your secret store of choice, and never sit around in plaintext on a developer's laptop. That's already a real upgrade over the "paste your private key into a GitHub secret" pattern.
+
+But the more I used it, the more I noticed that the sealed-secrets machinery — as elegant as it is — was solving a problem I'd rather not have at all. The best key is no key.
+
+## The shift
+
+Tailscale is how I got rid of the keys. Not most of them — all of them.
+
+The idea is simple. Instead of distributing a credential to every machine that might want to talk to your hosts, you distribute *identity*. My laptop is on the tailnet because I logged into it with my SSO. The CI runner is on the tailnet because it authenticated with an OAuth client and was tagged ephemeral, so it'll evaporate when the job ends. The host is on the tailnet because it ran `tailscale up` once at provisioning time. Everybody has an identity; nobody is holding a static key that opens a door.
+
+What does deploying look like with this in place? Here's the entire pre-flight on a fresh laptop:
+
+```sh
+tailscale up
+yoink up --config yoink.yaml
+```
+
+That's it. Yoink reaches the target host by its MagicDNS name — `app-eu-1`, say — over the WireGuard mesh. There's no `~/.ssh/config` entry. There's no `IdentityFile` line. There's no key on disk. The host's `sshd` is running, but it's bound to the tailscale interface:
+
+```
+ListenAddress 100.64.0.0/10
+```
+
+The public interface doesn't even have port 22 open. The provider firewall blocks it; the host firewall blocks it; the daemon doesn't listen on it. The brute-force traffic that used to fill `/var/log/auth.log` is just gone, because there's nothing to brute-force against.
+
+When someone leaves the team, I remove them from the tailnet ACL and they lose access to every host at once. When CI's OAuth client gets rotated, every old token dies the next time it's used. None of this requires touching a single `authorized_keys` file. The keys that used to be the connective tissue of the deploy system simply aren't there anymore.
+
+## The backplane falls out for free
+
+Here's the part I didn't expect. The same tailnet that carries my deploy traffic is also a perfectly good backplane network for the services themselves.
+
+Suppose I want a second host in another region — `app-us-1` on a different provider entirely. With a traditional setup that's a real project: VPC peering, transit gateways, NAT, route tables, a bastion or two, and probably a meeting about who pays for the egress. With Tailscale it's `tailscale up` again. The two hosts are now on the same flat network, addressable by name, mutually authenticated. If `app-eu-1` needs to talk to a Postgres replica running on `app-us-1`, it just dials `app-us-1:5432`. The traffic is encrypted, the endpoints are authenticated, and neither host has anything listening on the public internet.
+
+It also means you don't have to colocate every service on a single box just to keep the wiring sane. If I want Postgres on a host with fast local disk, Redis on a small memory-optimized box, and the application tier on a third host sized for CPU, I can. Each one is a yoink target on the same tailnet; the app dials `pg-1:5432` and `redis-1:6379` by name, with traffic encrypted and authenticated end to end, and none of those datastores need a public IP at all. The "everything on one big VM" pattern stops being the path of least resistance, because splitting things up no longer costs you a networking project.
+
+This works across providers. It works across continents. It works for hosts I run on a closet machine at home, if I want. The blast radius of a compromised provider account is dramatically smaller because the provider isn't in the trust path of the network — Tailscale's coordination plane is, and that's a small, well-scoped thing to reason about.
+
+## Why the combination
+
+The reason I keep coming back to this pairing is that each tool stays simple by leaning on the other. Yoink doesn't have to solve identity, because Tailscale already did. Tailscale doesn't have to solve orchestration, because yoink already did. Yoink's sealed secrets are still pulling their weight — there are plenty of real secrets in any deploy that aren't SSH keys, and you want those encrypted in the repo and fetched fresh each time. But the credential that used to sit at the center of the whole pipeline, the one you used to lose sleep over, is gone.
+
+The first time you delete the SSH section of your runbook, it feels like cheating. It isn't. It's just what happens when identity moves up the stack and stops pretending to be a file on disk.

--- a/docs/content/blog/2026-05-01-yoink-and-tailscale.mdx
+++ b/docs/content/blog/2026-05-01-yoink-and-tailscale.mdx
@@ -52,6 +52,8 @@ Suppose I want a second host in another region. Call it `app-us-1`, on a differe
 
 It also means I don't have to keep cramming everything onto one box just to keep the wiring sane. I can put Postgres on a host with fast disk, Redis on a smaller memory-optimized one, and the app on a third sized for CPU. Each is a yoink target on the same tailnet, and the app dials `pg-1:5432` and `redis-1:6379` by name. None of the datastores need a public IP. Splitting services across hosts stops being a networking project, so I actually do it.
 
+The same tailnet ACLs that gate SSH also gate this east-west traffic. A few lines say only `tag:app` can reach `pg-1:5432`, only `tag:app` can reach `redis-1:6379`, and the app hosts can't reach each other on anything other than the ports they need. The result is a flat-looking network that isn't actually flat — closer to per-service security groups than the "everything on the LAN" feel a hobby tailnet usually has, and without the cloud console clicking that gets you there.
+
 This works across providers and across continents, and it works for the box in my closet. Provider compromise stops being load-bearing for network trust, because the provider isn't in the trust path anymore. Trust now concentrates in two places: my SSO and Tailscale's coordination plane. That's a real tradeoff, not a free win — phish my SSO and an attacker has the same access I do. The bet I'm making is that those two are easier to defend well than a fleet of `authorized_keys` files I'd otherwise be re-pasting by hand.
 
 ## How it fits together

--- a/docs/content/blog/2026-05-01-yoink-and-tailscale.mdx
+++ b/docs/content/blog/2026-05-01-yoink-and-tailscale.mdx
@@ -29,11 +29,11 @@ ListenAddress 100.64.0.0/10
 
 Port 22 isn't open on the public IP. The provider firewall blocks it, the host firewall blocks it, and `sshd` isn't listening on it anyway. The constant brute-force noise that used to fill `auth.log` stops, because there's nothing on the public internet to attack.
 
-If I want to retire a device I remove it from the tailnet and it can't reach anything. If I want to rotate CI's auth I rotate the OAuth client and old tokens die on next use. I haven't touched an `authorized_keys` file in months.
+If I want to retire a device I remove it from the tailnet and it can't reach anything. If I want to rotate CI's auth I rotate the OAuth client and old tokens die on next use. I haven't had to open an `authorized_keys` file since.
 
 ## A shout-out to Depot
 
-The CI side of this is much nicer if your runners join the tailnet without you wiring it up by hand. I run CI on [Depot](https://depot.dev), which has native Tailscale integration. Flip a switch in project settings and every runner joins the tailnet for the duration of a job as an ephemeral device, then leaves when the job ends. There's no bootstrap auth key to plumb through, no `tailscaled` install step in a workflow, no auth keys to forget about and find lying around six months later.
+The CI side of this is much nicer if your runners join the tailnet without you wiring it up by hand. I run CI on [Depot](https://depot.dev), which has native Tailscale integration. Flip a switch in project settings and every runner joins the tailnet for the duration of a job as an ephemeral device, then leaves when the job ends. There's no bootstrap auth key to plumb through, no `tailscaled` install step in a workflow, no auth keys hanging around in a secret store waiting to be forgotten about.
 
 Runners come up tagged `tag:ci`, and one line in my tailnet ACLs lets `tag:ci` SSH into hosts tagged `tag:prod`. That's the whole authorization model. With yoink the deploy step is:
 
@@ -57,4 +57,4 @@ This works across providers and across continents, and it works for the box in m
 
 Each tool stays small by leaning on the other. Yoink hands off identity to Tailscale, Tailscale hands off orchestration to yoink, and neither has to grow features to cover what the other already does. Sealed secrets still earn their keep, because there are plenty of secrets in any deploy that aren't SSH keys, but the credential that used to sit at the center of the whole pipeline isn't there to manage anymore.
 
-I noticed this when I went to update the SSH section of my runbook and realized I'd deleted it months ago and hadn't missed it.
+When I sat down to write the SSH section of my runbook for this setup, I didn't have anything to put in it.

--- a/docs/content/blog/2026-05-01-yoink-and-tailscale.mdx
+++ b/docs/content/blog/2026-05-01-yoink-and-tailscale.mdx
@@ -53,6 +53,24 @@ It also means I don't have to keep cramming everything onto one box just to keep
 
 This works across providers and across continents, and it works for the box in my closet. Provider compromise also stops being load-bearing for network trust, because the provider isn't in the trust path anymore. Tailscale's coordination plane is, and that's a much smaller thing to worry about.
 
+## How it fits together
+
+```mermaid
+flowchart TB
+    L([My laptop<br/>SSO identity])
+    C([Depot CI runner<br/>tag:ci, ephemeral])
+    T(((Tailnet)))
+    L -- yoink up --> T
+    C -- yoink up --> T
+    T --> APP1[app-eu-1]
+    T --> APP2[app-us-1<br/>different provider]
+    APP1 --> PG[(pg-1)]
+    APP1 --> RD[(redis-1)]
+    APP2 -. backplane .-> PG
+```
+
+Identity at the top, tailnet in the middle, hosts at the bottom. Nothing in this picture has a public listener for SSH, and nothing relies on a static key.
+
 ## Why the two together
 
 Each tool stays small by leaning on the other. Yoink hands off identity to Tailscale, Tailscale hands off orchestration to yoink, and neither has to grow features to cover what the other already does. Sealed secrets still earn their keep, because there are plenty of secrets in any deploy that aren't SSH keys, but the credential that used to sit at the center of the whole pipeline isn't there to manage anymore.

--- a/docs/content/blog/2026-05-01-yoink-and-tailscale.mdx
+++ b/docs/content/blog/2026-05-01-yoink-and-tailscale.mdx
@@ -22,10 +22,10 @@ tailscale up
 yoink up --config yoink.yaml
 ```
 
-Yoink dials the host by its MagicDNS name (`app-eu-1`, say) over the mesh. There is no `~/.ssh/config` entry, no `IdentityFile`, no key file. `sshd` is running on the host but it's bound to the tailscale interface:
+Yoink dials the host by its MagicDNS name (`app-eu-1`, say) over the mesh. There is no `~/.ssh/config` entry, no `IdentityFile`, no key file. `sshd` is running on the host but it's bound to the host's tailnet IP only:
 
 ```
-ListenAddress 100.64.0.0/10
+ListenAddress 100.x.y.z   # the host's tailnet IP
 ```
 
 Port 22 isn't open on the public IP. The provider firewall blocks it, the host firewall blocks it, and `sshd` isn't listening on it anyway. The constant brute-force noise that used to fill `auth.log` stops, because there's nothing on the public internet to attack.
@@ -34,7 +34,7 @@ If I want to retire a device I remove it from the tailnet and it can't reach any
 
 ## A shout-out to Depot
 
-The CI side of this is much nicer if your runners join the tailnet without you wiring it up by hand. I run CI on [Depot](https://depot.dev/docs/integrations/tailscale), which has native Tailscale integration. Flip a switch in project settings and every runner joins the tailnet for the duration of a job as an ephemeral device, then leaves when the job ends. There's no bootstrap auth key to plumb through, no `tailscaled` install step in a workflow, no auth keys hanging around in a secret store waiting to be forgotten about.
+The CI side of this is much nicer if your runners join the tailnet without you wiring it up by hand. I run CI on [Depot](https://depot.dev/docs/integrations/tailscale), which has native Tailscale integration. Connect Depot to your tailnet once in organization settings (an OAuth client + a tag, both standard Tailscale primitives) and every runner joins the tailnet for the duration of a job as an ephemeral device, then leaves when the job ends. There's no bootstrap auth key to plumb through, no `tailscaled` install step in a workflow, no auth keys hanging around in a secret store waiting to be forgotten about.
 
 Runners come up tagged `tag:ci`, and one line in my tailnet ACLs lets `tag:ci` SSH into hosts tagged `tag:prod`. That's the whole authorization model. With yoink the deploy step is:
 

--- a/docs/source.config.ts
+++ b/docs/source.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig, defineDocs, remarkInclude } from 'fumadocs-mdx/config';
+import { defineConfig, defineDocs, frontmatterSchema, remarkInclude } from 'fumadocs-mdx/config';
 import { remarkCodeTab, remarkMdxMermaid, remarkSteps } from 'fumadocs-core/mdx-plugins';
 
 export const docs = defineDocs({
@@ -12,6 +12,12 @@ export const docs = defineDocs({
 
 export const blog = defineDocs({
   dir: 'content/blog',
+  docs: {
+    schema: frontmatterSchema.loose(),
+    postprocess: {
+      includeProcessedMarkdown: true,
+    },
+  },
 });
 
 export const about = defineDocs({

--- a/docs/src/routes/blog/$slug.tsx
+++ b/docs/src/routes/blog/$slug.tsx
@@ -56,14 +56,20 @@ const clientLoader = browserCollections.blog.createClientLoader({
       <DocsPage toc={[]}>
         <DocsBody>
           <h1 className="text-3xl font-bold mb-2">{frontmatter.title as string}</h1>
-          {frontmatter.date && (
-            <time className="text-sm text-fd-muted-foreground block mb-8">
-              {new Date(frontmatter.date as string).toLocaleDateString('en-US', {
-                year: 'numeric',
-                month: 'long',
-                day: 'numeric',
-              })}
-            </time>
+          {(frontmatter.date || frontmatter.author) && (
+            <p className="text-sm text-fd-muted-foreground mb-8">
+              {frontmatter.date && (
+                <time>
+                  {new Date(frontmatter.date as string).toLocaleDateString('en-US', {
+                    year: 'numeric',
+                    month: 'long',
+                    day: 'numeric',
+                  })}
+                </time>
+              )}
+              {frontmatter.date && frontmatter.author && ' · '}
+              {frontmatter.author && <span>{frontmatter.author as string}</span>}
+            </p>
           )}
           <div className="prose max-w-none">
             <MDX components={useMDXComponents()} />

--- a/docs/src/routes/blog/index.tsx
+++ b/docs/src/routes/blog/index.tsx
@@ -12,18 +12,59 @@ export const Route = createFileRoute('/blog/')({
   loader: () => listPosts(),
 });
 
+const firstParagraph = (markdown: string): string => {
+  const blocks = markdown.split(/\n\s*\n/);
+  for (const raw of blocks) {
+    const block = raw.trim();
+    if (!block) continue;
+    if (block.startsWith('#')) continue;
+    if (block.startsWith('```')) continue;
+    if (block.startsWith('import ') || block.startsWith('export ')) continue;
+    return block.replace(/\s+/g, ' ');
+  }
+  return '';
+};
+
 const listPosts = createServerFn({ method: 'GET' })
   .middleware([staticFunctionMiddleware])
   .handler(async () => {
     const pages = blogSource.getPages();
-    const posts = pages
-      .map((p) => ({
-        slug: p.slugs.join('/'),
-        title: p.data.title as string,
-        description: (p.data.description ?? '') as string,
-        date: (p.data.date ?? '') as string,
-      }))
-      .sort((a, b) => b.date.localeCompare(a.date));
+    const posts = await Promise.all(
+      pages.map(async (p) => {
+        const d = p.data as Record<string, unknown> & {
+          getText?: (type: 'raw' | 'processed') => Promise<string>;
+          _markdown?: string;
+        };
+        const rawDate = d.date;
+        const dateStr =
+          rawDate instanceof Date
+            ? rawDate.toISOString().slice(0, 10)
+            : typeof rawDate === 'string'
+              ? rawDate
+              : '';
+        let excerpt = (d.description ?? '') as string;
+        try {
+          if (typeof d.getText === 'function') {
+            const md = await d.getText('processed');
+            const para = firstParagraph(md);
+            if (para) excerpt = para;
+          } else if (typeof d._markdown === 'string') {
+            const para = firstParagraph(d._markdown);
+            if (para) excerpt = para;
+          }
+        } catch {
+          // fall back to description
+        }
+        return {
+          slug: p.slugs.join('/'),
+          title: d.title as string,
+          excerpt,
+          date: dateStr,
+          author: (d.author ?? '') as string,
+        };
+      }),
+    );
+    posts.sort((a, b) => b.date.localeCompare(a.date));
     return {
       posts,
       pageTree: await source.serializePageTree(source.getPageTree()),
@@ -46,17 +87,23 @@ function BlogIndex() {
                     {post.title}
                   </h2>
                 </Link>
-                {post.date && (
-                  <time className="text-sm text-fd-muted-foreground mt-1 block">
-                    {new Date(post.date).toLocaleDateString('en-US', {
-                      year: 'numeric',
-                      month: 'long',
-                      day: 'numeric',
-                    })}
-                  </time>
+                {(post.date || post.author) && (
+                  <p className="text-sm text-fd-muted-foreground mt-1">
+                    {post.date && (
+                      <time>
+                        {new Date(post.date).toLocaleDateString('en-US', {
+                          year: 'numeric',
+                          month: 'long',
+                          day: 'numeric',
+                        })}
+                      </time>
+                    )}
+                    {post.date && post.author && ' · '}
+                    {post.author && <span>{post.author}</span>}
+                  </p>
                 )}
-                {post.description && (
-                  <p className="text-fd-muted-foreground mt-2">{post.description}</p>
+                {post.excerpt && (
+                  <p className="text-fd-muted-foreground mt-2">{post.excerpt}</p>
                 )}
               </article>
             ))}


### PR DESCRIPTION
## Summary
- Adds a new blog post at `docs/content/blog/2026-05-01-yoink-and-tailscale.mdx` covering the case for pairing yoink with Tailscale.
- Themes: SSH-key tax in small-team ops, why sealed secrets help but no-keys-at-all is better, locking down public :22, and how the same tailnet doubles as a free cross-provider service backplane (Postgres / Redis / app on separate hosts).
- Follows the format of the existing hello-world blog post (frontmatter with title/date/description).

## Test plan
- [ ] `pnpm dev` in `docs/` and confirm the post renders in the blog index and detail view.
- [ ] Spot-check links and code blocks.