### PR TITLE
feat(secrets): add `yoink secrets env` for sourcing into local dev shell

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5194,7 +5194,7 @@ checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "yoink"
-version = "0.16.2"
+version = "0.17.0"
 dependencies = [
  "age",
  "ansi-to-tui",

--- a/docs/content/docs/how-to/sealed-secrets-workflow.mdx
+++ b/docs/content/docs/how-to/sealed-secrets-workflow.mdx
@@ -118,6 +118,16 @@ services:
 
 Yoink resolves the values from the sealed bundle and injects them as env vars. The values feed into [`spec_hash`](/docs/guide/architecture#drift-detection), so rotating a secret triggers a redeploy like a config change. Editing *any* key in `secrets.age` rerolls every service that references *any* secret — `yoink up --dry-run` shows the diff first.
 
+## Loading into a local dev shell
+
+```sh
+source <(yoink secrets env)                  # exports every key into the current shell
+eval "$(yoink secrets env)"                  # equivalent for shells without process substitution
+yoink secrets env --no-export > .env.local   # bare KEY='value' for `docker run --env-file` etc.
+```
+
+Values are POSIX single-quote-escaped so `$`, embedded quotes, and newlines round-trip literally — a `JWT_SIGNING_KEY` containing `$` won't get re-expanded by the shell. Refuses to run when `$CI` / `$GITHUB_ACTIONS` / etc. are set unless `YOINK_ALLOW_REVEAL_IN_CI=1`; this is meant for laptops, not build logs.
+
 ## Multiple environments (staging / prod)
 
 To keep staging and prod values separate so a leaked staging key can't unlock prod:

--- a/docs/content/docs/reference/cli.md
+++ b/docs/content/docs/reference/cli.md
@@ -217,6 +217,15 @@ yoink secrets edit                       decrypt the configured sealed file into
 yoink secrets show [--reveal]            print KEY=value (values masked unless --reveal).
                                          Refuses --reveal in CI ($CI set) unless
                                          YOINK_ALLOW_REVEAL_IN_CI=1.
+yoink secrets env                        decrypt the bundle and print
+                                         `export KEY='value'` lines for sourcing
+                                         into a local dev shell, e.g.
+                                         `source <(yoink secrets env)`. Values
+                                         are POSIX single-quoted so `$`, quotes,
+                                         and newlines pass through literally.
+                                         Same CI guard as `show --reveal`.
+  --no-export                            emit bare `KEY='value'` lines (dotenv
+                                         style) instead of `export KEY='value'`.
 yoink secrets seal --in <PATH>           seal a plaintext dotenv (or read from stdin)
   --as KEY=value                         set one key directly; --as KEY=@PATH reads
                                          the value from a file. Repeatable.

--- a/yoink/src/main.rs
+++ b/yoink/src/main.rs
@@ -811,6 +811,30 @@ enum SecretsAction {
         #[arg(long)]
         reveal: bool,
     },
+    /// Decrypt and print the sealed bundle as shell-evalable
+    /// `export KEY='value'` lines, for loading secrets into your
+    /// current shell during local development:
+    ///
+    ///   source <(yoink secrets env)
+    ///   # or
+    ///   eval "$(yoink secrets env)"
+    ///
+    /// Values are POSIX single-quote-escaped so embedded quotes,
+    /// newlines, and `$` are passed through literally. Pass
+    /// `--no-export` to drop the `export ` prefix (useful for
+    /// piping into a `.env`-style file consumed by tools like
+    /// `docker run --env-file`).
+    ///
+    /// Refuses to run in CI by default — same guard as
+    /// `secrets show --reveal`. Override with
+    /// `YOINK_ALLOW_REVEAL_IN_CI=1` if you really mean it.
+    Env {
+        /// Emit bare `KEY='value'` lines instead of
+        /// `export KEY='value'`. Use when feeding tools that
+        /// consume dotenv-style files rather than shell `source`.
+        #[arg(long)]
+        no_export: bool,
+    },
     /// One-shot: read a plaintext dotenv from `--in` (or stdin) OR
     /// individual `--as KEY=...` pairs, **merge** into the existing
     /// sealed bundle (matching `secrets ssh-key generate --seal-as`'s
@@ -4173,6 +4197,7 @@ fn cmd_secrets(config: &Config, action: SecretsAction) -> Result<()> {
         },
         SecretsAction::Edit => cmd_secrets_edit(config),
         SecretsAction::Show { reveal } => cmd_secrets_show(config, reveal),
+        SecretsAction::Env { no_export } => cmd_secrets_env(config, no_export),
         SecretsAction::Seal {
             r#in,
             as_pairs,
@@ -4453,6 +4478,52 @@ fn cmd_secrets_show(config: &Config, reveal: bool) -> Result<()> {
         }
     }
     Ok(())
+}
+
+fn cmd_secrets_env(config: &Config, no_export: bool) -> Result<()> {
+    use yoink::config::SecretsConfig;
+    use yoink::sealed;
+    if let Some(ci_var) = detected_ci_env()
+        && !is_truthy_env("YOINK_ALLOW_REVEAL_IN_CI")
+    {
+        return Err(anyhow::anyhow!(
+            "refusing to print real secret values: detected CI environment (${ci_var} is set). \
+             `secrets env` is meant for sourcing into a local dev shell, not CI logs. \
+             If this is intentional, set YOINK_ALLOW_REVEAL_IN_CI=1"
+        ));
+    }
+    let SecretsConfig::Age { file, recipients } = expect_secrets_provider_age(config)? else {
+        unreachable!()
+    };
+    let path = sealed::resolve_sealed_path(config, file.as_deref())?;
+    let bytes =
+        std::fs::read(&path).with_context(|| format!("read sealed file {}", path.display()))?;
+    let identity = sealed::load_identity(recipients)?;
+    let plaintext = sealed::unseal(&bytes, &identity)?;
+    let parsed = sealed::parse_dotenv(&plaintext)?;
+    let prefix = if no_export { "" } else { "export " };
+    for (k, v) in &parsed {
+        println!("{prefix}{k}={}", posix_single_quote(v));
+    }
+    Ok(())
+}
+
+/// POSIX-safe single-quote escape: wrap in `'…'`, and replace each
+/// embedded `'` with `'\''` (close-quote, escaped quote, reopen).
+/// Passes through newlines, `$`, backticks, and backslashes literally,
+/// so values round-trip into the shell exactly as sealed.
+fn posix_single_quote(s: &str) -> String {
+    let mut out = String::with_capacity(s.len() + 2);
+    out.push('\'');
+    for ch in s.chars() {
+        if ch == '\'' {
+            out.push_str("'\\''");
+        } else {
+            out.push(ch);
+        }
+    }
+    out.push('\'');
+    out
 }
 
 #[allow(clippy::too_many_lines, clippy::items_after_statements)]


### PR DESCRIPTION
## Summary

- New `yoink secrets env` subcommand: decrypts the sealed bundle and prints `export KEY='value'` lines for `source <(yoink secrets env)` (or `eval "$(yoink secrets env)"`). The missing piece for running services locally against the same secrets prod uses, without copying values into a `.env` file by hand.
- Values are POSIX single-quote-escaped so `$`, backticks, backslashes, and newlines round-trip literally — a value containing `$HOME` won't get re-expanded by the shell.
- `--no-export` drops the prefix for tools that consume dotenv-style files (`docker run --env-file`).
- Same CI guard as `secrets show --reveal`: refuses when `$CI` / `$GITHUB_ACTIONS` / etc. are set unless `YOINK_ALLOW_REVEAL_IN_CI=1`.
- Docs: new "Loading into a local dev shell" section in the sealed-secrets how-to + a reference entry in `cli.md`.

## Test plan

- [x] `cargo build -p yoink --release` clean
- [x] `cargo test -p yoink` — 466 passed (5 suites)
- [x] No new clippy lints introduced
- [x] Round-trip 9-key bundle through `seal` → `env` → `source` → variables match `secrets show --reveal` byte-for-byte
- [x] Tricky values verified: `$5.00` not expanded, backticks not executed, embedded `'` escaped via `'\''`, multi-line preserved, empty value, `key=val=more`, backslashes literal
- [x] `--no-export` emits bare `KEY='value'` lines
- [x] CI guard: `CI=1` and `GITHUB_ACTIONS=true` both refuse with the matching env-var name in the error
- [x] `YOINK_ALLOW_REVEAL_IN_CI=1` override proceeds
- [x] Missing-identity / wrong-identity error paths are clean
- [x] `pnpm build` for docs: 144 pages prerendered, new content present in rendered HTML