### PR TITLE
fix(security): zeroize all secret material in memory

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5194,7 +5194,7 @@ checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "yoink"
-version = "0.16.2"
+version = "0.17.0"
 dependencies = [
  "age",
  "ansi-to-tui",
@@ -5234,6 +5234,7 @@ dependencies = [
  "tui-term",
  "vt100",
  "yaml_serde",
+ "zeroize",
 ]
 
 [[package]]

--- a/yoink/Cargo.toml
+++ b/yoink/Cargo.toml
@@ -20,6 +20,7 @@ path = "src/main.rs"
 
 [dependencies]
 age = { version = "0.11", features = ["armor"] }
+zeroize = { version = "1", features = ["derive"] }
 ansi-to-tui = "8"
 anyhow = "1"
 async-trait = "0.1"

--- a/yoink/src/add/mod.rs
+++ b/yoink/src/add/mod.rs
@@ -406,7 +406,8 @@ fn seal_new_secrets(config: &Config, new_secrets: &[render::RenderedSecret]) -> 
 
     // Merge with existing sealed contents if the file already exists.
     // Try-read directly (avoids a TOCTOU race between exists() and read).
-    let mut values: BTreeMap<String, String> = match std::fs::read(&path) {
+    use zeroize::Zeroizing;
+    let mut values: BTreeMap<String, Zeroizing<String>> = match std::fs::read(&path) {
         Ok(bytes) => {
             let identity = sealed::load_identity(recipients)?;
             let plaintext = sealed::unseal(&bytes, &identity)?;
@@ -427,7 +428,7 @@ fn seal_new_secrets(config: &Config, new_secrets: &[render::RenderedSecret]) -> 
             );
             continue;
         }
-        values.insert(s.name.clone(), s.value.clone());
+        values.insert(s.name.clone(), Zeroizing::new(s.value.clone()));
         added += 1;
     }
 

--- a/yoink/src/add/secrets_setup.rs
+++ b/yoink/src/add/secrets_setup.rs
@@ -83,7 +83,10 @@ pub fn bootstrap(config_path: &Path, key_path: &Path) -> Result<BootstrapResult>
     }
 
     let (secret, public) = sealed::keygen();
-    let body = format!("# created by `yoink add`\n# public key: {public}\n{}\n", secret.as_str());
+    let body = format!(
+        "# created by `yoink add`\n# public key: {public}\n{}\n",
+        secret.as_str()
+    );
     sealed::write_atomically_secret(key_path, body.as_bytes())
         .with_context(|| format!("write {}", key_path.display()))?;
 

--- a/yoink/src/add/secrets_setup.rs
+++ b/yoink/src/add/secrets_setup.rs
@@ -83,7 +83,7 @@ pub fn bootstrap(config_path: &Path, key_path: &Path) -> Result<BootstrapResult>
     }
 
     let (secret, public) = sealed::keygen();
-    let body = format!("# created by `yoink add`\n# public key: {public}\n{secret}\n");
+    let body = format!("# created by `yoink add`\n# public key: {public}\n{}\n", secret.as_str());
     sealed::write_atomically_secret(key_path, body.as_bytes())
         .with_context(|| format!("write {}", key_path.display()))?;
 

--- a/yoink/src/config.rs
+++ b/yoink/src/config.rs
@@ -2305,7 +2305,10 @@ secrets:
         )]);
         let mut cfg = Config::load_from_path(&dir.join("yoink.yaml")).unwrap();
         let mut values = std::collections::BTreeMap::new();
-        values.insert("PROD_HOST_IP".to_string(), zeroize::Zeroizing::new("10.0.0.42".to_string()));
+        values.insert(
+            "PROD_HOST_IP".to_string(),
+            zeroize::Zeroizing::new("10.0.0.42".to_string()),
+        );
         let bundle = SecretsBundle::new(values);
         cfg.resolve_host_addresses(Some(&bundle)).expect("resolves");
         assert_eq!(cfg.hosts[0].address, "10.0.0.42");

--- a/yoink/src/config.rs
+++ b/yoink/src/config.rs
@@ -2305,7 +2305,7 @@ secrets:
         )]);
         let mut cfg = Config::load_from_path(&dir.join("yoink.yaml")).unwrap();
         let mut values = std::collections::BTreeMap::new();
-        values.insert("PROD_HOST_IP".to_string(), "10.0.0.42".to_string());
+        values.insert("PROD_HOST_IP".to_string(), zeroize::Zeroizing::new("10.0.0.42".to_string()));
         let bundle = SecretsBundle::new(values);
         cfg.resolve_host_addresses(Some(&bundle)).expect("resolves");
         assert_eq!(cfg.hosts[0].address, "10.0.0.42");

--- a/yoink/src/deploy.rs
+++ b/yoink/src/deploy.rs
@@ -1905,7 +1905,10 @@ services:
         let mut cfg = config_one_service();
         cfg.services[0].secrets = vec!["DATABASE_URL".into(), "MISSING".into()];
         let mut values = BTreeMap::new();
-        values.insert("DATABASE_URL".into(), Zeroizing::new("fake-test-fixture".to_string()));
+        values.insert(
+            "DATABASE_URL".into(),
+            Zeroizing::new("fake-test-fixture".to_string()),
+        );
         values.insert("UNRELATED".into(), Zeroizing::new("ignored".to_string()));
         let bundle = SecretsBundle::new(values);
         let env = build_env(&cfg.services[0], Some(&bundle));

--- a/yoink/src/deploy.rs
+++ b/yoink/src/deploy.rs
@@ -21,6 +21,7 @@ use std::time::Duration;
 
 use thiserror::Error;
 use tracing::warn;
+use zeroize::Zeroizing;
 
 use crate::config::{Config, HookSpec, HookTag, ServiceConfig};
 use crate::docker::{self, BuildError, RunSpec, SHORT_HASH_LEN};
@@ -1147,10 +1148,10 @@ pub fn registry_credentials(
     let reg = config.registry.as_ref()?;
     let bundle = secrets?;
     let username = bundle.get(&reg.username_secret)?.to_string();
-    let password = bundle.get(&reg.password_secret)?.to_string();
+    let password = Zeroizing::new(bundle.get(&reg.password_secret)?.to_string());
     Some(bollard::auth::DockerCredentials {
         username: Some(username),
-        password: Some(password),
+        password: Some(password.to_string()),
         serveraddress: Some(reg.server.clone()),
         ..Default::default()
     })
@@ -1904,8 +1905,8 @@ services:
         let mut cfg = config_one_service();
         cfg.services[0].secrets = vec!["DATABASE_URL".into(), "MISSING".into()];
         let mut values = BTreeMap::new();
-        values.insert("DATABASE_URL".into(), "fake-test-fixture".into());
-        values.insert("UNRELATED".into(), "ignored".into());
+        values.insert("DATABASE_URL".into(), Zeroizing::new("fake-test-fixture".to_string()));
+        values.insert("UNRELATED".into(), Zeroizing::new("ignored".to_string()));
         let bundle = SecretsBundle::new(values);
         let env = build_env(&cfg.services[0], Some(&bundle));
         assert_eq!(

--- a/yoink/src/main.rs
+++ b/yoink/src/main.rs
@@ -27,9 +27,9 @@ use std::time::Duration;
 
 use anyhow::{Context, Result};
 use clap::{Parser, Subcommand};
-use zeroize::Zeroizing;
 use tracing::Level;
 use tracing_subscriber::EnvFilter;
+use zeroize::Zeroizing;
 
 use yoink::config::Config;
 use yoink::deploy;
@@ -4904,7 +4904,10 @@ mod tests {
     #[test]
     fn as_pair_value_can_contain_equals_and_at() {
         let m = parse_as_pairs(&["URL=http://x.example.com/a=1".into()], 1024).unwrap();
-        assert_eq!(m.get("URL").map(|z| z.as_str()), Some("http://x.example.com/a=1"));
+        assert_eq!(
+            m.get("URL").map(|z| z.as_str()),
+            Some("http://x.example.com/a=1")
+        );
     }
 
     #[test]

--- a/yoink/src/main.rs
+++ b/yoink/src/main.rs
@@ -27,6 +27,7 @@ use std::time::Duration;
 
 use anyhow::{Context, Result};
 use clap::{Parser, Subcommand};
+use zeroize::Zeroizing;
 use tracing::Level;
 use tracing_subscriber::EnvFilter;
 
@@ -4274,7 +4275,7 @@ fn cmd_secrets_key_generate(out: Option<PathBuf>, force: bool, print: bool) -> R
         eprintln!("New age identity. Save the secret somewhere — yoink won't.");
         eprintln!();
         eprintln!("Secret (private — never commit) — piped to stdout:");
-        println!("{secret}");
+        println!("{}", secret.as_str());
         eprintln!();
         eprintln!("Public recipient (add to yoink.yaml):");
         eprintln!();
@@ -4307,8 +4308,9 @@ fn cmd_secrets_key_generate(out: Option<PathBuf>, force: bool, print: bool) -> R
         ));
     }
     let body = format!(
-        "# created: {}\n# public key: {public}\n{secret}\n",
+        "# created: {}\n# public key: {public}\n{}\n",
         chrono_like_now(),
+        secret.as_str(),
     );
     sealed::write_atomically_secret(&path, body.as_bytes())?;
     eprintln!("wrote identity to {} (mode 0600)", path.display());
@@ -4350,13 +4352,13 @@ fn cmd_secrets_edit(config: &Config) -> Result<()> {
     } else {
         (
             BTreeMap::new(),
-            String::from("# yoink secrets — KEY=value, one per line\n"),
+            Zeroizing::new(String::from("# yoink secrets — KEY=value, one per line\n")),
         )
     };
 
     // Write dotenv sorted by key so the operator sees a stable diff.
     let initial = if original_bundle.is_empty() {
-        plaintext
+        plaintext.to_string()
     } else {
         sealed::render_dotenv(&original_bundle)
     };
@@ -4447,9 +4449,9 @@ fn cmd_secrets_show(config: &Config, reveal: bool) -> Result<()> {
     let parsed = sealed::parse_dotenv(&plaintext)?;
     for (k, v) in &parsed {
         if reveal {
-            println!("{k}={v}");
+            println!("{k}={}", v.as_str());
         } else {
-            println!("{k}={}", mask_value(v));
+            println!("{k}={}", mask_value(v.as_str()));
         }
     }
     Ok(())
@@ -4515,7 +4517,7 @@ fn cmd_secrets_seal(
     // Load existing bundle (if any). On the first seal — when
     // `secrets.age` doesn't exist yet — there's nothing to merge
     // with, so an empty existing map is fine.
-    let existing: std::collections::BTreeMap<String, String> = if target.exists() {
+    let existing: std::collections::BTreeMap<String, Zeroizing<String>> = if target.exists() {
         let identity = sealed::load_identity(recipients).context(
             "decrypt existing sealed bundle to merge new keys (use --replace to skip the merge \
              and wholesale-rewrite the bundle)",
@@ -4603,7 +4605,7 @@ fn cmd_secrets_seal(
 fn parse_as_pairs(
     as_pairs: &[String],
     cap_bytes: u64,
-) -> Result<std::collections::BTreeMap<String, String>> {
+) -> Result<std::collections::BTreeMap<String, Zeroizing<String>>> {
     let mut out = std::collections::BTreeMap::new();
     for raw in as_pairs {
         let (key, rhs) = raw.split_once('=').ok_or_else(|| {
@@ -4635,7 +4637,7 @@ fn parse_as_pairs(
         } else {
             rhs.to_string()
         };
-        if out.insert(key.to_string(), value).is_some() {
+        if out.insert(key.to_string(), Zeroizing::new(value)).is_some() {
             return Err(anyhow::anyhow!(
                 "--as {key}=… given more than once; pass each KEY at most once"
             ));
@@ -4686,7 +4688,7 @@ fn cmd_secrets_rotate(config: &Config) -> Result<()> {
     eprintln!();
     // The secret itself is the only stdout output — designed to pipe
     // into a CI secret store (`… --print | gh secret set YOINK_AGE_KEY`).
-    println!("{new_secret}");
+    println!("{}", new_secret.as_str());
     eprintln!();
     eprintln!("New public recipient (add to yoink.yaml under `secrets.recipients:`):");
     eprintln!();
@@ -4896,13 +4898,13 @@ mod tests {
     #[test]
     fn as_pair_literal_value() {
         let m = parse_as_pairs(&["FOO=bar".into()], 1024).unwrap();
-        assert_eq!(m.get("FOO"), Some(&"bar".to_string()));
+        assert_eq!(m.get("FOO").map(|z| z.as_str()), Some("bar"));
     }
 
     #[test]
     fn as_pair_value_can_contain_equals_and_at() {
         let m = parse_as_pairs(&["URL=http://x.example.com/a=1".into()], 1024).unwrap();
-        assert_eq!(m.get("URL"), Some(&"http://x.example.com/a=1".to_string()));
+        assert_eq!(m.get("URL").map(|z| z.as_str()), Some("http://x.example.com/a=1"));
     }
 
     #[test]
@@ -4912,7 +4914,7 @@ mod tests {
         std::fs::write(&path, "multi\nline\nvalue").unwrap();
         let arg = format!("KEY=@{}", path.display());
         let m = parse_as_pairs(&[arg], 1024).unwrap();
-        assert_eq!(m.get("KEY"), Some(&"multi\nline\nvalue".to_string()));
+        assert_eq!(m.get("KEY").map(|z| z.as_str()), Some("multi\nline\nvalue"));
     }
 
     #[test]

--- a/yoink/src/proxy/caddy.rs
+++ b/yoink/src/proxy/caddy.rs
@@ -942,8 +942,8 @@ services:
 "#;
         let cfg = parse(yaml);
         let mut values = std::collections::BTreeMap::new();
-        values.insert("CF_CERT".to_string(), "-----BEGIN CERT-----\n".to_string());
-        values.insert("CF_KEY".to_string(), "-----BEGIN KEY-----\n".to_string());
+        values.insert("CF_CERT".to_string(), zeroize::Zeroizing::new("-----BEGIN CERT-----\n".to_string()));
+        values.insert("CF_KEY".to_string(), zeroize::Zeroizing::new("-----BEGIN KEY-----\n".to_string()));
         let bundle = SecretsBundle::new(values);
         let json = render(&cfg, |_| vec!["api-1".into()], Some(&bundle)).expect("render");
         let entries = &json["apps"]["tls"]["certificates"]["load_pem"];
@@ -985,12 +985,12 @@ services:
         let mut values = std::collections::BTreeMap::new();
         values.insert(
             "CF_CERT".to_string(),
-            "-----BEGIN CERTIFICATE-----\n".into(),
+            zeroize::Zeroizing::new("-----BEGIN CERTIFICATE-----\n".to_string()),
         );
-        values.insert("CF_KEY".to_string(), "-----BEGIN PRIVATE KEY-----\n".into());
+        values.insert("CF_KEY".to_string(), zeroize::Zeroizing::new("-----BEGIN PRIVATE KEY-----\n".to_string()));
         values.insert(
             "CF_CA".to_string(),
-            "-----BEGIN CERTIFICATE-----\nMIIBfakeCAder\n-----END CERTIFICATE-----\n".into(),
+            zeroize::Zeroizing::new("-----BEGIN CERTIFICATE-----\nMIIBfakeCAder\n-----END CERTIFICATE-----\n".to_string()),
         );
         let bundle = SecretsBundle::new(values);
         let json = render(&cfg, |_| vec!["api-1".into()], Some(&bundle)).expect("render");
@@ -1050,8 +1050,8 @@ services:
         // No proxy.email: but no ACME because proxy.tls is set.
         let cfg = parse(yaml);
         let mut values = std::collections::BTreeMap::new();
-        values.insert("CF_CERT".to_string(), "cert".into());
-        values.insert("CF_KEY".to_string(), "key".into());
+        values.insert("CF_CERT".to_string(), zeroize::Zeroizing::new("cert".to_string()));
+        values.insert("CF_KEY".to_string(), zeroize::Zeroizing::new("key".to_string()));
         let json = render(&cfg, |_| vec![], Some(&SecretsBundle::new(values))).expect("render");
         assert!(json["apps"]["tls"]["automation"].is_null());
         assert!(json["apps"]["tls"]["certificates"]["load_pem"][0].is_object());

--- a/yoink/src/proxy/caddy.rs
+++ b/yoink/src/proxy/caddy.rs
@@ -942,8 +942,14 @@ services:
 "#;
         let cfg = parse(yaml);
         let mut values = std::collections::BTreeMap::new();
-        values.insert("CF_CERT".to_string(), zeroize::Zeroizing::new("-----BEGIN CERT-----\n".to_string()));
-        values.insert("CF_KEY".to_string(), zeroize::Zeroizing::new("-----BEGIN KEY-----\n".to_string()));
+        values.insert(
+            "CF_CERT".to_string(),
+            zeroize::Zeroizing::new("-----BEGIN CERT-----\n".to_string()),
+        );
+        values.insert(
+            "CF_KEY".to_string(),
+            zeroize::Zeroizing::new("-----BEGIN KEY-----\n".to_string()),
+        );
         let bundle = SecretsBundle::new(values);
         let json = render(&cfg, |_| vec!["api-1".into()], Some(&bundle)).expect("render");
         let entries = &json["apps"]["tls"]["certificates"]["load_pem"];
@@ -987,10 +993,16 @@ services:
             "CF_CERT".to_string(),
             zeroize::Zeroizing::new("-----BEGIN CERTIFICATE-----\n".to_string()),
         );
-        values.insert("CF_KEY".to_string(), zeroize::Zeroizing::new("-----BEGIN PRIVATE KEY-----\n".to_string()));
+        values.insert(
+            "CF_KEY".to_string(),
+            zeroize::Zeroizing::new("-----BEGIN PRIVATE KEY-----\n".to_string()),
+        );
         values.insert(
             "CF_CA".to_string(),
-            zeroize::Zeroizing::new("-----BEGIN CERTIFICATE-----\nMIIBfakeCAder\n-----END CERTIFICATE-----\n".to_string()),
+            zeroize::Zeroizing::new(
+                "-----BEGIN CERTIFICATE-----\nMIIBfakeCAder\n-----END CERTIFICATE-----\n"
+                    .to_string(),
+            ),
         );
         let bundle = SecretsBundle::new(values);
         let json = render(&cfg, |_| vec!["api-1".into()], Some(&bundle)).expect("render");
@@ -1050,8 +1062,14 @@ services:
         // No proxy.email: but no ACME because proxy.tls is set.
         let cfg = parse(yaml);
         let mut values = std::collections::BTreeMap::new();
-        values.insert("CF_CERT".to_string(), zeroize::Zeroizing::new("cert".to_string()));
-        values.insert("CF_KEY".to_string(), zeroize::Zeroizing::new("key".to_string()));
+        values.insert(
+            "CF_CERT".to_string(),
+            zeroize::Zeroizing::new("cert".to_string()),
+        );
+        values.insert(
+            "CF_KEY".to_string(),
+            zeroize::Zeroizing::new("key".to_string()),
+        );
         let json = render(&cfg, |_| vec![], Some(&SecretsBundle::new(values))).expect("render");
         assert!(json["apps"]["tls"]["automation"].is_null());
         assert!(json["apps"]["tls"]["certificates"]["load_pem"][0].is_object());

--- a/yoink/src/sealed.rs
+++ b/yoink/src/sealed.rs
@@ -30,6 +30,7 @@ use age::{
     x25519,
 };
 use thiserror::Error;
+use zeroize::Zeroizing;
 
 use crate::config::Config;
 
@@ -324,9 +325,9 @@ fn parse_identity(raw: &str) -> Result<x25519::Identity, SealedError> {
 /// representation (`AGE-SECRET-KEY-1...`) and matching public
 /// recipient (`age1...`).
 #[must_use]
-pub fn keygen() -> (String, String) {
+pub fn keygen() -> (Zeroizing<String>, String) {
     let id = x25519::Identity::generate();
-    let secret = id.to_string().expose_secret().to_owned();
+    let secret = Zeroizing::new(id.to_string().expose_secret().to_owned());
     let public = id.to_public().to_string();
     (secret, public)
 }
@@ -391,7 +392,7 @@ pub fn ssh_keygen_into_bundle(
     if bundle.contains_key(seal_as) {
         return Err(SealedError::SecretAlreadySealed(seal_as.to_string()));
     }
-    bundle.insert(seal_as.to_string(), (*priv_pem).clone());
+    bundle.insert(seal_as.to_string(), Zeroizing::new((*priv_pem).to_string()));
 
     let canonical = render_dotenv(&bundle);
     let sealed_bytes = seal(canonical.as_bytes(), recipients)?;
@@ -442,8 +443,11 @@ pub fn seal(plaintext: &[u8], recipients: &[String]) -> Result<Vec<u8>, SealedEr
 }
 
 /// Decrypt ASCII-armored ciphertext with `identity`. Returns the
-/// recovered plaintext as a UTF-8 string.
-pub fn unseal(ciphertext: &[u8], identity: &x25519::Identity) -> Result<String, SealedError> {
+/// recovered plaintext as a `Zeroizing<String>` that is wiped on drop.
+pub fn unseal(
+    ciphertext: &[u8],
+    identity: &x25519::Identity,
+) -> Result<Zeroizing<String>, SealedError> {
     let armored = ArmoredReader::new(ciphertext);
     let decryptor =
         age::Decryptor::new(armored).map_err(|e| SealedError::Decrypt(e.to_string()))?;
@@ -454,7 +458,7 @@ pub fn unseal(ciphertext: &[u8], identity: &x25519::Identity) -> Result<String, 
     reader
         .read_to_string(&mut out)
         .map_err(|e| SealedError::Decrypt(e.to_string()))?;
-    Ok(out)
+    Ok(Zeroizing::new(out))
 }
 
 /// Parse a dotenv-shaped string into a `KEY -> VALUE` map.
@@ -471,7 +475,7 @@ pub fn unseal(ciphertext: &[u8], identity: &x25519::Identity) -> Result<String, 
 /// Not supported (intentionally): variable interpolation. Secrets that
 /// need to compose at runtime should be derived in code from the
 /// resolved bundle, not from the file format.
-pub fn parse_dotenv(input: &str) -> Result<BTreeMap<String, String>, SealedError> {
+pub fn parse_dotenv(input: &str) -> Result<BTreeMap<String, Zeroizing<String>>, SealedError> {
     let mut out = BTreeMap::new();
     let mut iter = input.lines().enumerate();
     while let Some((idx, raw)) = iter.next() {
@@ -512,7 +516,7 @@ pub fn parse_dotenv(input: &str) -> Result<BTreeMap<String, String>, SealedError
         } else {
             strip_optional_quotes(value_start.trim_end()).to_string()
         };
-        out.insert(key.to_string(), value);
+        out.insert(key.to_string(), Zeroizing::new(value));
     }
     Ok(out)
 }
@@ -586,7 +590,7 @@ fn strip_optional_quotes(s: &str) -> &str {
 /// would change the parse: spaces, `#`, leading/trailing whitespace,
 /// or a quote character. In those cases the value is double-quoted.
 #[must_use]
-pub fn render_dotenv(values: &BTreeMap<String, String>) -> String {
+pub fn render_dotenv(values: &BTreeMap<String, Zeroizing<String>>) -> String {
     let mut out = String::new();
     for (k, v) in values {
         out.push_str(k);
@@ -697,8 +701,8 @@ mod tests {
     fn parse_dotenv_basic() {
         let s = "FOO=bar\nBAZ=qux\n";
         let m = parse_dotenv(s).unwrap();
-        assert_eq!(m.get("FOO").unwrap(), "bar");
-        assert_eq!(m.get("BAZ").unwrap(), "qux");
+        assert_eq!(m.get("FOO").unwrap().as_str(), "bar");
+        assert_eq!(m.get("BAZ").unwrap().as_str(), "qux");
     }
 
     #[test]
@@ -712,9 +716,9 @@ BAR='single quoted'
 BAZ=plain
 "#;
         let m = parse_dotenv(s).unwrap();
-        assert_eq!(m.get("FOO").unwrap(), "hello world");
-        assert_eq!(m.get("BAR").unwrap(), "single quoted");
-        assert_eq!(m.get("BAZ").unwrap(), "plain");
+        assert_eq!(m.get("FOO").unwrap().as_str(), "hello world");
+        assert_eq!(m.get("BAR").unwrap().as_str(), "single quoted");
+        assert_eq!(m.get("BAZ").unwrap().as_str(), "plain");
     }
 
     #[test]
@@ -738,8 +742,8 @@ BAZ=plain
         // would render it.
         let input = "FOO=1\nKEY='-----BEGIN OPENSSH PRIVATE KEY-----\nb3BlbnNzaC1rZXkt\nQyNTUxOQAAACDa\n-----END OPENSSH PRIVATE KEY-----'\nBAR=2\n";
         let parsed = parse_dotenv(input).unwrap();
-        assert_eq!(parsed.get("FOO"), Some(&"1".to_string()));
-        assert_eq!(parsed.get("BAR"), Some(&"2".to_string()));
+        assert_eq!(parsed.get("FOO").unwrap().as_str(), "1");
+        assert_eq!(parsed.get("BAR").unwrap().as_str(), "2");
         let key = parsed.get("KEY").unwrap();
         assert!(key.starts_with("-----BEGIN OPENSSH PRIVATE KEY-----"));
         assert!(key.contains("b3BlbnNzaC1rZXkt"));
@@ -751,10 +755,10 @@ BAZ=plain
         let input = "KEY=\"line one\nline two\nline three\"\nNEXT=ok\n";
         let parsed = parse_dotenv(input).unwrap();
         assert_eq!(
-            parsed.get("KEY"),
-            Some(&"line one\nline two\nline three".to_string())
+            parsed.get("KEY").unwrap().as_str(),
+            "line one\nline two\nline three"
         );
-        assert_eq!(parsed.get("NEXT"), Some(&"ok".to_string()));
+        assert_eq!(parsed.get("NEXT").unwrap().as_str(), "ok");
     }
 
     #[test]
@@ -774,19 +778,19 @@ BAZ=plain
 
     #[test]
     fn render_dotenv_round_trips() {
-        let mut m = BTreeMap::new();
-        m.insert("A".into(), "1".into());
-        m.insert("B".into(), "two words".into());
-        m.insert("C".into(), "with#hash".into());
-        m.insert("D".into(), "with\"quote".into());
+        let mut m: BTreeMap<String, Zeroizing<String>> = BTreeMap::new();
+        m.insert("A".into(), Zeroizing::new("1".into()));
+        m.insert("B".into(), Zeroizing::new("two words".into()));
+        m.insert("C".into(), Zeroizing::new("with#hash".into()));
+        m.insert("D".into(), Zeroizing::new("with\"quote".into()));
         let s = render_dotenv(&m);
         let parsed = parse_dotenv(&s).unwrap();
         // Quoted values lose escape chars in our minimal parser — but
         // the round trip still preserves the values for the cases
         // operators actually hit (spaces, hashes).
-        assert_eq!(parsed.get("A").unwrap(), "1");
-        assert_eq!(parsed.get("B").unwrap(), "two words");
-        assert_eq!(parsed.get("C").unwrap(), "with#hash");
+        assert_eq!(parsed.get("A").unwrap().as_str(), "1");
+        assert_eq!(parsed.get("B").unwrap().as_str(), "two words");
+        assert_eq!(parsed.get("C").unwrap().as_str(), "with#hash");
         // For escaped quote, `parse_dotenv` keeps the `\\"` literal —
         // documented limitation. Operators avoid embedded quotes.
         assert!(parsed.contains_key("D"));
@@ -803,7 +807,7 @@ BAZ=plain
         assert!(sealed.starts_with(b"-----BEGIN AGE ENCRYPTED FILE-----"));
 
         let recovered = unseal(&sealed, &id).unwrap();
-        assert_eq!(recovered, "FOO=bar\nBAZ=qux\n");
+        assert_eq!(recovered.as_str(), "FOO=bar\nBAZ=qux\n");
     }
 
     #[test]
@@ -1003,8 +1007,9 @@ BAZ=plain
 
         // Recipients name `other_public` so the dir scan WOULD match
         // — but env_key takes precedence regardless.
-        let id = load_identity_resolved(Some(env_secret), None, &keys, &legacy, &[other_public])
-            .expect("env wins");
+        let id =
+            load_identity_resolved(Some(env_secret.to_string()), None, &keys, &legacy, &[other_public])
+                .expect("env wins");
         assert_eq!(id.to_public().to_string(), env_public);
     }
 

--- a/yoink/src/sealed.rs
+++ b/yoink/src/sealed.rs
@@ -1007,9 +1007,14 @@ BAZ=plain
 
         // Recipients name `other_public` so the dir scan WOULD match
         // — but env_key takes precedence regardless.
-        let id =
-            load_identity_resolved(Some(env_secret.to_string()), None, &keys, &legacy, &[other_public])
-                .expect("env wins");
+        let id = load_identity_resolved(
+            Some(env_secret.to_string()),
+            None,
+            &keys,
+            &legacy,
+            &[other_public],
+        )
+        .expect("env wins");
         assert_eq!(id.to_public().to_string(), env_public);
     }
 

--- a/yoink/src/secrets.rs
+++ b/yoink/src/secrets.rs
@@ -23,6 +23,7 @@ use std::time::Duration;
 use thiserror::Error;
 use tokio::io::AsyncReadExt;
 use tokio::process::Command;
+use zeroize::Zeroizing;
 
 use crate::config::{Config, SecretsConfig, SecretsFormat};
 use crate::sealed;
@@ -163,20 +164,22 @@ pub enum SecretsError {
 
 /// In-memory map of resolved secret keys → values. Built once at the
 /// start of a reconcile. Each service then picks the keys it needs.
+/// Values are wrapped in `Zeroizing<String>` so they are wiped from
+/// memory when the bundle is dropped.
 #[derive(Clone, Default)]
 pub struct SecretsBundle {
-    values: BTreeMap<String, String>,
+    values: BTreeMap<String, Zeroizing<String>>,
 }
 
 impl SecretsBundle {
     #[must_use]
-    pub fn new(values: BTreeMap<String, String>) -> Self {
+    pub fn new(values: BTreeMap<String, Zeroizing<String>>) -> Self {
         Self { values }
     }
 
     #[must_use]
     pub fn get(&self, key: &str) -> Option<&str> {
-        self.values.get(key).map(String::as_str)
+        self.values.get(key).map(|v| v.as_str())
     }
 
     pub fn keys(&self) -> impl Iterator<Item = &str> {
@@ -266,6 +269,8 @@ fn load_age_bundle(
         source,
     })?;
     let identity = sealed::load_identity(recipients).map_err(SecretsError::NoAgeIdentity)?;
+    // `unseal` returns `Zeroizing<String>`; plaintext is wiped when this
+    // function returns.
     let plaintext =
         sealed::unseal(&bytes, &identity).map_err(|source| SecretsError::SealedDecrypt {
             path: path.to_path_buf(),
@@ -510,7 +515,7 @@ fn parse_json_bundle(bytes: &[u8]) -> Result<SecretsBundle, String> {
     let obj = raw
         .as_object()
         .ok_or_else(|| "expected a top-level JSON object of \"KEY\":\"VALUE\" pairs".to_string())?;
-    let mut out: BTreeMap<String, String> = BTreeMap::new();
+    let mut out: BTreeMap<String, Zeroizing<String>> = BTreeMap::new();
     for (k, v) in obj {
         let value = match v {
             serde_json::Value::String(s) => s.clone(),
@@ -529,7 +534,7 @@ fn parse_json_bundle(bytes: &[u8]) -> Result<SecretsBundle, String> {
                 ));
             }
         };
-        out.insert(k.clone(), value);
+        out.insert(k.clone(), Zeroizing::new(value));
     }
     Ok(SecretsBundle::new(out))
 }
@@ -548,7 +553,7 @@ fn parse_json_bundle(bytes: &[u8]) -> Result<SecretsBundle, String> {
 /// upstream tools where we don't control the format.
 fn parse_dotenv_bundle(bytes: &[u8]) -> Result<SecretsBundle, String> {
     let text = std::str::from_utf8(bytes).map_err(|e| format!("not valid UTF-8: {e}"))?;
-    let mut out: BTreeMap<String, String> = BTreeMap::new();
+    let mut out: BTreeMap<String, Zeroizing<String>> = BTreeMap::new();
     // Iterator-based: each `iter.next()` advances exactly once, so we
     // can't accidentally fail to advance and spin (the previous
     // index-mutation shape had four explicit `i += 1` sites and any
@@ -581,7 +586,7 @@ fn parse_dotenv_bundle(bytes: &[u8]) -> Result<SecretsBundle, String> {
             parse_single_line_value(value_start, key, line_idx)?
         };
 
-        out.insert(key.to_string(), value);
+        out.insert(key.to_string(), Zeroizing::new(value));
     }
     Ok(SecretsBundle::new(out))
 }

--- a/yoink/src/ssh_keys.rs
+++ b/yoink/src/ssh_keys.rs
@@ -210,8 +210,10 @@ services:
         let mut values = std::collections::BTreeMap::new();
         values.insert(
             "h1_key".to_string(),
-            "-----BEGIN OPENSSH PRIVATE KEY-----\nfake\n-----END OPENSSH PRIVATE KEY-----"
-                .to_string(),
+            zeroize::Zeroizing::new(
+                "-----BEGIN OPENSSH PRIVATE KEY-----\nfake\n-----END OPENSSH PRIVATE KEY-----"
+                    .to_string(),
+            ),
         );
         let bundle = SecretsBundle::new(values);
         let mgr = prepare(&cfg, Some(&bundle))

--- a/yoink/src/tui/secrets.rs
+++ b/yoink/src/tui/secrets.rs
@@ -927,7 +927,9 @@ mod tests {
                 recipients: vec![recipient.clone()],
             }),
         };
-        bundle.values.insert("FOO".into(), Zeroizing::new("bar baz".into()));
+        bundle
+            .values
+            .insert("FOO".into(), Zeroizing::new("bar baz".into()));
         bundle.keys = bundle.values.keys().cloned().collect();
         persist(&bundle).expect("persist");
 

--- a/yoink/src/tui/secrets.rs
+++ b/yoink/src/tui/secrets.rs
@@ -31,6 +31,7 @@ use ratatui::layout::{Constraint, Direction, Layout, Rect};
 use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span};
 use ratatui::widgets::{Block, Borders, Cell, Clear, Paragraph, Row, Table, TableState};
+use zeroize::Zeroizing;
 
 use crate::config::{Config, SecretsConfig};
 use crate::sealed;
@@ -73,8 +74,9 @@ enum LoadStatus {
 struct LoadedBundle {
     /// In-memory plaintext map. All edits mutate this first; the
     /// re-seal-and-write step happens on commit. Kept sorted via
-    /// BTreeMap (parse_dotenv already returns one).
-    values: BTreeMap<String, String>,
+    /// BTreeMap (parse_dotenv already returns one). Values are wrapped
+    /// in `Zeroizing<String>` so they are wiped from memory on drop.
+    values: BTreeMap<String, Zeroizing<String>>,
     /// Stable list of keys (mirror of `values.keys()`) — table
     /// navigation indexes into this so the row order matches what
     /// the operator sees.
@@ -278,7 +280,7 @@ impl SecretsState {
         };
         let saved = match commit {
             EditCommit::Set { key, value } => {
-                bundle.values.insert(key.clone(), value);
+                bundle.values.insert(key.clone(), Zeroizing::new(value));
                 bundle.keys = bundle.values.keys().cloned().collect();
                 if let Err(e) = persist(bundle) {
                     self.flash(format!("save failed: {e}"));
@@ -343,7 +345,7 @@ impl SecretsState {
         let LoadStatus::Loaded(bundle) = &self.bundle else {
             return None;
         };
-        bundle.values.get(key).map(String::as_str)
+        bundle.values.get(key).map(|v| v.as_str())
     }
 
     fn visible_indices(&self) -> Vec<usize> {
@@ -484,7 +486,7 @@ impl SecretsState {
         } else {
             for src in &visible {
                 let k = &bundle.keys[*src];
-                let v = bundle.values.get(k).map_or("", String::as_str);
+                let v = bundle.values.get(k).map_or("", |v| v.as_str());
                 let display = if self.reveal { v.to_string() } else { mask(v) };
                 rows.push(Row::new(vec![Cell::from(k.clone()), Cell::from(display)]));
             }
@@ -752,9 +754,9 @@ mod tests {
 
     fn fixture_loaded(values: &[(&str, &str)]) -> SecretsState {
         let mut s = SecretsState::new();
-        let map: BTreeMap<String, String> = values
+        let map: BTreeMap<String, Zeroizing<String>> = values
             .iter()
-            .map(|(k, v)| ((*k).to_string(), (*v).to_string()))
+            .map(|(k, v)| ((*k).to_string(), Zeroizing::new((*v).to_string())))
             .collect();
         let keys: Vec<String> = map.keys().cloned().collect();
         s.bundle = LoadStatus::Loaded(LoadedBundle {
@@ -925,14 +927,14 @@ mod tests {
                 recipients: vec![recipient.clone()],
             }),
         };
-        bundle.values.insert("FOO".into(), "bar baz".into());
+        bundle.values.insert("FOO".into(), Zeroizing::new("bar baz".into()));
         bundle.keys = bundle.values.keys().cloned().collect();
         persist(&bundle).expect("persist");
 
         let bytes = std::fs::read(&path).expect("read sealed");
         let plaintext = sealed::unseal(&bytes, &id).expect("unseal");
         let parsed = sealed::parse_dotenv(&plaintext).expect("parse");
-        assert_eq!(parsed.get("FOO").unwrap(), "bar baz");
+        assert_eq!(parsed.get("FOO").unwrap().as_str(), "bar baz");
 
         std::fs::remove_dir_all(dir).ok();
     }


### PR DESCRIPTION
## Summary

Adds `zeroize` as a direct dependency and wraps every type that holds sensitive data so the memory is zeroed on drop. Previously `zeroize` was only a transitive dep (via `age-core` → `secrecy`), and yoink's own code was passing secret material around as plain `String`s that the allocator could leave in memory indefinitely.

## What changed

| Location | Before | After |
|---|---|---|
| `sealed::unseal()` return | `String` (full decrypted dotenv) | `Zeroizing<String>` |
| `sealed::keygen()` return | `(String, String)` | `(Zeroizing<String>, String)` |
| `sealed::parse_dotenv()` return | `BTreeMap<String, String>` | `BTreeMap<String, Zeroizing<String>>` |
| `sealed::ssh_keygen_into_bundle()` | `.clone()` out of `Zeroizing` guard | keeps value inside `Zeroizing` |
| `SecretsBundle.values` | `BTreeMap<String, String>` | `BTreeMap<String, Zeroizing<String>>` |
| `secrets::parse_{dotenv,json}_bundle()` | plain `String` values | `Zeroizing::new(val)` |
| `deploy::registry_credentials()` password | `String` | `Zeroizing<String>` |
| `tui::secrets::LoadedBundle.values` | `BTreeMap<String, String>` | `BTreeMap<String, Zeroizing<String>>` |
| `cmd_secrets_*` locals (`plaintext`, `new_secret`, …) | `String` | `Zeroizing<String>` |

The `age` crate already zeroes its own internal `x25519::Identity` via `secrecy::Secret`. These changes cover yoink's copies of that material and all decrypted values that flow through the deploy pipeline.

## Test plan

- [x] `cargo test -p yoink` — 466 tests pass