### PR TITLE
feat(audit): on-host JSONL audit log + `yoink audit` CLI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5232,6 +5232,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "tui-term",
+ "uuid",
  "vt100",
  "yaml_serde",
  "zeroize",

--- a/docs/content/docs/how-to/audit-log.mdx
+++ b/docs/content/docs/how-to/audit-log.mdx
@@ -1,9 +1,14 @@
 ---
-title: Read the on-host audit log
-description: Stream `/var/lib/yoink/audit/events.jsonl` across the fleet to see every state-changing op yoink performed, including deploys whose containers no longer exist.
+title: Read the audit log
+description: Merge the operator-side and on-host JSONL logs to see every state-changing op yoink performed, including deploys whose containers no longer exist.
 ---
 
-`yoink history` reads container labels — once a container is `docker rm`'d, that line is gone. The audit log is yoink's durable record: every state-changing run (`up`, `rollback`, `prune`, `secrets rotate`) appends JSONL events to `/var/lib/yoink/audit/events.jsonl` on each managed host. Failed deploys whose containers got swept stay on record; lock contention is observable; secret rotations leave a timestamp.
+`yoink history` reads container labels — once a container is `docker rm`'d, that line is gone. The audit log is yoink's durable record. Two files, one merged read path:
+
+- **Operator side** (`$XDG_STATE_HOME/yoink/audit/events.jsonl`, defaults to `~/.local/state/yoink/audit/`) — fleet-wide events: `RunStarted`, `RunFinished`, validation/build failures that never reach a host.
+- **Host side** (`/var/lib/yoink/audit/events.jsonl` on each managed host) — per-host events: `LockAcquired`, `LockReleased`, `ContainerStarted`, `ContainerCreated`, `DeployFailed`, …
+
+Each line carries an `event_id` (`UUIDv7`) so the merge view dedupes safely, and an `origin` field (`"operator"` or `"host"`) so a glance at the table shows where each line came from.
 
 ## Read everything from the last week
 
@@ -11,18 +16,27 @@ description: Stream `/var/lib/yoink/audit/events.jsonl` across the fleet to see 
 yoink audit log
 ```
 
-Default window is `7d`, default limit is 100 rows, sorted newest-first. The output looks like:
+Default window is `7d`, default limit is 100 rows, sorted newest-first. The output:
 
 ```text
-ts                        host                    deploy_id                 event                         details
-2026-05-01T15:42:01.317Z  cax11.example.com       0190f0c7-c5b1-7c98-…      RunFinished                   up ok
-2026-05-01T15:42:01.299Z  cax11.example.com       0190f0c7-c5b1-7c98-…      LockReleased
-2026-05-01T15:41:58.612Z  cax11.example.com       0190f0c7-c5b1-7c98-…      ContainerCreated              docs docs-3fdc075b tag=sha-3fdc075
-2026-05-01T15:41:42.005Z  cax11.example.com       0190f0c7-c5b1-7c98-…      LockAcquired
-2026-05-01T15:41:42.005Z  cax11.example.com       0190f0c7-c5b1-7c98-…      RunStarted                    up services=[docs]
+ts                        origin    host                    deploy_id                 event                         details
+2026-05-01T15:42:01.317Z  operator  —                       0190f0c7-c5b1-7c98-…      RunFinished                   up ok
+2026-05-01T15:42:01.299Z  host      cax11.example.com       0190f0c7-c5b1-7c98-…      LockReleased
+2026-05-01T15:41:58.612Z  host      cax11.example.com       0190f0c7-c5b1-7c98-…      ContainerCreated              docs docs-3fdc075b tag=sha-3fdc075
+2026-05-01T15:41:42.005Z  host      cax11.example.com       0190f0c7-c5b1-7c98-…      LockAcquired
+2026-05-01T15:41:42.005Z  operator  —                       0190f0c7-c5b1-7c98-…      RunStarted                    up services=[docs]
 ```
 
 `deploy_id` is a `UUIDv7` — one per `yoink up` invocation. Lexicographic sort orders runs by start time.
+
+## Filter by side
+
+```sh
+yoink audit log --origin operator   # only the local file
+yoink audit log --origin host       # only the on-host SSH fetches
+```
+
+Use `--origin host` together with `--host <ADDR>` to focus on one host's local view of a deploy.
 
 ## Reconstruct one run
 
@@ -54,7 +68,7 @@ yoink audit log --event DeployFailed --since 30d
 
 ## Retention and rotation
 
-The active `events.jsonl` rotates when it exceeds 5 MiB — the file is renamed to `events-<UTC-timestamp>.jsonl` and a fresh one starts. `yoink audit log` reads both the active and rotated files when `--since` reaches further back than 24 hours.
+Both the operator-side and per-host active files rotate at 5 MiB — renamed to `events-<UTC-timestamp>.jsonl` while a fresh one starts. `yoink audit log` reads both the active and rotated files when `--since` reaches further back than 24 hours.
 
 To prune rotated files past a retention window:
 

--- a/docs/content/docs/how-to/audit-log.mdx
+++ b/docs/content/docs/how-to/audit-log.mdx
@@ -1,0 +1,94 @@
+---
+title: Read the on-host audit log
+description: Stream `/var/lib/yoink/audit/events.jsonl` across the fleet to see every state-changing op yoink performed, including deploys whose containers no longer exist.
+---
+
+`yoink history` reads container labels — once a container is `docker rm`'d, that line is gone. The audit log is yoink's durable record: every state-changing run (`up`, `rollback`, `prune`, `secrets rotate`) appends JSONL events to `/var/lib/yoink/audit/events.jsonl` on each managed host. Failed deploys whose containers got swept stay on record; lock contention is observable; secret rotations leave a timestamp.
+
+## Read everything from the last week
+
+```sh
+yoink audit log
+```
+
+Default window is `7d`, default limit is 100 rows, sorted newest-first. The output looks like:
+
+```text
+ts                        host                    deploy_id                 event                         details
+2026-05-01T15:42:01.317Z  cax11.example.com       0190f0c7-c5b1-7c98-…      RunFinished                   up ok
+2026-05-01T15:42:01.299Z  cax11.example.com       0190f0c7-c5b1-7c98-…      LockReleased
+2026-05-01T15:41:58.612Z  cax11.example.com       0190f0c7-c5b1-7c98-…      ContainerCreated              docs docs-3fdc075b tag=sha-3fdc075
+2026-05-01T15:41:42.005Z  cax11.example.com       0190f0c7-c5b1-7c98-…      LockAcquired
+2026-05-01T15:41:42.005Z  cax11.example.com       0190f0c7-c5b1-7c98-…      RunStarted                    up services=[docs]
+```
+
+`deploy_id` is a `UUIDv7` — one per `yoink up` invocation. Lexicographic sort orders runs by start time.
+
+## Reconstruct one run
+
+```sh
+yoink audit log --deploy-id 0190f0c7-c5b1-7c98-aa92-1d77b8e91f10
+# or, since the prefix is unique:
+yoink audit run 0190f0c7
+```
+
+Returns every event tagged with that run, across every host, ordered by timestamp. Use it after a deploy to confirm what actually happened, or when triaging a failure.
+
+## Filter by host, service, or event type
+
+```sh
+yoink audit log --host docs.example.com
+yoink audit log --service api --event ContainerCreated --event DeployFailed
+yoink audit log --since 30m --format json | jq 'select(.event == "DeployFailed")'
+```
+
+`--format json` emits one event per line (raw JSONL — no pretty-printing) so it pipes cleanly into `jq`, `vector`, or whatever else.
+
+## Find failed deploys
+
+```sh
+yoink audit log --event DeployFailed --since 30d
+```
+
+`DeployFailed` events carry the failed container's last log lines under `log_tail`, captured at the moment yoink gave up. The container is usually long gone from `docker ps`; the audit log is the only thing that still has the diagnosis.
+
+## Retention and rotation
+
+The active `events.jsonl` rotates when it exceeds 5 MiB — the file is renamed to `events-<UTC-timestamp>.jsonl` and a fresh one starts. `yoink audit log` reads both the active and rotated files when `--since` reaches further back than 24 hours.
+
+To prune rotated files past a retention window:
+
+```sh
+yoink audit gc --keep 90d           # default retention
+yoink audit gc --keep 30d --dry-run # preview before deleting
+yoink audit gc --keep 30d --host docs.example.com
+```
+
+The active file is never touched. Schedule `yoink audit gc` from cron / a deploy hook if you have a strict retention requirement.
+
+## What's recorded vs. not
+
+Recorded (every state-changing op):
+
+- `RunStarted` / `RunFinished` envelope on every `yoink up`, `rollback`, `prune`, `secrets rotate`.
+- `LockAcquired` / `LockReleased` per host — the gap between them is your hold time.
+- `ContainerCreated` / `ContainerRemoved` per replica — the forensic record of swaps.
+- `DeployFailed` with `log_tail` when a healthcheck never passes.
+- `HookFinished` with the exit code.
+- Progress events (`PullStarted`, `NetworkReady`, `HealthcheckHealthy`, …) for richer triage.
+
+Not recorded:
+
+- Read commands (`status`, `history`, `doctor`, `diff`, `tui`, `audit log` itself, `secrets show`, `secrets env`). They emit nothing — your `audit log` invocation does not show up in its own output.
+- Operator identity beyond `$USER@$HOSTNAME`. There's no central identity provider; the field is informational only.
+- Secret values. Event payloads carry names (`SecretsRotated.new_recipient`), never values.
+
+## Schema
+
+See [Audit event schema](/docs/reference/audit-event-schema) for the per-variant fields and JSON shape. The schema is versioned via the per-event `v` field; older readers can refuse newer lines instead of misreading them.
+
+## See also
+
+- [Audit event schema](/docs/reference/audit-event-schema) — every event variant and its payload.
+- [CLI reference: `yoink audit`](/docs/reference/cli) — every flag.
+- [Sealed secrets workflow](/docs/how-to/sealed-secrets-workflow) — `secrets rotate` shows up in the audit log too.

--- a/docs/content/docs/how-to/audit-log.mdx
+++ b/docs/content/docs/how-to/audit-log.mdx
@@ -97,6 +97,18 @@ Not recorded:
 - Operator identity beyond `$USER@$HOSTNAME`. There's no central identity provider; the field is informational only.
 - Secret values. Event payloads carry names (`SecretsRotated.new_recipient`), never values.
 
+## In the TUI
+
+`yoink tui` opens to the dashboard; press `a` (or `7`) to open the **Audit** pane. Same merged-and-deduped view, plus:
+
+- `↑↓` / `j` `k` — select row
+- `Enter` — toggle a detail panel below the table (full `event_id`, `deploy_id`, actor + git SHA, and the failed-deploy `log_tail` when applicable)
+- `/` — substring filter across host, event name, summary, `deploy_id`, and actor; `Enter` commits, `Esc` cancels editing
+- `r` — re-fetch (parallel SSH per host plus one local read for the operator log)
+- `Esc` — clears the active filter on first press, returns to Dashboard on second
+
+`yoink tui --mode audit` jumps straight there.
+
 ## Schema
 
 See [Audit event schema](/docs/reference/audit-event-schema) for the per-variant fields and JSON shape. The schema is versioned via the per-event `v` field; older readers can refuse newer lines instead of misreading them.

--- a/docs/content/docs/how-to/meta.json
+++ b/docs/content/docs/how-to/meta.json
@@ -24,6 +24,8 @@
     "---Storage & Backup---",
     "volume-backups",
     "multi-host-redis-storage",
+    "---Operations---",
+    "audit-log",
     "---Developer Tooling---",
     "vscode"
   ]

--- a/docs/content/docs/reference/audit-event-schema.md
+++ b/docs/content/docs/reference/audit-event-schema.md
@@ -10,12 +10,14 @@ Every line in the on-host audit log is a single JSON object. Top-level fields ar
 | field | type | notes |
 |---|---|---|
 | `v` | int | Schema version. Currently `1`. Bumped on backward-incompatible changes; older readers can refuse newer lines. |
+| `event_id` | string | `UUIDv7` per individual line. The merge view dedupes on this; the TUI uses it as a stable row identifier. |
+| `origin` | string | `"operator"` (line written to `$XDG_STATE_HOME/yoink/audit/events.jsonl` on the operator's machine) or `"host"` (line written to `/var/lib/yoink/audit/events.jsonl` on the managed host). |
 | `ts` | string | RFC 3339 wall-clock with millisecond precision (`2026-05-01T15:42:01.317Z`). |
 | `deploy_id` | string | `UUIDv7` — one per `yoink up` / `rollback` / `prune` / `secrets rotate` run. Lexicographic sort orders by start time. |
 | `actor` | string | `$USER@$HOSTNAME` of the operator. `?@?` when not resolvable. |
 | `yoink_version` | string | Operator's yoink version. |
 | `git_sha` | string \| null | Short git SHA of the operator's working tree at the time of the run. `null` when not a git repo or `--allow-dirty` was set. |
-| `host` | string | The host the event applies to. Empty for envelope events that aren't host-specific (rare). |
+| `host` | string | The host the event applies to. Empty for `origin: "operator"` events that aren't host-specific (e.g. a `RunStarted` that fans out to multiple hosts). |
 | `event` | string | Discriminator — picks the variant below. |
 
 ## Envelope events
@@ -172,9 +174,15 @@ The flush policy is per-variant. **Forensic** events bypass the per-host buffer 
 
 ## Storage
 
-- **Active file**: `/var/lib/yoink/audit/events.jsonl`. Permissions `0640`, owned by the SSH deploy user.
-- **Rotation**: when the active file exceeds 5 MiB, atomically renamed to `events-<UTC-timestamp>.jsonl`; a fresh active file starts.
-- **Retention**: yoink does not enforce one. Run `yoink audit gc --keep <DURATION>` from cron to prune.
+Two files; same line shape, different paths:
+
+| origin | path | who writes |
+|---|---|---|
+| `operator` | `$XDG_STATE_HOME/yoink/audit/events.jsonl` (defaults to `~/.local/state/yoink/audit/`) | the operator's `yoink` process — local file write |
+| `host` | `/var/lib/yoink/audit/events.jsonl` on each managed host | operator over SSH (`tee -a`); permissions `0640`, owned by the SSH deploy user |
+
+- **Rotation**: each active file rotates at 5 MiB into `events-<UTC-timestamp>.jsonl`; a fresh active file starts.
+- **Retention**: yoink does not enforce one. Run `yoink audit gc --keep <DURATION>` from cron to prune (host-side only currently; operator-side rotated files accumulate until you delete them manually).
 
 ## See also
 

--- a/docs/content/docs/reference/audit-event-schema.md
+++ b/docs/content/docs/reference/audit-event-schema.md
@@ -1,0 +1,183 @@
+---
+title: Audit event schema
+description: Per-variant JSON fields for events in `/var/lib/yoink/audit/events.jsonl`.
+---
+
+Every line in the on-host audit log is a single JSON object. Top-level fields are constant; the `event` discriminator selects which variant fields are present. See [Read the on-host audit log](/docs/how-to/audit-log) for the operator-facing reading flow.
+
+## Envelope (every event)
+
+| field | type | notes |
+|---|---|---|
+| `v` | int | Schema version. Currently `1`. Bumped on backward-incompatible changes; older readers can refuse newer lines. |
+| `ts` | string | RFC 3339 wall-clock with millisecond precision (`2026-05-01T15:42:01.317Z`). |
+| `deploy_id` | string | `UUIDv7` — one per `yoink up` / `rollback` / `prune` / `secrets rotate` run. Lexicographic sort orders by start time. |
+| `actor` | string | `$USER@$HOSTNAME` of the operator. `?@?` when not resolvable. |
+| `yoink_version` | string | Operator's yoink version. |
+| `git_sha` | string \| null | Short git SHA of the operator's working tree at the time of the run. `null` when not a git repo or `--allow-dirty` was set. |
+| `host` | string | The host the event applies to. Empty for envelope events that aren't host-specific (rare). |
+| `event` | string | Discriminator — picks the variant below. |
+
+## Envelope events
+
+### `RunStarted`
+
+| field | type | notes |
+|---|---|---|
+| `command` | string | `up`, `rollback`, `prune`, `secrets rotate`. |
+| `services` | array&lt;string&gt; | Selected service names; empty when the run targets the full config. |
+
+### `RunFinished`
+
+| field | type | notes |
+|---|---|---|
+| `command` | string | Same as `RunStarted.command`. |
+| `ok` | bool | `true` on clean reconcile; `false` if any host or service failed. |
+| `error` | string \| null | First operator-facing error string when `ok=false`. |
+
+### `LockAcquired`, `LockReleased`
+
+No additional fields. The gap between paired events is the deploy-lock hold time on that host.
+
+## Per-service / per-container events
+
+### `HookStarted`, `HookFinished`
+
+| field | type |
+|---|---|
+| `name` | string |
+
+`HookFinished` is forensic — it lands per-event so a triage tail of the audit log shows hooks even on aborted runs.
+
+### `PullStarted`, `PullFinished`
+
+| field | type |
+|---|---|
+| `image` | string |
+| `tag` | string |
+
+### `NetworkReady`
+
+| field | type | notes |
+|---|---|---|
+| `network` | string | Docker network name. |
+| `created` | bool | `true` if yoink created it on this run; `false` if it already existed. |
+
+### `ContainerStarted`
+
+| field | type |
+|---|---|
+| `service` | string |
+| `container` | string |
+| `spec_hash` | string |
+| `tag` | string |
+
+Progress event — fired when the new replica's container is created and started, before the healthcheck. The forensic counterpart is `ContainerCreated`.
+
+### `HealthcheckHealthy`
+
+| field | type | notes |
+|---|---|---|
+| `service` | string |  |
+| `container` | string |  |
+| `attempts` | int | Polls before passing. |
+
+### `ContainerCreated`
+
+Forensic event: the new replica passed its healthcheck and was promoted into routing. This is the "we did the deploy" event.
+
+| field | type |
+|---|---|
+| `service` | string |
+| `container` | string |
+| `spec_hash` | string |
+| `tag` | string |
+
+### `AlreadyAtSpec`
+
+| field | type |
+|---|---|
+| `service` | string |
+| `container` | string |
+| `spec_hash` | string |
+
+Fired when every replica was already at the desired spec — no work done.
+
+### `OldContainerStopped`, `ContainerRemoved`
+
+| field | type |
+|---|---|
+| `service` | string |
+| `container` | string |
+
+`OldContainerStopped` is progress (best-effort flush). `ContainerRemoved` is forensic.
+
+### `DeployFailed`
+
+Forensic. Fired when the new replica never passed its healthcheck and yoink rolled back.
+
+| field | type | notes |
+|---|---|---|
+| `service` | string |  |
+| `container` | string |  |
+| `log_tail` | array&lt;string&gt; | The last few stdout/stderr lines from the failed container, captured before yoink removed it. |
+
+### `RollbackStarted`, `RollbackFinished`
+
+| field | type | notes |
+|---|---|---|
+| `service` | string |  |
+| `target_tag` (Started) | string | The tag yoink is restoring to. |
+| `ok` (Finished) | bool |  |
+| `error` (Finished) | string \| null |  |
+
+### `ContainerPruned`
+
+Fired by `yoink prune` for every removed container.
+
+| field | type | notes |
+|---|---|---|
+| `service` | string \| null | `null` when the container had no `yoink.service` label. |
+| `container` | string |  |
+
+### `SecretsRotated`
+
+| field | type | notes |
+|---|---|---|
+| `new_recipient` | string | The new `age1…` public key. The old recipient is in the prior `secrets:` block — diff git history to see it. |
+
+### `FileUploaded`
+
+| field | type | notes |
+|---|---|---|
+| `service` | string | Service that owns the mount. |
+| `sha256` | string | Content hash — same as the path under `/var/lib/yoink/files/`. |
+| `remote_path` | string | Absolute path on the host. |
+
+## Forensic vs. progress
+
+The flush policy is per-variant. **Forensic** events bypass the per-host buffer and SSH-flush immediately, so a `kill -9` mid-deploy still lands them on disk. **Progress** events buffer and flush at end of run.
+
+| Forensic | Progress |
+|---|---|
+| `RunStarted`, `RunFinished` | `HookStarted` |
+| `LockAcquired`, `LockReleased` | `PullStarted`, `PullFinished` |
+| `HookFinished` | `NetworkReady` |
+| `ContainerCreated`, `ContainerRemoved` | `ContainerStarted` |
+| `DeployFailed` | `HealthcheckHealthy` |
+| `RollbackStarted`, `RollbackFinished` | `OldContainerStopped` |
+| `ContainerPruned` | `AlreadyAtSpec` |
+| `SecretsRotated` |  |
+| `FileUploaded` |  |
+
+## Storage
+
+- **Active file**: `/var/lib/yoink/audit/events.jsonl`. Permissions `0640`, owned by the SSH deploy user.
+- **Rotation**: when the active file exceeds 5 MiB, atomically renamed to `events-<UTC-timestamp>.jsonl`; a fresh active file starts.
+- **Retention**: yoink does not enforce one. Run `yoink audit gc --keep <DURATION>` from cron to prune.
+
+## See also
+
+- [Read the on-host audit log](/docs/how-to/audit-log) — operator-facing how-to.
+- [CLI reference: `yoink audit`](/docs/reference/cli) — every flag.
+- [Architecture: drift detection](/docs/guide/architecture#drift-detection) — `spec_hash` is the same one that appears in `ContainerCreated.spec_hash`.

--- a/docs/content/docs/reference/cli.md
+++ b/docs/content/docs/reference/cli.md
@@ -113,13 +113,15 @@ yoink rollback <SERVICE>                 redeploy the previous spec_hash
 yoink history <SERVICE>                  list past deploys (when, version, state, deployed-by)
   --limit <N>                            cap the row count
 
-yoink audit log                          stream the on-host JSONL audit log across the fleet
-                                         (every state-changing op yoink performed on each host;
-                                         survives `docker rm`)
-  --host <ADDR>                          restrict to one host
+yoink audit log                          merge operator-side log
+                                         ($XDG_STATE_HOME/yoink/audit/events.jsonl) with each
+                                         host's /var/lib/yoink/audit/events.jsonl, dedupe on
+                                         `event_id`, sort newest-first
+  --host <ADDR>                          restrict the host fetch to one host
   --service <NAME>                       restrict to one service
-  --deploy-id <ID>                       only events from this run
+  --deploy-id <ID>                       only events from this run (prefix-match)
   --event <NAME>                         filter by event name (repeatable)
+  --origin operator|host                 only one side of the merge
   --since <DURATION>                     window relative to now (default 7d)
   --limit <N>                            cap the row count (default 100)
   --format text|json                     `json` emits raw JSONL — pipes cleanly into jq

--- a/docs/content/docs/reference/cli.md
+++ b/docs/content/docs/reference/cli.md
@@ -113,6 +113,23 @@ yoink rollback <SERVICE>                 redeploy the previous spec_hash
 yoink history <SERVICE>                  list past deploys (when, version, state, deployed-by)
   --limit <N>                            cap the row count
 
+yoink audit log                          stream the on-host JSONL audit log across the fleet
+                                         (every state-changing op yoink performed on each host;
+                                         survives `docker rm`)
+  --host <ADDR>                          restrict to one host
+  --service <NAME>                       restrict to one service
+  --deploy-id <ID>                       only events from this run
+  --event <NAME>                         filter by event name (repeatable)
+  --since <DURATION>                     window relative to now (default 7d)
+  --limit <N>                            cap the row count (default 100)
+  --format text|json                     `json` emits raw JSONL — pipes cleanly into jq
+yoink audit run <DEPLOY_ID>              every event for one run, ordered, across all hosts.
+                                         Useful for reconstructing what one `yoink up` did.
+yoink audit gc [--keep <DURATION>]       remove rotated audit files older than --keep
+                                         (default 90d). Active events.jsonl is never touched.
+  --host <ADDR>                          restrict to one host
+  --dry-run                              preview what would be removed
+
 yoink prune                              remove yoink-managed containers no longer in config
   --dry-run                              show what would be removed
 

--- a/docs/content/docs/reference/meta.json
+++ b/docs/content/docs/reference/meta.json
@@ -5,6 +5,7 @@
     "cli",
     "config",
     "tui",
+    "audit-event-schema",
     "glossary"
   ]
 }

--- a/docs/content/docs/reference/tui.md
+++ b/docs/content/docs/reference/tui.md
@@ -38,6 +38,7 @@ Heavily inspired by [k9s](https://k9scli.io/) and [lazydocker](https://github.co
 | `l` | Logs |
 | `R` | Resources (Images / Volumes / Networks) |
 | `e` | Encrypted-secrets |
+| `a` | Audit log (merged operator + on-host JSONL) |
 | `Tab` / `Shift-Tab` | cycle modes forward / backward |
 | `?` | toggle help overlay (per-view keybinds) |
 | `q` / `Ctrl-C` | quit |
@@ -198,6 +199,20 @@ The buffer is bounded at 5,000 lines; older lines fall off as new ones arrive. F
 
 Reached via `Enter` from any list view. Same shape as the multiplexed Logs pane, scoped to one container. Same keybindings; `Esc` returns to the parent. `!` and `B` are also bound here for quick "tail logs → drop into shell" pivots.
 
+## Audit pane (`a`)
+
+Merged operator + per-host JSONL audit log: every state-changing run yoink performed (deploy, rollback, prune, secrets rotate). Same data path as `yoink audit log`, with stable selection on `event_id` so a refresh keeps you on the row you were looking at.
+
+| key | action |
+|---|---|
+| `↑↓` / `j` `k` | select row |
+| `Enter` | toggle detail panel (full `event_id`, `deploy_id`, actor, git SHA, log tail for `DeployFailed`) |
+| `/` | begin substring filter — matches host, event name, summary, `deploy_id`, actor |
+| `r` | refresh (parallel SSH per host + local operator log read) |
+| `Esc` | clears active filter on first press, returns to Dashboard on second |
+
+The first column tags each row with `operator` (purple) or `host` (cyan) so you can tell at a glance which side of the merge a line came from.
+
 ## Shell / debug sidecar (`!`, `B`)
 
 Both gestures put you on a PTY inside the host's docker daemon with no SSH on top; yoink uses the Docker exec API and the TUI streams bytes both ways through a terminal-emulator parser.
@@ -245,7 +260,7 @@ yoink tui --mode hosts          # start on a specific top-level pane
 yoink tui --mouse               # enable mouse capture (scroll wheel + selection)
 ```
 
-`--mode` accepts `dashboard` / `hosts` / `services` / `logs` / `resources` / `secrets`. `--mouse` is opt-in because mouse capture disables your terminal's native text-selection; if you don't actively use mouse scroll inside the TUI, leave it off.
+`--mode` accepts `dashboard` / `hosts` / `services` / `logs` / `resources` / `secrets` / `audit`. `--mouse` is opt-in because mouse capture disables your terminal's native text-selection; if you don't actively use mouse scroll inside the TUI, leave it off.
 
 `YOINK_NO_HL=1` in the environment skips the `hl` auto-detection (the logs pane will use raw output even if `hl` is on PATH). Useful when troubleshooting `hl` itself.
 

--- a/yoink/Cargo.toml
+++ b/yoink/Cargo.toml
@@ -55,6 +55,7 @@ tokio-util = { version = "0.7", features = ["io"] }
 yaml_serde = "0.10"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", default-features = false, features = ["fmt", "env-filter"] }
+uuid = { version = "1", features = ["v7"] }
 
 [dev-dependencies]
 insta = { version = "1", features = ["yaml"] }

--- a/yoink/src/audit.rs
+++ b/yoink/src/audit.rs
@@ -73,14 +73,27 @@ pub enum AuditEventKind {
     LockAcquired,
     LockReleased,
     /// A pre-/post-deploy hook started running. Best-effort.
-    HookStarted { name: String },
+    HookStarted {
+        name: String,
+    },
     /// Hook finished. Forensic — the exit code matters for triage.
-    HookFinished { name: String },
+    HookFinished {
+        name: String,
+    },
     /// Image pull began on this host. Best-effort progress event.
-    PullStarted { image: String, tag: String },
-    PullFinished { image: String, tag: String },
+    PullStarted {
+        image: String,
+        tag: String,
+    },
+    PullFinished {
+        image: String,
+        tag: String,
+    },
     /// Docker network ensured (created if missing). Progress event.
-    NetworkReady { network: String, created: bool },
+    NetworkReady {
+        network: String,
+        created: bool,
+    },
     /// New container started. Progress (the forensic
     /// "this is the container we'll keep" event is `ContainerCreated`,
     /// emitted after the healthcheck passes).
@@ -111,10 +124,16 @@ pub enum AuditEventKind {
         spec_hash: String,
     },
     /// Old replica stopped after a successful swap. Progress.
-    OldContainerStopped { service: String, container: String },
+    OldContainerStopped {
+        service: String,
+        container: String,
+    },
     /// Old replica removed. Forensic — pairs with `ContainerCreated` to
     /// reconstruct a swap.
-    ContainerRemoved { service: String, container: String },
+    ContainerRemoved {
+        service: String,
+        container: String,
+    },
     /// Healthcheck never passed; the deploy aborted and this is the
     /// container's last log lines for triage.
     DeployFailed {
@@ -123,7 +142,10 @@ pub enum AuditEventKind {
         log_tail: Vec<String>,
     },
     /// `yoink rollback <SERVICE>` started.
-    RollbackStarted { service: String, target_tag: String },
+    RollbackStarted {
+        service: String,
+        target_tag: String,
+    },
     /// `yoink rollback <SERVICE>` finished.
     RollbackFinished {
         service: String,
@@ -136,7 +158,9 @@ pub enum AuditEventKind {
         container: String,
     },
     /// `yoink secrets rotate` re-sealed against a new recipient.
-    SecretsRotated { new_recipient: String },
+    SecretsRotated {
+        new_recipient: String,
+    },
     /// File uploaded into `/var/lib/yoink/files/` for a service mount.
     FileUploaded {
         service: String,
@@ -279,7 +303,7 @@ pub fn ts_string_for(unix_secs: u64) -> String {
     clippy::cast_possible_truncation,
     clippy::cast_sign_loss,
     clippy::cast_possible_wrap,
-    clippy::many_single_char_names,
+    clippy::many_single_char_names
 )]
 fn unix_to_components(secs: u64) -> (i32, u32, u32, u32, u32, u32) {
     let s = secs % 86_400;
@@ -724,7 +748,11 @@ pub fn map_deploy_event(
             String::new(),
             AuditEventKind::HookFinished { name: name.clone() },
         )),
-        DeployEvent::PullStarted { host, image, tag: t } => Some((
+        DeployEvent::PullStarted {
+            host,
+            image,
+            tag: t,
+        } => Some((
             host.clone(),
             AuditEventKind::PullStarted {
                 image: image.clone(),
@@ -817,8 +845,7 @@ fn short_hash_from_name(container: &str) -> String {
     if parts.is_empty() {
         return String::new();
     }
-    let trailing_is_index =
-        parts[0].chars().all(|c| c.is_ascii_digit()) && !parts[0].is_empty();
+    let trailing_is_index = parts[0].chars().all(|c| c.is_ascii_digit()) && !parts[0].is_empty();
     if trailing_is_index && parts.len() > 1 {
         parts[1].to_string()
     } else {
@@ -913,25 +940,31 @@ mod tests {
     #[test]
     fn forensic_classification_matches_plan() {
         assert!(AuditEventKind::LockAcquired.is_forensic());
-        assert!(AuditEventKind::ContainerCreated {
-            service: "s".into(),
-            container: "c".into(),
-            spec_hash: "h".into(),
-            tag: "t".into(),
-        }
-        .is_forensic());
+        assert!(
+            AuditEventKind::ContainerCreated {
+                service: "s".into(),
+                container: "c".into(),
+                spec_hash: "h".into(),
+                tag: "t".into(),
+            }
+            .is_forensic()
+        );
         assert!(!AuditEventKind::HookStarted { name: "n".into() }.is_forensic());
-        assert!(!AuditEventKind::PullStarted {
-            image: "i".into(),
-            tag: "t".into(),
-        }
-        .is_forensic());
-        assert!(!AuditEventKind::HealthcheckHealthy {
-            service: "s".into(),
-            container: "c".into(),
-            attempts: 1,
-        }
-        .is_forensic());
+        assert!(
+            !AuditEventKind::PullStarted {
+                image: "i".into(),
+                tag: "t".into(),
+            }
+            .is_forensic()
+        );
+        assert!(
+            !AuditEventKind::HealthcheckHealthy {
+                service: "s".into(),
+                container: "c".into(),
+                attempts: 1,
+            }
+            .is_forensic()
+        );
     }
 
     #[tokio::test]

--- a/yoink/src/audit.rs
+++ b/yoink/src/audit.rs
@@ -853,6 +853,311 @@ fn short_hash_from_name(container: &str) -> String {
     }
 }
 
+// ---------------------------------------------------------------------------
+// Read path: same code is shared by the `yoink audit log|run` CLI and the TUI
+// pane. Each caller layers its own filter / format on top of `fetch_events`.
+
+/// Knobs for [`fetch_events`]. Filters that are CLI-only (service,
+/// deploy-id prefix, event-name) live in `cmd_audit_log` rather than
+/// here so the TUI doesn't pay for them.
+#[derive(Debug, Clone)]
+pub struct FetchOptions {
+    /// Restrict the host fetch to one host's address; the operator log
+    /// is still pulled (it's fleet-wide) unless `origin == Some("host")`.
+    pub host_filter: Option<String>,
+    /// Window relative to now, in seconds. Events older than this are
+    /// dropped.
+    pub since_secs: u64,
+    /// Restrict to one origin. `Some("operator")` skips host fetches
+    /// entirely; `Some("host")` skips the operator log.
+    pub origin: Option<String>,
+}
+
+/// Result of a fetch. Errors carry the source label (host address or
+/// `"operator log"`) plus a one-line message.
+#[derive(Debug, Clone, Default)]
+pub struct FetchOutcome {
+    pub events: Vec<AuditEvent>,
+    pub errors: Vec<(String, String)>,
+}
+
+/// Read the operator log + every host's log (subject to filters),
+/// dedupe on `event_id`, drop events older than `since_secs`, sort
+/// newest-first. Per-host fetch failures land in `errors` instead of
+/// aborting the whole call.
+pub async fn fetch_events(hosts: &[Host], opts: &FetchOptions) -> FetchOutcome {
+    let cutoff_unix = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_or(0, |d| d.as_secs())
+        .saturating_sub(opts.since_secs);
+    let want_rotated = opts.since_secs > 24 * 3600;
+    let cutoff_ts = ts_string_for(cutoff_unix);
+
+    let mut events: Vec<AuditEvent> = Vec::new();
+    let mut errors: Vec<(String, String)> = Vec::new();
+
+    let want_operator = opts.origin.as_deref() != Some("host");
+    if want_operator {
+        match read_operator_audit_files(want_rotated).await {
+            Ok(bytes) => collect_jsonl(&mut events, &mut errors, &bytes, "operator log"),
+            Err(e) => errors.push(("operator log".into(), e.to_string())),
+        }
+    }
+
+    let want_host = opts.origin.as_deref() != Some("operator");
+    if want_host {
+        let scoped: Vec<Host> = hosts
+            .iter()
+            .filter(|h| opts.host_filter.as_ref().is_none_or(|f| &h.address == f))
+            .cloned()
+            .collect();
+        let fetches = scoped.iter().map(|h| async move {
+            let host = h.clone();
+            let bytes = fetch_audit_files(&host, want_rotated).await;
+            (host, bytes)
+        });
+        let results = futures_util::future::join_all(fetches).await;
+        for (host, fetch) in results {
+            match fetch {
+                Ok(bytes) => collect_jsonl(&mut events, &mut errors, &bytes, &host.address),
+                Err(e) => errors.push((host.address, e.to_string())),
+            }
+        }
+    }
+
+    let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
+    events.retain(|ev| seen.insert(ev.event_id.clone()) && ev.ts >= cutoff_ts);
+    events.sort_by(|a, b| b.ts.cmp(&a.ts));
+
+    FetchOutcome { events, errors }
+}
+
+/// Read the operator-side audit files. Concatenates the active file
+/// plus (when `include_rotated`) every `events-*.jsonl` in the same
+/// directory. Missing files are silently treated as empty.
+pub async fn read_operator_audit_files(include_rotated: bool) -> std::io::Result<String> {
+    let mut out = String::new();
+    if let Ok(bytes) = tokio::fs::read_to_string(operator_audit_file()).await {
+        out.push_str(&bytes);
+    }
+    if include_rotated {
+        let dir = operator_audit_dir();
+        if let Ok(mut rd) = tokio::fs::read_dir(&dir).await {
+            while let Ok(Some(entry)) = rd.next_entry().await {
+                let name = entry.file_name();
+                let name_str = name.to_string_lossy();
+                if name_str.starts_with("events-")
+                    && name_str.ends_with(".jsonl")
+                    && let Ok(bytes) = tokio::fs::read_to_string(entry.path()).await
+                {
+                    out.push_str(&bytes);
+                }
+            }
+        }
+    }
+    Ok(out)
+}
+
+/// Cat the active host audit file plus rotated files (when requested)
+/// over SSH (or locally for the synthetic `local` host). Returns the
+/// concatenated JSONL bytes; missing files read as empty.
+pub async fn fetch_audit_files(host: &Host, include_rotated: bool) -> anyhow::Result<String> {
+    let script = if include_rotated {
+        format!("cat {AUDIT_FILE} {AUDIT_DIR}/events-*.jsonl 2>/dev/null || true")
+    } else {
+        format!("cat {AUDIT_FILE} 2>/dev/null || true")
+    };
+    run_audit_shell(host, &script).await
+}
+
+/// Run `script` on `host`'s shell. Local synthetic host uses `sh -c`;
+/// remote uses `ssh -o BatchMode=yes user@addr script`. Returns stdout.
+pub async fn run_audit_shell(host: &Host, script: &str) -> anyhow::Result<String> {
+    use anyhow::Context as _;
+    let output = if host.is_local() {
+        tokio::process::Command::new("sh")
+            .arg("-c")
+            .arg(script)
+            .output()
+            .await
+            .context("local sh -c")?
+    } else {
+        tokio::process::Command::new("ssh")
+            .arg("-o")
+            .arg("BatchMode=yes")
+            .arg(format!("{}@{}", host.user, host.address))
+            .arg(script)
+            .output()
+            .await
+            .with_context(|| format!("ssh {}@{}", host.user, host.address))?
+    };
+    if !output.status.success() {
+        let prog = if host.is_local() { "sh" } else { "ssh" };
+        anyhow::bail!(
+            "{prog} exit {:?}: {}",
+            output.status.code(),
+            String::from_utf8_lossy(&output.stderr).trim()
+        );
+    }
+    Ok(String::from_utf8_lossy(&output.stdout).into_owned())
+}
+
+/// Parse a JSONL blob into `events`; malformed lines push a
+/// `(source, message)` row into `errors` instead of aborting. The
+/// source is the host address or `"operator log"`.
+fn collect_jsonl(
+    events: &mut Vec<AuditEvent>,
+    errors: &mut Vec<(String, String)>,
+    bytes: &str,
+    source: &str,
+) {
+    for line in bytes.lines() {
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        match serde_json::from_str::<AuditEvent>(trimmed) {
+            Ok(ev) => events.push(ev),
+            Err(e) => errors.push((source.into(), format!("malformed event: {e}"))),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Display helpers — used by the CLI text format and the TUI pane.
+
+/// Stable `PascalCase` label for the variant. Used for column rendering
+/// and `--event` filter matching.
+#[must_use]
+pub fn event_name(kind: &AuditEventKind) -> &'static str {
+    use AuditEventKind as K;
+    match kind {
+        K::RunStarted { .. } => "RunStarted",
+        K::RunFinished { .. } => "RunFinished",
+        K::LockAcquired => "LockAcquired",
+        K::LockReleased => "LockReleased",
+        K::HookStarted { .. } => "HookStarted",
+        K::HookFinished { .. } => "HookFinished",
+        K::PullStarted { .. } => "PullStarted",
+        K::PullFinished { .. } => "PullFinished",
+        K::NetworkReady { .. } => "NetworkReady",
+        K::ContainerStarted { .. } => "ContainerStarted",
+        K::HealthcheckHealthy { .. } => "HealthcheckHealthy",
+        K::ContainerCreated { .. } => "ContainerCreated",
+        K::AlreadyAtSpec { .. } => "AlreadyAtSpec",
+        K::OldContainerStopped { .. } => "OldContainerStopped",
+        K::ContainerRemoved { .. } => "ContainerRemoved",
+        K::DeployFailed { .. } => "DeployFailed",
+        K::RollbackStarted { .. } => "RollbackStarted",
+        K::RollbackFinished { .. } => "RollbackFinished",
+        K::ContainerPruned { .. } => "ContainerPruned",
+        K::SecretsRotated { .. } => "SecretsRotated",
+        K::FileUploaded { .. } => "FileUploaded",
+    }
+}
+
+/// Service field on event kinds that have one; `None` for envelope
+/// events (`RunStarted`, `LockAcquired`, etc.).
+#[must_use]
+pub fn event_service(ev: &AuditEvent) -> Option<&str> {
+    use AuditEventKind as K;
+    match &ev.kind {
+        K::ContainerStarted { service, .. }
+        | K::ContainerCreated { service, .. }
+        | K::ContainerRemoved { service, .. }
+        | K::AlreadyAtSpec { service, .. }
+        | K::OldContainerStopped { service, .. }
+        | K::DeployFailed { service, .. }
+        | K::RollbackStarted { service, .. }
+        | K::RollbackFinished { service, .. }
+        | K::HealthcheckHealthy { service, .. }
+        | K::FileUploaded { service, .. } => Some(service.as_str()),
+        K::ContainerPruned { service, .. } => service.as_deref(),
+        _ => None,
+    }
+}
+
+/// One-line human summary of the variant payload.
+#[must_use]
+pub fn event_summary(kind: &AuditEventKind) -> String {
+    use AuditEventKind as K;
+    match kind {
+        K::RunStarted { command, services } => {
+            format!("{command} services=[{}]", services.join(","))
+        }
+        K::RunFinished {
+            command, ok, error, ..
+        } => {
+            if *ok {
+                format!("{command} ok")
+            } else {
+                format!("{command} FAILED: {}", error.as_deref().unwrap_or(""))
+            }
+        }
+        K::LockAcquired | K::LockReleased => String::new(),
+        K::HookStarted { name } | K::HookFinished { name } => name.clone(),
+        K::PullStarted { image, tag } | K::PullFinished { image, tag } => {
+            format!("{image}:{tag}")
+        }
+        K::NetworkReady { network, created } => {
+            if *created {
+                format!("{network} (created)")
+            } else {
+                network.clone()
+            }
+        }
+        K::ContainerStarted {
+            service,
+            container,
+            tag,
+            ..
+        }
+        | K::ContainerCreated {
+            service,
+            container,
+            tag,
+            ..
+        } => format!("{service} {container} tag={tag}"),
+        K::AlreadyAtSpec {
+            service,
+            container,
+            spec_hash,
+        } => format!("{service} {container} spec={spec_hash}"),
+        K::HealthcheckHealthy {
+            service,
+            container,
+            attempts,
+        } => format!("{service} {container} after {attempts}"),
+        K::OldContainerStopped { service, container }
+        | K::ContainerRemoved { service, container } => format!("{service} {container}"),
+        K::DeployFailed {
+            service,
+            container,
+            log_tail,
+        } => format!("{service} {container} ({} log lines)", log_tail.len()),
+        K::RollbackStarted {
+            service,
+            target_tag,
+        } => format!("{service} → {target_tag}"),
+        K::RollbackFinished { service, ok, error } => {
+            if *ok {
+                format!("{service} ok")
+            } else {
+                format!("{service} FAILED: {}", error.as_deref().unwrap_or(""))
+            }
+        }
+        K::ContainerPruned { service, container } => {
+            format!("{} {container}", service.as_deref().unwrap_or("?"))
+        }
+        K::SecretsRotated { new_recipient } => format!("→ {new_recipient}"),
+        K::FileUploaded {
+            service,
+            sha256,
+            remote_path,
+        } => format!("{service} {sha256} → {remote_path}"),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/yoink/src/audit.rs
+++ b/yoink/src/audit.rs
@@ -1,0 +1,842 @@
+//! On-host audit log. Each yoink-managed host gets an append-only
+//! JSONL file at `/var/lib/yoink/audit/events.jsonl` recording every
+//! state-changing operation yoink performs there. Surfaced via
+//! `yoink audit log|run|gc`.
+//!
+//! ## Why on-host, not a central store
+//!
+//! Yoink's bet is "no daemon, no DB". Pushing audit events to a remote
+//! aggregator at deploy time would tie operators to a piece of infra
+//! they don't otherwise need. Writing to the host filesystem follows
+//! the same shape as `/var/lib/yoink/files/` and survives the operator
+//! disconnecting mid-deploy.
+//!
+//! ## Hybrid flush policy
+//!
+//! - **Per-event flush** for forensic events (`RunStarted`/`RunFinished`,
+//!   `ContainerCreated`/`ContainerRemoved`, `Rollback*`, `SecretsRotated`,
+//!   `HookFinished`, `LockAcquired`/`LockReleased`, `FileUploaded`). One
+//!   SSH `tee -a` per event; tolerates partial runs.
+//! - **Batched flush** for progress events (`PullStarted`/`PullFinished`,
+//!   `NetworkReady`, `HealthcheckHealthy`, `HookStarted`,
+//!   `OldContainerStopped`, `ContainerStarted`, `AlreadyAtSpec`).
+//!   Buffered in a per-host ring, flushed at end-of-run (and
+//!   explicitly on `flush()`).
+//!
+//! Audit-write failures never block deploys — they warn to stderr and
+//! continue. Forensic events that fail are logged loudly so the
+//! operator notices; progress events fail in stderr noise.
+
+use std::sync::Arc;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+use tokio::process::Command;
+use tokio::sync::Mutex;
+
+use crate::docker_ops::Host;
+
+/// Where we keep the audit log on each host. Same parent directory as
+/// `/var/lib/yoink/files/` so all yoink host-side state sits in one
+/// predictable place.
+pub const AUDIT_DIR: &str = "/var/lib/yoink/audit";
+pub const AUDIT_FILE: &str = "/var/lib/yoink/audit/events.jsonl";
+/// Active file size at which a flush triggers a rotation. 5 MiB ≈
+/// thousands of events; a busy host's audit file rotates every few
+/// weeks at most.
+pub const ROTATE_BYTES: u64 = 5 * 1024 * 1024;
+
+/// Audit-event payload variants. Discriminated on the `event` JSON
+/// field; serde tag = "event" keeps the wire shape flat: every field
+/// at the top level, no nested `payload: { ... }`. This matches what
+/// JSONL consumers (jq, awk, vector) expect.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "event", rename_all = "PascalCase")]
+pub enum AuditEventKind {
+    /// Envelope: a `yoink up` / rollback / prune / secrets-rotate run
+    /// has begun. One per command invocation, before any host work.
+    RunStarted {
+        command: String,
+        services: Vec<String>,
+    },
+    /// Envelope: same run finished. `ok: false` carries the operator-
+    /// visible error message so a tail of the audit log shows why a
+    /// deploy died without grepping terminal scrollback.
+    RunFinished {
+        command: String,
+        ok: bool,
+        error: Option<String>,
+    },
+    /// Lock sentinel created on this host. `LockReleased` always pairs
+    /// with this — the gap between them is the deploy-lock hold time.
+    LockAcquired,
+    LockReleased,
+    /// A pre-/post-deploy hook started running. Best-effort.
+    HookStarted { name: String },
+    /// Hook finished. Forensic — the exit code matters for triage.
+    HookFinished { name: String },
+    /// Image pull began on this host. Best-effort progress event.
+    PullStarted { image: String, tag: String },
+    PullFinished { image: String, tag: String },
+    /// Docker network ensured (created if missing). Progress event.
+    NetworkReady { network: String, created: bool },
+    /// New container started. Progress (the forensic
+    /// "this is the container we'll keep" event is `ContainerCreated`,
+    /// emitted after the healthcheck passes).
+    ContainerStarted {
+        service: String,
+        container: String,
+        spec_hash: String,
+        tag: String,
+    },
+    HealthcheckHealthy {
+        service: String,
+        container: String,
+        attempts: u32,
+    },
+    /// New container at the target spec passed its healthcheck and was
+    /// promoted into routing — this is the "we did the deploy" event.
+    ContainerCreated {
+        service: String,
+        container: String,
+        spec_hash: String,
+        tag: String,
+    },
+    /// Service was already at the desired spec — no work done. The
+    /// operator can use this to verify a redeploy was a no-op.
+    AlreadyAtSpec {
+        service: String,
+        container: String,
+        spec_hash: String,
+    },
+    /// Old replica stopped after a successful swap. Progress.
+    OldContainerStopped { service: String, container: String },
+    /// Old replica removed. Forensic — pairs with `ContainerCreated` to
+    /// reconstruct a swap.
+    ContainerRemoved { service: String, container: String },
+    /// Healthcheck never passed; the deploy aborted and this is the
+    /// container's last log lines for triage.
+    DeployFailed {
+        service: String,
+        container: String,
+        log_tail: Vec<String>,
+    },
+    /// `yoink rollback <SERVICE>` started.
+    RollbackStarted { service: String, target_tag: String },
+    /// `yoink rollback <SERVICE>` finished.
+    RollbackFinished {
+        service: String,
+        ok: bool,
+        error: Option<String>,
+    },
+    /// `yoink prune` removed an orphaned container.
+    ContainerPruned {
+        service: Option<String>,
+        container: String,
+    },
+    /// `yoink secrets rotate` re-sealed against a new recipient.
+    SecretsRotated { new_recipient: String },
+    /// File uploaded into `/var/lib/yoink/files/` for a service mount.
+    FileUploaded {
+        service: String,
+        sha256: String,
+        remote_path: String,
+    },
+}
+
+impl AuditEventKind {
+    /// Forensic events bypass the ring buffer and SSH-flush
+    /// immediately. Progress events buffer up and flush in batches.
+    #[must_use]
+    pub const fn is_forensic(&self) -> bool {
+        matches!(
+            self,
+            AuditEventKind::RunStarted { .. }
+                | AuditEventKind::RunFinished { .. }
+                | AuditEventKind::LockAcquired
+                | AuditEventKind::LockReleased
+                | AuditEventKind::HookFinished { .. }
+                | AuditEventKind::ContainerCreated { .. }
+                | AuditEventKind::ContainerRemoved { .. }
+                | AuditEventKind::DeployFailed { .. }
+                | AuditEventKind::RollbackStarted { .. }
+                | AuditEventKind::RollbackFinished { .. }
+                | AuditEventKind::ContainerPruned { .. }
+                | AuditEventKind::SecretsRotated { .. }
+                | AuditEventKind::FileUploaded { .. }
+        )
+    }
+}
+
+/// One line in the JSONL log. The envelope (timestamp, `deploy_id`,
+/// actor, version) is held flat alongside the variant fields so a
+/// `jq '.deploy_id' < events.jsonl` works for every event.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AuditEvent {
+    /// Schema version. Bumped on backward-incompatible changes; older
+    /// readers can refuse newer lines instead of misreading them.
+    pub v: u32,
+    /// RFC 3339 wall-clock timestamp with millisecond precision.
+    pub ts: String,
+    /// One per `yoink up` / rollback / prune / secrets-rotate run.
+    /// `UUIDv7` — time-sortable, so a lexicographic sort on this column
+    /// orders events by run.
+    pub deploy_id: String,
+    /// `$USER@$HOSTNAME` of the operator (or `?@?` when unset, e.g. in
+    /// stripped-down CI containers).
+    pub actor: String,
+    pub yoink_version: String,
+    /// Short git SHA of the operator's working tree, if known.
+    pub git_sha: Option<String>,
+    /// Resolves to one of the hosts in `yoink.yaml`.
+    pub host: String,
+    #[serde(flatten)]
+    pub kind: AuditEventKind,
+}
+
+/// Per-run envelope passed into every event built by the sink. Carries
+/// the fields that don't change between events (`deploy_id`, actor,
+/// version, `git_sha`, command name).
+#[derive(Debug, Clone)]
+pub struct RunContext {
+    pub deploy_id: String,
+    pub actor: String,
+    pub yoink_version: String,
+    pub git_sha: Option<String>,
+    pub command: String,
+}
+
+impl RunContext {
+    /// Build a run context with a fresh `UUIDv7` `deploy_id`, the current
+    /// operator, the running yoink version, and the short git SHA of
+    /// `cwd` if any.
+    pub fn new(command: impl Into<String>) -> Self {
+        let user = std::env::var("USER")
+            .or_else(|_| std::env::var("LOGNAME"))
+            .unwrap_or_else(|_| "?".into());
+        let host = std::env::var("HOSTNAME")
+            .ok()
+            .or_else(|| hostname_via_uname().ok().filter(|s| !s.is_empty()))
+            .unwrap_or_else(|| "?".into());
+        let actor = format!("{user}@{host}");
+        let git_sha = crate::git::current_short_sha(std::path::Path::new(".")).ok();
+        Self {
+            deploy_id: uuid::Uuid::now_v7().to_string(),
+            actor,
+            yoink_version: env!("CARGO_PKG_VERSION").to_string(),
+            git_sha,
+            command: command.into(),
+        }
+    }
+}
+
+fn hostname_via_uname() -> std::io::Result<String> {
+    // No portable std API; fall back to `uname -n` which exists on
+    // every POSIX system we deploy from.
+    let out = std::process::Command::new("uname").arg("-n").output()?;
+    Ok(String::from_utf8_lossy(&out.stdout).trim().to_string())
+}
+
+/// RFC 3339 timestamp with millisecond precision. We hand-format
+/// instead of pulling in `chrono` because nothing else needs it.
+#[must_use]
+pub fn now_rfc3339_millis() -> String {
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default();
+    let secs = now.as_secs();
+    let millis = now.subsec_millis();
+    let (y, mo, d, h, mi, s) = unix_to_components(secs);
+    format!("{y:04}-{mo:02}-{d:02}T{h:02}:{mi:02}:{s:02}.{millis:03}Z")
+}
+
+/// RFC 3339 timestamp from a Unix-seconds value (no millisecond
+/// component). Used by callers that want to compare an event's `ts`
+/// string against a `since` cutoff lexicographically.
+#[must_use]
+pub fn ts_string_for(unix_secs: u64) -> String {
+    let (y, mo, d, h, mi, s) = unix_to_components(unix_secs);
+    format!("{y:04}-{mo:02}-{d:02}T{h:02}:{mi:02}:{s:02}.000Z")
+}
+
+/// Civil time from Unix seconds (UTC). Shamelessly inlined to avoid a
+/// chrono dep — the algorithm is Hinnant's "`days_from_civil`" inverse.
+#[allow(
+    clippy::cast_possible_truncation,
+    clippy::cast_sign_loss,
+    clippy::cast_possible_wrap,
+    clippy::many_single_char_names,
+)]
+fn unix_to_components(secs: u64) -> (i32, u32, u32, u32, u32, u32) {
+    let s = secs % 86_400;
+    let h = (s / 3600) as u32;
+    let mi = ((s % 3600) / 60) as u32;
+    let sec = (s % 60) as u32;
+    let days = (secs / 86_400) as i64;
+    // Hinnant: civil_from_days, with epoch at 1970-01-01.
+    let z = days + 719_468;
+    let era = z.div_euclid(146_097);
+    let doe = (z - era * 146_097) as u64;
+    let yoe = (doe - doe / 1460 + doe / 36_524 - doe / 146_096) / 365;
+    let y = yoe as i64 + era * 400;
+    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
+    let mp = (5 * doy + 2) / 153;
+    let d = (doy - (153 * mp + 2) / 5 + 1) as u32;
+    let mo = if mp < 10 { mp + 3 } else { mp - 9 } as u32;
+    let y_final = if mo <= 2 { y + 1 } else { y };
+    (y_final as i32, mo, d, h, mi, sec)
+}
+
+/// Sink an `AuditEvent` lands in. The deploy code holds an
+/// `Arc<dyn AuditSink>` — concrete impls write to a host file, an
+/// in-memory ring (tests), or `/dev/null` (when audit is disabled).
+#[async_trait]
+pub trait AuditSink: Send + Sync {
+    /// Record one event. Forensic events flush immediately; progress
+    /// events buffer until `flush()`.
+    async fn record(&self, event: AuditEvent);
+    /// Drain any buffered progress events to durable storage.
+    async fn flush(&self);
+}
+
+/// No-op sink — used when audit is intentionally disabled (no hosts in
+/// the config; tests that don't care).
+pub struct NullSink;
+
+#[async_trait]
+impl AuditSink for NullSink {
+    async fn record(&self, _event: AuditEvent) {}
+    async fn flush(&self) {}
+}
+
+/// In-memory sink for unit tests. Captures every event in order.
+pub struct MemorySink {
+    inner: Mutex<Vec<AuditEvent>>,
+}
+
+impl Default for MemorySink {
+    fn default() -> Self {
+        Self {
+            inner: Mutex::new(Vec::new()),
+        }
+    }
+}
+
+impl MemorySink {
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub async fn events(&self) -> Vec<AuditEvent> {
+        self.inner.lock().await.clone()
+    }
+}
+
+#[async_trait]
+impl AuditSink for MemorySink {
+    async fn record(&self, event: AuditEvent) {
+        self.inner.lock().await.push(event);
+    }
+    async fn flush(&self) {}
+}
+
+/// Writes audit events to `/var/lib/yoink/audit/events.jsonl` on each
+/// host via raw SSH (same transport as `files::upload`). Forensic
+/// events flush per-event; progress events buffer per-host and flush
+/// in one SSH call on `flush()` or wave-end.
+pub struct HostAuditSink {
+    /// Host descriptors keyed by address. Populated by `register()`
+    /// before any event for that host is recorded.
+    hosts: Mutex<std::collections::HashMap<String, Host>>,
+    /// One pending-line buffer per host.
+    buffers: Mutex<std::collections::HashMap<String, Vec<String>>>,
+}
+
+impl HostAuditSink {
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            hosts: Mutex::new(std::collections::HashMap::new()),
+            buffers: Mutex::new(std::collections::HashMap::new()),
+        }
+    }
+
+    /// Register a host so its buffer slot exists. Required before any
+    /// event for that host can flush — without the descriptor we don't
+    /// know which user/address to SSH to.
+    pub async fn register(&self, host: Host) {
+        self.hosts.lock().await.insert(host.address.clone(), host);
+    }
+
+    /// Drain one host's buffer to disk via a single SSH invocation.
+    /// Failure is logged to stderr; lines are dropped (deploy must not
+    /// block on audit).
+    async fn flush_host(&self, host_addr: &str) {
+        let lines = {
+            let mut bufs = self.buffers.lock().await;
+            match bufs.get_mut(host_addr) {
+                Some(b) if !b.is_empty() => std::mem::take(b),
+                _ => return,
+            }
+        };
+        let Some(host) = self.hosts.lock().await.get(host_addr).cloned() else {
+            eprintln!(
+                "yoink audit: no host descriptor registered for {host_addr}; \
+                 dropping {} event(s)",
+                lines.len()
+            );
+            return;
+        };
+        if host.is_local() {
+            // Synthetic local host — no SSH; write directly to the
+            // local filesystem.
+            if let Err(e) = append_local(&lines).await {
+                eprintln!("yoink audit: local append failed: {e}");
+            }
+            return;
+        }
+        let count = lines.len();
+        if let Err(e) = append_via_ssh(&host, &lines).await {
+            eprintln!(
+                "yoink audit: failed to flush {count} event(s) to {}: {e}",
+                host.address
+            );
+        }
+    }
+}
+
+impl Default for HostAuditSink {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl AuditSink for HostAuditSink {
+    async fn record(&self, event: AuditEvent) {
+        let host_addr = event.host.clone();
+        let line = match serde_json::to_string(&event) {
+            Ok(s) => s,
+            Err(e) => {
+                eprintln!("yoink audit: serialize failed: {e}");
+                return;
+            }
+        };
+        let is_forensic = event.kind.is_forensic();
+        {
+            let mut bufs = self.buffers.lock().await;
+            bufs.entry(host_addr.clone()).or_default().push(line);
+        }
+        if is_forensic {
+            self.flush_host(&host_addr).await;
+        }
+    }
+
+    async fn flush(&self) {
+        let addrs: Vec<String> = {
+            let bufs = self.buffers.lock().await;
+            bufs.keys().cloned().collect()
+        };
+        for addr in addrs {
+            self.flush_host(&addr).await;
+        }
+    }
+}
+
+/// Pipe `lines` (newline-joined) through `ssh user@host sh -c "…"`.
+/// Single roundtrip: mkdir + tee + size-based rotate, all in one
+/// shell.
+async fn append_via_ssh(host: &Host, lines: &[String]) -> std::io::Result<()> {
+    let payload = lines.join("\n") + "\n";
+    let script = format!(
+        "set -e; \
+         mkdir -p {AUDIT_DIR}; \
+         cat >> {AUDIT_FILE}; \
+         chmod 0640 {AUDIT_FILE} 2>/dev/null || true; \
+         sz=$(wc -c < {AUDIT_FILE} 2>/dev/null || echo 0); \
+         if [ $sz -gt {ROTATE_BYTES} ]; then \
+           mv {AUDIT_FILE} {AUDIT_DIR}/events-$(date -u +%Y%m%dT%H%M%SZ).jsonl; \
+         fi"
+    );
+    let mut child = Command::new("ssh")
+        .arg("-o")
+        .arg("BatchMode=yes")
+        .arg(format!("{}@{}", host.user, host.address))
+        .arg(script)
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .spawn()?;
+    if let Some(mut stdin) = child.stdin.take() {
+        use tokio::io::AsyncWriteExt;
+        stdin.write_all(payload.as_bytes()).await?;
+        stdin.shutdown().await?;
+    }
+    let out = child.wait_with_output().await?;
+    if out.status.success() {
+        Ok(())
+    } else {
+        Err(std::io::Error::other(format!(
+            "ssh exit {:?}: {}",
+            out.status.code(),
+            String::from_utf8_lossy(&out.stderr).trim()
+        )))
+    }
+}
+
+/// Append directly to the local filesystem (the `local` synthetic
+/// host). Writes through the same path layout as remote hosts so a
+/// `yoink audit log --host local` reads back consistently.
+async fn append_local(lines: &[String]) -> std::io::Result<()> {
+    use tokio::fs::OpenOptions;
+    use tokio::io::AsyncWriteExt;
+    tokio::fs::create_dir_all(AUDIT_DIR).await?;
+    let mut f = OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(AUDIT_FILE)
+        .await?;
+    let payload = lines.join("\n") + "\n";
+    f.write_all(payload.as_bytes()).await?;
+    if let Ok(meta) = f.metadata().await
+        && meta.len() > ROTATE_BYTES
+    {
+        drop(f);
+        let stamp: String = now_rfc3339_millis()
+            .chars()
+            .filter(|c| !matches!(c, ':' | '-' | '.'))
+            .collect();
+        let rotated = format!("{AUDIT_DIR}/events-{stamp}.jsonl");
+        tokio::fs::rename(AUDIT_FILE, &rotated).await?;
+    }
+    Ok(())
+}
+
+/// Helper for sites that build events from a `RunContext`. Saves the
+/// caller from typing the envelope four times.
+#[must_use]
+pub fn build_event(ctx: &RunContext, host: impl Into<String>, kind: AuditEventKind) -> AuditEvent {
+    AuditEvent {
+        v: 1,
+        ts: now_rfc3339_millis(),
+        deploy_id: ctx.deploy_id.clone(),
+        actor: ctx.actor.clone(),
+        yoink_version: ctx.yoink_version.clone(),
+        git_sha: ctx.git_sha.clone(),
+        host: host.into(),
+        kind,
+    }
+}
+
+/// Convenience used by `cmd_up` and friends: wrap an `Arc<dyn AuditSink>`
+/// and fire an event through it without forcing every call site to
+/// build the envelope by hand.
+pub async fn emit(sink: &Arc<dyn AuditSink>, ctx: &RunContext, host: &str, kind: AuditEventKind) {
+    sink.record(build_event(ctx, host, kind)).await;
+}
+
+/// Translate a `deploy::DeployEvent` into the host + audit kind to
+/// record. Returns `None` for events we don't audit at this stage
+/// (e.g. `Started`, which is a per-host announcement subsumed by the
+/// later `ContainerStarted` / `ContainerCreated` events).
+///
+/// Some payload fields (`tag`, `spec_hash`) aren't carried in
+/// `DeployEvent` — we derive `spec_hash` from the container name's
+/// trailing short hash and leave `tag` empty for now. Callers that
+/// know the tag (e.g. `cmd_up`'s `tag_overrides`) can patch it in via
+/// the `tag_for` parameter, keyed by service name.
+#[must_use]
+pub fn map_deploy_event(
+    service: Option<&str>,
+    event: &crate::deploy::DeployEvent,
+    tag_for: &dyn Fn(&str) -> String,
+) -> Option<(String, AuditEventKind)> {
+    use crate::deploy::DeployEvent;
+    let svc = || service.unwrap_or("").to_string();
+    let tag = || service.map(tag_for).unwrap_or_default();
+    match event {
+        DeployEvent::HookStarted { name } => Some((
+            String::new(),
+            AuditEventKind::HookStarted { name: name.clone() },
+        )),
+        DeployEvent::HookFinished { name } => Some((
+            String::new(),
+            AuditEventKind::HookFinished { name: name.clone() },
+        )),
+        DeployEvent::PullStarted { host, image, tag: t } => Some((
+            host.clone(),
+            AuditEventKind::PullStarted {
+                image: image.clone(),
+                tag: t.clone(),
+            },
+        )),
+        DeployEvent::NetworkReady {
+            host,
+            network,
+            created,
+        } => Some((
+            host.clone(),
+            AuditEventKind::NetworkReady {
+                network: network.clone(),
+                created: *created,
+            },
+        )),
+        DeployEvent::ContainerStarted { host, container } => Some((
+            host.clone(),
+            AuditEventKind::ContainerStarted {
+                service: svc(),
+                container: container.clone(),
+                spec_hash: short_hash_from_name(container),
+                tag: tag(),
+            },
+        )),
+        DeployEvent::HealthcheckHealthy {
+            host,
+            container,
+            attempts,
+        } => Some((
+            host.clone(),
+            AuditEventKind::HealthcheckHealthy {
+                service: svc(),
+                container: container.clone(),
+                attempts: *attempts,
+            },
+        )),
+        DeployEvent::OldContainerStopped { host, container } => Some((
+            host.clone(),
+            AuditEventKind::OldContainerStopped {
+                service: svc(),
+                container: container.clone(),
+            },
+        )),
+        DeployEvent::AlreadyAtSpec { host, container } => Some((
+            host.clone(),
+            AuditEventKind::AlreadyAtSpec {
+                service: svc(),
+                container: container.clone(),
+                spec_hash: short_hash_from_name(container),
+            },
+        )),
+        DeployEvent::ContainerLogTail {
+            host,
+            container,
+            lines,
+        } => Some((
+            host.clone(),
+            AuditEventKind::DeployFailed {
+                service: svc(),
+                container: container.clone(),
+                log_tail: lines.clone(),
+            },
+        )),
+        DeployEvent::Done { host, container } => Some((
+            host.clone(),
+            AuditEventKind::ContainerCreated {
+                service: svc(),
+                container: container.clone(),
+                spec_hash: short_hash_from_name(container),
+                tag: tag(),
+            },
+        )),
+        // Skip: `Started` (announcement-only; the rest of the wave
+        // makes the same point), `PullFinished` (needs image/tag we
+        // didn't keep), `HealthcheckSkipped` (low-signal).
+        DeployEvent::Started { .. }
+        | DeployEvent::PullFinished { .. }
+        | DeployEvent::HealthcheckSkipped { .. } => None,
+    }
+}
+
+/// Container names are `<service>-<short_hash>` or
+/// `<service>-<short_hash>-<replica_index>`. Pick the short hash by
+/// looking at the last hyphen-separated segment: if it's all digits,
+/// the hash is one segment back; otherwise it's the last segment.
+fn short_hash_from_name(container: &str) -> String {
+    let parts: Vec<&str> = container.rsplit('-').collect();
+    if parts.is_empty() {
+        return String::new();
+    }
+    let trailing_is_index =
+        parts[0].chars().all(|c| c.is_ascii_digit()) && !parts[0].is_empty();
+    if trailing_is_index && parts.len() > 1 {
+        parts[1].to_string()
+    } else {
+        parts[0].to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn fixture_ctx() -> RunContext {
+        RunContext {
+            deploy_id: "01HFE9TESTTESTTESTTESTTEST".into(),
+            actor: "alice@laptop".into(),
+            yoink_version: "0.18.0".into(),
+            git_sha: Some("abc1234".into()),
+            command: "up".into(),
+        }
+    }
+
+    #[test]
+    fn jsonl_round_trip_preserves_kind() {
+        let ev = build_event(
+            &fixture_ctx(),
+            "h1.example.com",
+            AuditEventKind::ContainerCreated {
+                service: "api".into(),
+                container: "api-ab12cd34".into(),
+                spec_hash: "ab12cd34".into(),
+                tag: "sha-3fdc075".into(),
+            },
+        );
+        let line = serde_json::to_string(&ev).unwrap();
+        let back: AuditEvent = serde_json::from_str(&line).unwrap();
+        assert_eq!(back, ev);
+    }
+
+    #[test]
+    fn jsonl_serializes_event_field_at_top_level() {
+        let ev = build_event(&fixture_ctx(), "h1", AuditEventKind::LockAcquired);
+        let line = serde_json::to_string(&ev).unwrap();
+        // The serde tag puts `event` at top level — required for jq
+        // `.event` to work without descending into a wrapper.
+        assert!(line.contains(r#""event":"LockAcquired""#));
+        assert!(line.contains(r#""deploy_id":"01HFE9"#));
+    }
+
+    #[test]
+    fn forensic_classification_matches_plan() {
+        assert!(AuditEventKind::LockAcquired.is_forensic());
+        assert!(AuditEventKind::ContainerCreated {
+            service: "s".into(),
+            container: "c".into(),
+            spec_hash: "h".into(),
+            tag: "t".into(),
+        }
+        .is_forensic());
+        assert!(!AuditEventKind::HookStarted { name: "n".into() }.is_forensic());
+        assert!(!AuditEventKind::PullStarted {
+            image: "i".into(),
+            tag: "t".into(),
+        }
+        .is_forensic());
+        assert!(!AuditEventKind::HealthcheckHealthy {
+            service: "s".into(),
+            container: "c".into(),
+            attempts: 1,
+        }
+        .is_forensic());
+    }
+
+    #[tokio::test]
+    async fn memory_sink_records_in_order() {
+        let sink = MemorySink::new();
+        let ctx = fixture_ctx();
+        sink.record(build_event(&ctx, "h1", AuditEventKind::LockAcquired))
+            .await;
+        sink.record(build_event(&ctx, "h1", AuditEventKind::LockReleased))
+            .await;
+        let events = sink.events().await;
+        assert_eq!(events.len(), 2);
+        assert!(matches!(events[0].kind, AuditEventKind::LockAcquired));
+        assert!(matches!(events[1].kind, AuditEventKind::LockReleased));
+    }
+
+    #[tokio::test]
+    async fn host_sink_buffers_progress_until_flush() {
+        // Without a registered host, flush silently drops buffered
+        // events and the test verifies that record() doesn't panic
+        // and that the buffer accumulates.
+        let sink = HostAuditSink::new();
+        let ctx = fixture_ctx();
+        sink.record(build_event(
+            &ctx,
+            "h1",
+            AuditEventKind::PullStarted {
+                image: "alpine".into(),
+                tag: "3.20".into(),
+            },
+        ))
+        .await;
+        sink.record(build_event(
+            &ctx,
+            "h1",
+            AuditEventKind::PullFinished {
+                image: "alpine".into(),
+                tag: "3.20".into(),
+            },
+        ))
+        .await;
+        let buf = sink.buffers.lock().await;
+        assert_eq!(buf.get("h1").map(Vec::len), Some(2));
+    }
+
+    #[test]
+    fn short_hash_from_name_handles_replicas() {
+        assert_eq!(short_hash_from_name("api-ab12cd34"), "ab12cd34");
+        assert_eq!(short_hash_from_name("api-ab12cd34-0"), "ab12cd34");
+        assert_eq!(short_hash_from_name("api-ab12cd34-15"), "ab12cd34");
+        assert_eq!(short_hash_from_name("nodash"), "nodash");
+        assert_eq!(short_hash_from_name(""), "");
+    }
+
+    #[test]
+    fn map_deploy_event_translates_done_to_container_created() {
+        use crate::deploy::DeployEvent;
+        let ev = DeployEvent::Done {
+            host: "h1".into(),
+            container: "api-ab12cd34".into(),
+        };
+        let (host, kind) = map_deploy_event(Some("api"), &ev, &|_| "v1".into()).unwrap();
+        assert_eq!(host, "h1");
+        match kind {
+            AuditEventKind::ContainerCreated {
+                service,
+                container,
+                spec_hash,
+                tag,
+            } => {
+                assert_eq!(service, "api");
+                assert_eq!(container, "api-ab12cd34");
+                assert_eq!(spec_hash, "ab12cd34");
+                assert_eq!(tag, "v1");
+            }
+            other => panic!("unexpected kind: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn map_deploy_event_skips_low_signal_variants() {
+        use crate::deploy::DeployEvent;
+        let started = DeployEvent::Started {
+            service: "api".into(),
+            tag: "v1".into(),
+            host: "h1".into(),
+        };
+        assert!(map_deploy_event(Some("api"), &started, &|_| String::new()).is_none());
+    }
+
+    #[test]
+    fn now_rfc3339_millis_has_correct_shape() {
+        let s = now_rfc3339_millis();
+        assert_eq!(s.len(), 24);
+        assert_eq!(&s[10..11], "T");
+        assert_eq!(&s[19..20], ".");
+        assert!(s.ends_with('Z'));
+    }
+
+    #[test]
+    fn unix_to_components_known_value() {
+        // 1_777_999_321 → 2026-05-05T16:42:01Z. Sanity-check Hinnant.
+        let t = 1_777_999_321_u64;
+        let (y, mo, d, h, mi, s) = unix_to_components(t);
+        assert_eq!((y, mo, d, h, mi, s), (2026, 5, 5, 16, 42, 1));
+        // Epoch itself: 1970-01-01T00:00:00Z.
+        let (y, mo, d, h, mi, s) = unix_to_components(0);
+        assert_eq!((y, mo, d, h, mi, s), (1970, 1, 1, 0, 0, 0));
+    }
+}

--- a/yoink/src/audit.rs
+++ b/yoink/src/audit.rs
@@ -885,7 +885,16 @@ pub struct FetchOutcome {
 /// dedupe on `event_id`, drop events older than `since_secs`, sort
 /// newest-first. Per-host fetch failures land in `errors` instead of
 /// aborting the whole call.
-pub async fn fetch_events(hosts: &[Host], opts: &FetchOptions) -> FetchOutcome {
+///
+/// `keypair_for` resolves the operator-side path of the SSH private
+/// key for a host that declares `ssh_key_secret:` in `yoink.yaml` —
+/// pass `|h| ops.ssh_keyfile(h)` from a `DockerOps` impl. Hosts that
+/// don't declare a managed key get the operator's normal SSH auth
+/// (agent, default identity).
+pub async fn fetch_events<F>(hosts: &[Host], opts: &FetchOptions, keypair_for: F) -> FetchOutcome
+where
+    F: Fn(&Host) -> Option<std::path::PathBuf> + Send + Sync,
+{
     let cutoff_unix = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .map_or(0, |d| d.as_secs())
@@ -906,15 +915,14 @@ pub async fn fetch_events(hosts: &[Host], opts: &FetchOptions) -> FetchOutcome {
 
     let want_host = opts.origin.as_deref() != Some("operator");
     if want_host {
-        let scoped: Vec<Host> = hosts
+        let scoped: Vec<(Host, Option<std::path::PathBuf>)> = hosts
             .iter()
             .filter(|h| opts.host_filter.as_ref().is_none_or(|f| &h.address == f))
-            .cloned()
+            .map(|h| (h.clone(), keypair_for(h)))
             .collect();
-        let fetches = scoped.iter().map(|h| async move {
-            let host = h.clone();
-            let bytes = fetch_audit_files(&host, want_rotated).await;
-            (host, bytes)
+        let fetches = scoped.iter().map(|(h, key)| async move {
+            let bytes = fetch_audit_files(h, key.as_deref(), want_rotated).await;
+            (h.clone(), bytes)
         });
         let results = futures_util::future::join_all(fetches).await;
         for (host, fetch) in results {
@@ -960,19 +968,31 @@ pub async fn read_operator_audit_files(include_rotated: bool) -> std::io::Result
 
 /// Cat the active host audit file plus rotated files (when requested)
 /// over SSH (or locally for the synthetic `local` host). Returns the
-/// concatenated JSONL bytes; missing files read as empty.
-pub async fn fetch_audit_files(host: &Host, include_rotated: bool) -> anyhow::Result<String> {
+/// concatenated JSONL bytes; missing files read as empty. `key_path`
+/// is the operator-side path to the SSH private key when the host
+/// declares `ssh_key_secret:` (decrypted by `ssh_keys::prepare`); pass
+/// `None` to fall back to the operator's normal SSH auth.
+pub async fn fetch_audit_files(
+    host: &Host,
+    key_path: Option<&std::path::Path>,
+    include_rotated: bool,
+) -> anyhow::Result<String> {
     let script = if include_rotated {
         format!("cat {AUDIT_FILE} {AUDIT_DIR}/events-*.jsonl 2>/dev/null || true")
     } else {
         format!("cat {AUDIT_FILE} 2>/dev/null || true")
     };
-    run_audit_shell(host, &script).await
+    run_audit_shell(host, key_path, &script).await
 }
 
 /// Run `script` on `host`'s shell. Local synthetic host uses `sh -c`;
-/// remote uses `ssh -o BatchMode=yes user@addr script`. Returns stdout.
-pub async fn run_audit_shell(host: &Host, script: &str) -> anyhow::Result<String> {
+/// remote uses `ssh -o BatchMode=yes [-i key_path] user@addr script`.
+/// Returns stdout.
+pub async fn run_audit_shell(
+    host: &Host,
+    key_path: Option<&std::path::Path>,
+    script: &str,
+) -> anyhow::Result<String> {
     use anyhow::Context as _;
     let output = if host.is_local() {
         tokio::process::Command::new("sh")
@@ -982,12 +1002,17 @@ pub async fn run_audit_shell(host: &Host, script: &str) -> anyhow::Result<String
             .await
             .context("local sh -c")?
     } else {
-        tokio::process::Command::new("ssh")
-            .arg("-o")
-            .arg("BatchMode=yes")
-            .arg(format!("{}@{}", host.user, host.address))
-            .arg(script)
-            .output()
+        let mut cmd = tokio::process::Command::new("ssh");
+        cmd.arg("-o").arg("BatchMode=yes");
+        if let Some(key) = key_path {
+            // -o IdentitiesOnly=yes prevents ssh from trying every key
+            // in the agent first (which would land on the wrong key
+            // and exhaust auth attempts before reaching `-i`).
+            cmd.arg("-o").arg("IdentitiesOnly=yes").arg("-i").arg(key);
+        }
+        cmd.arg(format!("{}@{}", host.user, host.address))
+            .arg(script);
+        cmd.output()
             .await
             .with_context(|| format!("ssh {}@{}", host.user, host.address))?
     };

--- a/yoink/src/audit.rs
+++ b/yoink/src/audit.rs
@@ -177,6 +177,16 @@ pub struct AuditEvent {
     /// Schema version. Bumped on backward-incompatible changes; older
     /// readers can refuse newer lines instead of misreading them.
     pub v: u32,
+    /// `UUIDv7` per individual event. Stable across re-reads; lets a
+    /// merge view dedupe lines that landed in both the operator log and
+    /// a host log (e.g. through SSH retry double-writes), and gives the
+    /// TUI a stable row identifier.
+    pub event_id: String,
+    /// Where this line was written: `"operator"` for the local file
+    /// under `$XDG_STATE_HOME/yoink/audit/`, `"host"` for the on-host
+    /// file under `/var/lib/yoink/audit/`. The merge view in
+    /// `yoink audit log` reads both and tags rows accordingly.
+    pub origin: String,
     /// RFC 3339 wall-clock timestamp with millisecond precision.
     pub ts: String,
     /// One per `yoink up` / rollback / prune / secrets-rotate run.
@@ -189,7 +199,10 @@ pub struct AuditEvent {
     pub yoink_version: String,
     /// Short git SHA of the operator's working tree, if known.
     pub git_sha: Option<String>,
-    /// Resolves to one of the hosts in `yoink.yaml`.
+    /// Resolves to one of the hosts in `yoink.yaml`. Empty string for
+    /// `origin: "operator"` events that aren't host-specific (e.g. a
+    /// `RunStarted` that fans out to multiple hosts; the operator log
+    /// records it once with `host: ""`).
     pub host: String,
     #[serde(flatten)]
     pub kind: AuditEventKind,
@@ -445,6 +458,114 @@ impl AuditSink for HostAuditSink {
     }
 }
 
+/// Resolve the operator-side audit directory:
+/// `$XDG_STATE_HOME/yoink/audit/` if set, else
+/// `$HOME/.local/state/yoink/audit/`. The same lookup is done by
+/// readers (`yoink audit log`) so write and read paths agree.
+#[must_use]
+pub fn operator_audit_dir() -> std::path::PathBuf {
+    if let Some(state) = std::env::var_os("XDG_STATE_HOME") {
+        let mut p = std::path::PathBuf::from(state);
+        p.push("yoink");
+        p.push("audit");
+        return p;
+    }
+    if let Some(home) = std::env::var_os("HOME") {
+        let mut p = std::path::PathBuf::from(home);
+        p.push(".local/state/yoink/audit");
+        return p;
+    }
+    // Fallback for environments without HOME (rare; CI containers
+    // sometimes strip it). Lands events under the cwd so they're at
+    // least not silently dropped.
+    std::path::PathBuf::from(".yoink-audit")
+}
+
+/// `<operator_audit_dir>/events.jsonl`.
+#[must_use]
+pub fn operator_audit_file() -> std::path::PathBuf {
+    let mut p = operator_audit_dir();
+    p.push("events.jsonl");
+    p
+}
+
+/// Operator-side audit sink. Writes to a local JSONL file under
+/// `$XDG_STATE_HOME/yoink/audit/` (or `~/.local/state/...`). All
+/// writes flush per-event — local file I/O is fast enough that the
+/// hybrid policy adds no value, and we want the line on disk before
+/// `cmd_up` proceeds in case the operator's process gets killed.
+///
+/// Rotation: the active file rotates at 5 MiB to
+/// `events-<UTC-stamp>.jsonl`, same shape as the on-host log.
+pub struct OperatorAuditSink;
+
+impl OperatorAuditSink {
+    /// Build a sink rooted at the resolved operator audit dir. Failure
+    /// to create the directory is reported lazily on the first write —
+    /// audit must never block command construction.
+    #[must_use]
+    pub const fn new() -> Self {
+        Self
+    }
+}
+
+impl Default for OperatorAuditSink {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl AuditSink for OperatorAuditSink {
+    async fn record(&self, event: AuditEvent) {
+        let line = match serde_json::to_string(&event) {
+            Ok(s) => s,
+            Err(e) => {
+                eprintln!("yoink audit: serialize failed: {e}");
+                return;
+            }
+        };
+        if let Err(e) = append_to_operator_log(&line).await {
+            eprintln!("yoink audit: operator log write failed: {e}");
+        }
+    }
+    async fn flush(&self) {}
+}
+
+/// Append `line\n` to `operator_audit_file()`, creating the parent
+/// directory if needed. Rotates when the active file exceeds
+/// `ROTATE_BYTES`. Best-effort: any error is returned to the caller,
+/// which warns but never aborts the run.
+async fn append_to_operator_log(line: &str) -> std::io::Result<()> {
+    use tokio::fs::OpenOptions;
+    use tokio::io::AsyncWriteExt;
+    let dir = operator_audit_dir();
+    tokio::fs::create_dir_all(&dir).await?;
+    let path = operator_audit_file();
+    let mut f = OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&path)
+        .await?;
+    let payload = format!("{line}\n");
+    f.write_all(payload.as_bytes()).await?;
+    if let Ok(meta) = f.metadata().await
+        && meta.len() > ROTATE_BYTES
+    {
+        drop(f);
+        let stamp: String = now_rfc3339_millis()
+            .chars()
+            .filter(|c| !matches!(c, ':' | '-' | '.'))
+            .collect();
+        let mut rotated = dir;
+        rotated.push(format!("events-{stamp}.jsonl"));
+        // Failure to rotate is non-fatal — next append continues to
+        // grow the active file. The operator can rotate manually.
+        let _ = tokio::fs::rename(&path, &rotated).await;
+    }
+    Ok(())
+}
+
 /// Pipe `lines` (newline-joined) through `ssh user@host sh -c "…"`.
 /// Single roundtrip: mkdir + tee + size-based rotate, all in one
 /// shell.
@@ -514,12 +635,40 @@ async fn append_local(lines: &[String]) -> std::io::Result<()> {
     Ok(())
 }
 
-/// Helper for sites that build events from a `RunContext`. Saves the
-/// caller from typing the envelope four times.
+/// Build a host-origin event — destined for the on-host JSONL log.
+/// Generates a fresh `event_id` and stamps `origin: "host"`. Use
+/// `build_operator_event` for events that go to the local operator log.
 #[must_use]
 pub fn build_event(ctx: &RunContext, host: impl Into<String>, kind: AuditEventKind) -> AuditEvent {
     AuditEvent {
         v: 1,
+        event_id: uuid::Uuid::now_v7().to_string(),
+        origin: "host".into(),
+        ts: now_rfc3339_millis(),
+        deploy_id: ctx.deploy_id.clone(),
+        actor: ctx.actor.clone(),
+        yoink_version: ctx.yoink_version.clone(),
+        git_sha: ctx.git_sha.clone(),
+        host: host.into(),
+        kind,
+    }
+}
+
+/// Build an operator-origin event — destined for the local
+/// `$XDG_STATE_HOME/yoink/audit/events.jsonl`. `host` is empty for
+/// fleet-wide events (`RunStarted`, `RunFinished`); it can be set when
+/// the operator log records something host-targeted but doesn't reach
+/// the host (DNS failure, lock contention).
+#[must_use]
+pub fn build_operator_event(
+    ctx: &RunContext,
+    host: impl Into<String>,
+    kind: AuditEventKind,
+) -> AuditEvent {
+    AuditEvent {
+        v: 1,
+        event_id: uuid::Uuid::now_v7().to_string(),
+        origin: "operator".into(),
         ts: now_rfc3339_millis(),
         deploy_id: ctx.deploy_id.clone(),
         actor: ctx.actor.clone(),
@@ -535,6 +684,16 @@ pub fn build_event(ctx: &RunContext, host: impl Into<String>, kind: AuditEventKi
 /// build the envelope by hand.
 pub async fn emit(sink: &Arc<dyn AuditSink>, ctx: &RunContext, host: &str, kind: AuditEventKind) {
     sink.record(build_event(ctx, host, kind)).await;
+}
+
+/// Same as [`emit`] but for operator-origin events.
+pub async fn emit_operator(
+    sink: &Arc<dyn AuditSink>,
+    ctx: &RunContext,
+    host: &str,
+    kind: AuditEventKind,
+) {
+    sink.record(build_operator_event(ctx, host, kind)).await;
 }
 
 /// Translate a `deploy::DeployEvent` into the host + audit kind to
@@ -699,13 +858,56 @@ mod tests {
     }
 
     #[test]
+    fn build_event_stamps_host_origin_and_unique_event_id() {
+        let ctx = fixture_ctx();
+        let a = build_event(&ctx, "h1", AuditEventKind::LockAcquired);
+        let b = build_event(&ctx, "h1", AuditEventKind::LockAcquired);
+        assert_eq!(a.origin, "host");
+        assert_eq!(b.origin, "host");
+        assert_ne!(a.event_id, b.event_id, "every event gets a fresh id");
+    }
+
+    #[test]
+    fn build_operator_event_stamps_operator_origin() {
+        let ctx = fixture_ctx();
+        let ev = build_operator_event(
+            &ctx,
+            "",
+            AuditEventKind::RunStarted {
+                command: "up".into(),
+                services: vec!["api".into()],
+            },
+        );
+        assert_eq!(ev.origin, "operator");
+        assert_eq!(ev.host, "");
+    }
+
+    #[test]
     fn jsonl_serializes_event_field_at_top_level() {
         let ev = build_event(&fixture_ctx(), "h1", AuditEventKind::LockAcquired);
         let line = serde_json::to_string(&ev).unwrap();
         // The serde tag puts `event` at top level — required for jq
-        // `.event` to work without descending into a wrapper.
+        // `.event` to work without descending into a wrapper. Same for
+        // event_id and origin.
         assert!(line.contains(r#""event":"LockAcquired""#));
         assert!(line.contains(r#""deploy_id":"01HFE9"#));
+        assert!(line.contains(r#""origin":"host""#));
+        assert!(line.contains(r#""event_id":""#));
+    }
+
+    #[test]
+    fn operator_audit_dir_ends_with_yoink_audit() {
+        // Don't mutate process env (that's `unsafe` and racy across
+        // parallel tests). Just confirm the resolved dir ends in the
+        // expected suffix — covers the HOME and XDG_STATE_HOME branches
+        // since both append `yoink/audit` and the `.yoink-audit`
+        // fallback isn't a path we'd actually hit on the test machine.
+        let dir = operator_audit_dir();
+        let s = dir.to_string_lossy();
+        assert!(
+            s.ends_with("yoink/audit") || s.ends_with(".yoink-audit"),
+            "unexpected dir: {s}"
+        );
     }
 
     #[test]

--- a/yoink/src/lib.rs
+++ b/yoink/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod add;
+pub mod audit;
 pub mod build;
 pub mod completion;
 pub mod config;

--- a/yoink/src/main.rs
+++ b/yoink/src/main.rs
@@ -597,6 +597,15 @@ enum Command {
         #[arg(long, value_enum, default_value_t = TableFormat::Text)]
         format: TableFormat,
     },
+    /// Read or prune the on-host audit log — the JSONL stream yoink
+    /// appends to `/var/lib/yoink/audit/events.jsonl` on each managed
+    /// host on every state-changing run (`up`, `rollback`, `prune`,
+    /// `secrets rotate`). Survives `docker rm`, so it remembers
+    /// containers no longer on the host.
+    Audit {
+        #[command(subcommand)]
+        action: AuditAction,
+    },
     /// `htop`-style snapshot of every running yoink-managed container
     /// across all hosts, sorted by CPU% descending. Single shot —
     /// wrap in \`watch -n 2 yoink top\` for a live display.
@@ -975,6 +984,60 @@ enum LockAction {
         /// Skip the "are you sure?" confirmation.
         #[arg(long)]
         yes: bool,
+    },
+}
+
+/// Subcommands for `yoink audit`. Read-only: nothing under `audit`
+/// emits new audit events.
+#[derive(clap::Subcommand)]
+enum AuditAction {
+    /// Stream the on-host audit JSONL across every host (or a filtered
+    /// subset). Default ordering: newest first.
+    Log {
+        /// Restrict to one host's events instead of merging the fleet.
+        #[arg(long)]
+        host: Option<String>,
+        /// Restrict to one service.
+        #[arg(long)]
+        service: Option<String>,
+        /// Show only events tagged with this `deploy_id`.
+        #[arg(long, value_name = "ID")]
+        deploy_id: Option<String>,
+        /// Filter by event name (e.g. `ContainerCreated`). Repeatable.
+        #[arg(long, value_name = "NAME", action = clap::ArgAction::Append)]
+        event: Vec<String>,
+        /// Window relative to now: `30m`, `24h`, `7d`. Default: `7d`.
+        #[arg(long, value_name = "DURATION", default_value = "7d")]
+        since: String,
+        /// Cap on rows printed (after filter + sort).
+        #[arg(long, default_value_t = 100)]
+        limit: usize,
+        /// Output format. `text` is human-readable; `json` is the raw
+        /// JSONL (one event per line, no pretty-printing).
+        #[arg(long, value_enum, default_value_t = TableFormat::Text)]
+        format: TableFormat,
+    },
+    /// Show every event for one run, ordered by timestamp, across all
+    /// hosts. Useful for reconstructing what a single `yoink up` did.
+    Run {
+        /// The `deploy_id` from `yoink audit log`.
+        deploy_id: String,
+        /// Output format.
+        #[arg(long, value_enum, default_value_t = TableFormat::Text)]
+        format: TableFormat,
+    },
+    /// Remove rotated audit files (`events-*.jsonl`) older than
+    /// `--keep`. The active `events.jsonl` is never touched.
+    Gc {
+        /// Retention window. Defaults to 90 days.
+        #[arg(long, value_name = "DURATION", default_value = "90d")]
+        keep: String,
+        /// Restrict to one host.
+        #[arg(long)]
+        host: Option<String>,
+        /// Print what would be removed without actually deleting.
+        #[arg(long)]
+        dry_run: bool,
     },
 }
 
@@ -1383,6 +1446,7 @@ async fn run(cli: Cli) -> Result<()> {
             limit,
             format,
         } => cmd_history(&config, &service, limit, format).await,
+        Command::Audit { action } => cmd_audit(&config, action).await,
         Command::Top { limit, format } => cmd_top(&config, limit, format).await,
         Command::Networks { host } => cmd_networks(&config, host.as_deref()).await,
         Command::Volumes { host } => cmd_volumes(&config, host.as_deref()).await,
@@ -1753,8 +1817,71 @@ async fn do_up_once(config: &Config, up: &UpOptions<'_>, dry_run: bool) -> Resul
         lock.spawn_heartbeat(ops.clone());
     }
 
-    let mut sink = |service: Option<&str>, event: deploy::DeployEvent| {
+    // Audit log: one sink for the whole run. We register every host
+    // up-front so per-event SSH writes know where to land. The
+    // RunStarted/LockAcquired envelope events fire here; their
+    // counterparts (LockReleased/RunFinished) fire after reconcile.
+    let host_audit = std::sync::Arc::new(yoink::audit::HostAuditSink::new());
+    for host_cfg in &config.hosts {
+        host_audit.register(Host::from(host_cfg)).await;
+    }
+    let audit_sink: std::sync::Arc<dyn yoink::audit::AuditSink> = host_audit.clone();
+    let run_ctx = yoink::audit::RunContext::new("up");
+    let selected_service_names: Vec<String> = config
+        .selected_services(services_filter)
+        .map(|s| s.name.clone())
+        .collect();
+    // Emit RunStarted + LockAcquired for each host (forensic; flushes
+    // immediately).
+    for host_cfg in &config.hosts {
+        let host = Host::from(host_cfg);
+        yoink::audit::emit(
+            &audit_sink,
+            &run_ctx,
+            &host.address,
+            yoink::audit::AuditEventKind::RunStarted {
+                command: "up".into(),
+                services: selected_service_names.clone(),
+            },
+        )
+        .await;
+        yoink::audit::emit(
+            &audit_sink,
+            &run_ctx,
+            &host.address,
+            yoink::audit::AuditEventKind::LockAcquired,
+        )
+        .await;
+    }
+
+    // Bridge the synchronous `on_event` closure to the async audit
+    // sink: the closure pushes to an unbounded mpsc; a drain task
+    // owns the sink and awaits each event in order.
+    let (audit_tx, mut audit_rx) =
+        tokio::sync::mpsc::unbounded_channel::<yoink::audit::AuditEvent>();
+    let drain_sink = audit_sink.clone();
+    let drain_task = tokio::spawn(async move {
+        while let Some(ev) = audit_rx.recv().await {
+            drain_sink.record(ev).await;
+        }
+    });
+    let tag_overrides_for_lookup = tag_overrides.clone();
+    let run_ctx_for_closure = run_ctx.clone();
+    let mut sink = move |service: Option<&str>, event: deploy::DeployEvent| {
         eprintln!("{}", output::format_deploy_event(service, &event));
+        if let Some((host, kind)) = yoink::audit::map_deploy_event(
+            service,
+            &event,
+            &|svc| {
+                tag_overrides_for_lookup
+                    .get(svc)
+                    .cloned()
+                    .unwrap_or_default()
+            },
+        ) {
+            let ev = yoink::audit::build_event(&run_ctx_for_closure, host, kind);
+            let _ = audit_tx.send(ev);
+        }
     };
 
     // Phase 0: prefetch all registry-hosted service images in parallel
@@ -1798,12 +1925,49 @@ async fn do_up_once(config: &Config, up: &UpOptions<'_>, dry_run: bool) -> Resul
     )
     .await;
 
+    // Drop the synchronous closure (and its tx) so the drain task can
+    // notice the channel is closed, drain pending events, and exit.
+    drop(sink);
+    // Wait for the drain to complete so all DeployEvent-derived audit
+    // events are recorded before we emit the run-ending envelope.
+    let _ = drain_task.await;
+
     // Always release the locks, even on reconcile failure — keeping
     // them around blocks the operator's next attempt until the
     // sentinel self-exits.
     for lock in locks {
         lock.release(&*ops).await;
     }
+
+    // Audit envelope: LockReleased + RunFinished per host, then a
+    // final flush to drain any remaining progress events.
+    let ok = reconcile_result.is_ok();
+    let err_msg = reconcile_result
+        .as_ref()
+        .err()
+        .map(std::string::ToString::to_string);
+    for host_cfg in &config.hosts {
+        let host = Host::from(host_cfg);
+        yoink::audit::emit(
+            &audit_sink,
+            &run_ctx,
+            &host.address,
+            yoink::audit::AuditEventKind::LockReleased,
+        )
+        .await;
+        yoink::audit::emit(
+            &audit_sink,
+            &run_ctx,
+            &host.address,
+            yoink::audit::AuditEventKind::RunFinished {
+                command: "up".into(),
+                ok,
+                error: err_msg.clone(),
+            },
+        )
+        .await;
+    }
+    audit_sink.flush().await;
 
     let reports = reconcile_result.context("reconcile")?;
     eprintln!("{}", output::format_deploy_summary(&reports));
@@ -3115,6 +3279,500 @@ async fn cmd_history(
         }
     }
     Ok(())
+}
+
+async fn cmd_audit(config: &Config, action: AuditAction) -> Result<()> {
+    match action {
+        AuditAction::Log {
+            host,
+            service,
+            deploy_id,
+            event,
+            since,
+            limit,
+            format,
+        } => {
+            cmd_audit_log(
+                config,
+                host.as_deref(),
+                service.as_deref(),
+                deploy_id.as_deref(),
+                &event,
+                &since,
+                limit,
+                format,
+            )
+            .await
+        }
+        AuditAction::Run { deploy_id, format } => {
+            cmd_audit_run(config, &deploy_id, format).await
+        }
+        AuditAction::Gc {
+            keep,
+            host,
+            dry_run,
+        } => cmd_audit_gc(config, &keep, host.as_deref(), dry_run).await,
+    }
+}
+
+/// Pull `/var/lib/yoink/audit/events.jsonl` from each host (and any
+/// rotated files when `--since` reaches further back), parse each line,
+/// filter, sort newest-first, format. Failures on any individual host
+/// print a stderr warning but don't abort the whole listing.
+#[allow(clippy::too_many_arguments)]
+async fn cmd_audit_log(
+    config: &Config,
+    host_filter: Option<&str>,
+    service_filter: Option<&str>,
+    deploy_id_filter: Option<&str>,
+    event_filter: &[String],
+    since: &str,
+    limit: usize,
+    format: TableFormat,
+) -> Result<()> {
+    use yoink::audit::AuditEvent;
+    use yoink::docker_ops::Host;
+    let cutoff_secs = parse_since(since)?;
+    let cutoff_unix = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0)
+        .saturating_sub(cutoff_secs);
+    let want_rotated = cutoff_secs > 24 * 3600;
+
+    let hosts: Vec<Host> = config
+        .hosts
+        .iter()
+        .filter(|h| host_filter.is_none_or(|f| h.address == f))
+        .map(Host::from)
+        .collect();
+    if hosts.is_empty() {
+        anyhow::bail!("no hosts match the filter (or no hosts configured)");
+    }
+    let event_set: std::collections::HashSet<&str> =
+        event_filter.iter().map(String::as_str).collect();
+
+    let fetches = hosts.iter().map(|h| async move {
+        let host = h.clone();
+        let bytes = fetch_audit_files(&host, want_rotated).await;
+        (host, bytes)
+    });
+    let results = futures_util::future::join_all(fetches).await;
+
+    let mut all: Vec<AuditEvent> = Vec::new();
+    for (host, fetch) in results {
+        match fetch {
+            Ok(bytes) => {
+                for line in bytes.lines() {
+                    let trimmed = line.trim();
+                    if trimmed.is_empty() {
+                        continue;
+                    }
+                    match serde_json::from_str::<AuditEvent>(trimmed) {
+                        Ok(ev) => all.push(ev),
+                        Err(e) => eprintln!(
+                            "yoink audit: skip malformed event from {}: {e}",
+                            host.address
+                        ),
+                    }
+                }
+            }
+            Err(e) => eprintln!("yoink audit: fetch failed on {}: {e}", host.address),
+        }
+    }
+
+    all.retain(|ev| {
+        if let Some(svc) = service_filter
+            && !audit_event_service(ev).is_some_and(|s| s == svc)
+        {
+            return false;
+        }
+        if let Some(id) = deploy_id_filter
+            && ev.deploy_id != id
+        {
+            return false;
+        }
+        if !event_set.is_empty() {
+            let name = audit_event_name(&ev.kind);
+            if !event_set.contains(name) {
+                return false;
+            }
+        }
+        // Cheap "is this newer than cutoff" filter on the RFC3339
+        // string. Lexicographic compare works because the format is
+        // big-endian (year first, padded).
+        let cutoff_str = yoink::audit::ts_string_for(cutoff_unix);
+        ev.ts >= cutoff_str
+    });
+
+    // Sort newest first.
+    all.sort_by(|a, b| b.ts.cmp(&a.ts));
+    all.truncate(limit);
+
+    if all.is_empty() {
+        eprintln!("no audit events match the filters");
+        return Ok(());
+    }
+
+    match format {
+        TableFormat::Json => {
+            for ev in &all {
+                println!("{}", serde_json::to_string(ev)?);
+            }
+        }
+        TableFormat::Text => {
+            use std::fmt::Write as _;
+            let mut buf = String::new();
+            writeln!(
+                buf,
+                "{:<24}  {:<22}  {:<24}  {:<28}  {}",
+                "ts", "host", "deploy_id", "event", "details"
+            )?;
+            for ev in &all {
+                let name = audit_event_name(&ev.kind);
+                let details = audit_event_summary(&ev.kind);
+                let id_short: String = ev.deploy_id.chars().take(24).collect();
+                writeln!(
+                    buf,
+                    "{:<24}  {:<22}  {:<24}  {:<28}  {}",
+                    ev.ts, ev.host, id_short, name, details
+                )?;
+            }
+            page_output(&buf);
+        }
+    }
+    Ok(())
+}
+
+async fn cmd_audit_run(
+    config: &Config,
+    deploy_id: &str,
+    format: TableFormat,
+) -> Result<()> {
+    cmd_audit_log(
+        config,
+        None,
+        None,
+        Some(deploy_id),
+        &[],
+        // Pulling rotated files too: a run from weeks ago could have
+        // landed in a rotated file already.
+        "365d",
+        usize::MAX,
+        format,
+    )
+    .await
+}
+
+async fn cmd_audit_gc(
+    config: &Config,
+    keep: &str,
+    host_filter: Option<&str>,
+    dry_run: bool,
+) -> Result<()> {
+    use yoink::docker_ops::Host;
+    let secs = parse_since(keep)?;
+    let cutoff_unix = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0)
+        .saturating_sub(secs);
+
+    let hosts: Vec<Host> = config
+        .hosts
+        .iter()
+        .filter(|h| host_filter.is_none_or(|f| h.address == f))
+        .map(Host::from)
+        .collect();
+    if hosts.is_empty() {
+        anyhow::bail!("no hosts match the filter (or no hosts configured)");
+    }
+
+    let mut removed = 0_usize;
+    for host in hosts {
+        let result = audit_gc_one(&host, cutoff_unix, dry_run).await;
+        match result {
+            Ok(n) => {
+                removed += n;
+                if n > 0 {
+                    eprintln!(
+                        "[{}] {} {n} rotated audit file(s)",
+                        host.address,
+                        if dry_run { "would remove" } else { "removed" }
+                    );
+                }
+            }
+            Err(e) => eprintln!("[{}] gc failed: {e}", host.address),
+        }
+    }
+    if removed == 0 {
+        eprintln!("no rotated audit files older than {keep}");
+    }
+    Ok(())
+}
+
+/// Cat the active audit file plus rotated files (when requested) on
+/// `host` and return the concatenated bytes. Empty string when the
+/// path doesn't exist (host is fresh and has never been deployed to).
+async fn fetch_audit_files(
+    host: &yoink::docker_ops::Host,
+    include_rotated: bool,
+) -> Result<String> {
+    use yoink::audit::{AUDIT_DIR, AUDIT_FILE};
+    let cmd = if include_rotated {
+        // Glob for active + rotated. cat ignores missing files
+        // gracefully via 2>/dev/null.
+        format!(
+            "cat {file} {dir}/events-*.jsonl 2>/dev/null || true",
+            dir = AUDIT_DIR,
+            file = AUDIT_FILE
+        )
+    } else {
+        format!("cat {AUDIT_FILE} 2>/dev/null || true")
+    };
+    let out = if host.is_local() {
+        let output = tokio::process::Command::new("sh")
+            .arg("-c")
+            .arg(&cmd)
+            .output()
+            .await
+            .with_context(|| format!("local sh -c {cmd:?}"))?;
+        String::from_utf8_lossy(&output.stdout).into_owned()
+    } else {
+        let output = tokio::process::Command::new("ssh")
+            .arg("-o")
+            .arg("BatchMode=yes")
+            .arg(format!("{}@{}", host.user, host.address))
+            .arg(&cmd)
+            .output()
+            .await
+            .with_context(|| format!("ssh {}@{}", host.user, host.address))?;
+        if !output.status.success() {
+            anyhow::bail!(
+                "ssh exit {:?}: {}",
+                output.status.code(),
+                String::from_utf8_lossy(&output.stderr).trim()
+            );
+        }
+        String::from_utf8_lossy(&output.stdout).into_owned()
+    };
+    Ok(out)
+}
+
+async fn audit_gc_one(
+    host: &yoink::docker_ops::Host,
+    cutoff_unix: u64,
+    dry_run: bool,
+) -> Result<usize> {
+    use yoink::audit::AUDIT_DIR;
+    // List rotated files with mtime in unix seconds — `find` is
+    // POSIX-portable enough for the fleet we target.
+    let list_cmd = format!(
+        "cd {AUDIT_DIR} 2>/dev/null && \
+         find . -maxdepth 1 -type f -name 'events-*.jsonl' -printf '%T@ %f\\n' 2>/dev/null \
+         || true"
+    );
+    let listing = if host.is_local() {
+        let out = tokio::process::Command::new("sh")
+            .arg("-c")
+            .arg(&list_cmd)
+            .output()
+            .await?;
+        String::from_utf8_lossy(&out.stdout).into_owned()
+    } else {
+        let out = tokio::process::Command::new("ssh")
+            .arg("-o")
+            .arg("BatchMode=yes")
+            .arg(format!("{}@{}", host.user, host.address))
+            .arg(&list_cmd)
+            .output()
+            .await?;
+        String::from_utf8_lossy(&out.stdout).into_owned()
+    };
+
+    let mut to_remove: Vec<String> = Vec::new();
+    for line in listing.lines() {
+        let mut parts = line.trim().splitn(2, char::is_whitespace);
+        let Some(mtime_str) = parts.next() else {
+            continue;
+        };
+        let Some(name) = parts.next() else { continue };
+        let mtime: f64 = mtime_str.parse().unwrap_or(0.0);
+        if (mtime as u64) < cutoff_unix {
+            to_remove.push(name.trim_start_matches("./").to_string());
+        }
+    }
+    if to_remove.is_empty() || dry_run {
+        return Ok(to_remove.len());
+    }
+
+    let rm_cmd = {
+        let names = to_remove
+            .iter()
+            .map(|n| format!("'{}'", n.replace('\'', "'\\''")))
+            .collect::<Vec<_>>()
+            .join(" ");
+        format!("cd {AUDIT_DIR} && rm -f {names}")
+    };
+    if host.is_local() {
+        tokio::process::Command::new("sh")
+            .arg("-c")
+            .arg(&rm_cmd)
+            .status()
+            .await?;
+    } else {
+        tokio::process::Command::new("ssh")
+            .arg("-o")
+            .arg("BatchMode=yes")
+            .arg(format!("{}@{}", host.user, host.address))
+            .arg(&rm_cmd)
+            .status()
+            .await?;
+    }
+    Ok(to_remove.len())
+}
+
+/// Parse a `humantime`-style duration like `7d`, `30m`, `24h` into
+/// seconds. Defaults to 0 on parse failure with an error.
+fn parse_since(s: &str) -> Result<u64> {
+    humantime::parse_duration(s)
+        .map(|d| d.as_secs())
+        .with_context(|| format!("invalid duration {s:?}"))
+}
+
+/// Best-effort label for `AuditEventKind` in the text-format table.
+fn audit_event_name(kind: &yoink::audit::AuditEventKind) -> &'static str {
+    use yoink::audit::AuditEventKind as K;
+    match kind {
+        K::RunStarted { .. } => "RunStarted",
+        K::RunFinished { .. } => "RunFinished",
+        K::LockAcquired => "LockAcquired",
+        K::LockReleased => "LockReleased",
+        K::HookStarted { .. } => "HookStarted",
+        K::HookFinished { .. } => "HookFinished",
+        K::PullStarted { .. } => "PullStarted",
+        K::PullFinished { .. } => "PullFinished",
+        K::NetworkReady { .. } => "NetworkReady",
+        K::ContainerStarted { .. } => "ContainerStarted",
+        K::HealthcheckHealthy { .. } => "HealthcheckHealthy",
+        K::ContainerCreated { .. } => "ContainerCreated",
+        K::AlreadyAtSpec { .. } => "AlreadyAtSpec",
+        K::OldContainerStopped { .. } => "OldContainerStopped",
+        K::ContainerRemoved { .. } => "ContainerRemoved",
+        K::DeployFailed { .. } => "DeployFailed",
+        K::RollbackStarted { .. } => "RollbackStarted",
+        K::RollbackFinished { .. } => "RollbackFinished",
+        K::ContainerPruned { .. } => "ContainerPruned",
+        K::SecretsRotated { .. } => "SecretsRotated",
+        K::FileUploaded { .. } => "FileUploaded",
+    }
+}
+
+/// Service field on event kinds that have one; `None` for envelope
+/// events (RunStarted, LockAcquired, etc.).
+fn audit_event_service(ev: &yoink::audit::AuditEvent) -> Option<&str> {
+    use yoink::audit::AuditEventKind as K;
+    match &ev.kind {
+        K::ContainerStarted { service, .. }
+        | K::ContainerCreated { service, .. }
+        | K::ContainerRemoved { service, .. }
+        | K::AlreadyAtSpec { service, .. }
+        | K::OldContainerStopped { service, .. }
+        | K::DeployFailed { service, .. }
+        | K::RollbackStarted { service, .. }
+        | K::RollbackFinished { service, .. }
+        | K::HealthcheckHealthy { service, .. }
+        | K::FileUploaded { service, .. } => Some(service.as_str()),
+        K::ContainerPruned { service, .. } => service.as_deref(),
+        _ => None,
+    }
+}
+
+/// One-line human summary of the variant payload.
+fn audit_event_summary(kind: &yoink::audit::AuditEventKind) -> String {
+    use yoink::audit::AuditEventKind as K;
+    match kind {
+        K::RunStarted { command, services } => {
+            format!("{command} services=[{}]", services.join(","))
+        }
+        K::RunFinished {
+            command, ok, error, ..
+        } => {
+            if *ok {
+                format!("{command} ok")
+            } else {
+                format!(
+                    "{command} FAILED: {}",
+                    error.as_deref().unwrap_or("")
+                )
+            }
+        }
+        K::LockAcquired => String::new(),
+        K::LockReleased => String::new(),
+        K::HookStarted { name } | K::HookFinished { name } => name.clone(),
+        K::PullStarted { image, tag } | K::PullFinished { image, tag } => {
+            format!("{image}:{tag}")
+        }
+        K::NetworkReady { network, created } => {
+            if *created {
+                format!("{network} (created)")
+            } else {
+                network.clone()
+            }
+        }
+        K::ContainerStarted {
+            service,
+            container,
+            tag,
+            ..
+        }
+        | K::ContainerCreated {
+            service,
+            container,
+            tag,
+            ..
+        } => format!("{service} {container} tag={tag}"),
+        K::AlreadyAtSpec {
+            service,
+            container,
+            spec_hash,
+        } => format!("{service} {container} spec={spec_hash}"),
+        K::HealthcheckHealthy {
+            service,
+            container,
+            attempts,
+        } => format!("{service} {container} after {attempts}"),
+        K::OldContainerStopped { service, container }
+        | K::ContainerRemoved { service, container } => format!("{service} {container}"),
+        K::DeployFailed {
+            service,
+            container,
+            log_tail,
+        } => format!(
+            "{service} {container} ({} log lines)",
+            log_tail.len()
+        ),
+        K::RollbackStarted {
+            service,
+            target_tag,
+        } => format!("{service} → {target_tag}"),
+        K::RollbackFinished { service, ok, error } => {
+            if *ok {
+                format!("{service} ok")
+            } else {
+                format!("{service} FAILED: {}", error.as_deref().unwrap_or(""))
+            }
+        }
+        K::ContainerPruned { service, container } => {
+            format!("{} {container}", service.as_deref().unwrap_or("?"))
+        }
+        K::SecretsRotated { new_recipient } => format!("→ {new_recipient}"),
+        K::FileUploaded {
+            service,
+            sha256,
+            remote_path,
+        } => format!("{service} {sha256} → {remote_path}"),
+    }
 }
 
 struct TopRow {

--- a/yoink/src/main.rs
+++ b/yoink/src/main.rs
@@ -3348,81 +3348,35 @@ async fn cmd_audit_log(
     limit: usize,
     format: TableFormat,
 ) -> Result<()> {
-    use yoink::audit::AuditEvent;
+    use yoink::audit::{FetchOptions, event_name, event_service, event_summary, fetch_events};
     use yoink::docker_ops::Host;
-    let cutoff_secs = parse_since(since)?;
-    let cutoff_unix = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .map_or(0, |d| d.as_secs())
-        .saturating_sub(cutoff_secs);
-    let want_rotated = cutoff_secs > 24 * 3600;
 
     if let Some(o) = origin_filter
         && !matches!(o, "operator" | "host")
     {
         anyhow::bail!("--origin must be 'operator' or 'host', got {o:?}");
     }
+    let hosts: Vec<Host> = config.hosts.iter().map(Host::from).collect();
+    if hosts.is_empty() && origin_filter == Some("host") {
+        anyhow::bail!("no hosts match the filter (or no hosts configured)");
+    }
 
-    let hosts: Vec<Host> = config
-        .hosts
-        .iter()
-        .filter(|h| host_filter.is_none_or(|f| h.address == f))
-        .map(Host::from)
-        .collect();
+    let opts = FetchOptions {
+        host_filter: host_filter.map(str::to_string),
+        since_secs: parse_since(since)?,
+        origin: origin_filter.map(str::to_string),
+    };
+    let outcome = fetch_events(&hosts, &opts).await;
+    for (source, msg) in &outcome.errors {
+        eprintln!("yoink audit: {source}: {msg}");
+    }
+
     let event_set: std::collections::HashSet<&str> =
         event_filter.iter().map(String::as_str).collect();
-
-    // Fetch in parallel: operator log (always) + each host's log.
-    // `--host <ADDR>` scopes the host fetch to one entry; the operator
-    // log is still pulled because operator events list the run, not a
-    // specific host. Pass `--origin host` together with `--host` to
-    // see only the named host.
-    let mut all: Vec<AuditEvent> = Vec::new();
-
-    // Operator side — local file read, no SSH. Skipped only if the
-    // caller explicitly asked for `--origin host`.
-    let want_operator = origin_filter != Some("host");
-    if want_operator {
-        match read_operator_audit_files(want_rotated).await {
-            Ok(bytes) => parse_into(&mut all, &bytes, "operator log"),
-            Err(e) => eprintln!("yoink audit: read operator log failed: {e}"),
-        }
-    }
-
-    // Host side — SSH cat each host. Skipped if the caller asked for
-    // `--origin operator`. With no configured hosts and origin=host,
-    // we'd otherwise leave the user with an empty result; bail loud.
-    let want_host = origin_filter != Some("operator");
-    if want_host {
-        if hosts.is_empty() && origin_filter == Some("host") {
-            anyhow::bail!("no hosts match the filter (or no hosts configured)");
-        }
-        let fetches = hosts.iter().map(|h| async move {
-            let host = h.clone();
-            let bytes = fetch_audit_files(&host, want_rotated).await;
-            (host, bytes)
-        });
-        let results = futures_util::future::join_all(fetches).await;
-        for (host, fetch) in results {
-            match fetch {
-                Ok(bytes) => parse_into(&mut all, &bytes, &host.address),
-                Err(e) => eprintln!("yoink audit: fetch failed on {}: {e}", host.address),
-            }
-        }
-    }
-
-    // One pass: dedupe on event_id (an SSH retry double-write would
-    // otherwise show twice) plus apply filters. Lexicographic compare
-    // on the RFC3339 `ts` against the cutoff is correct because the
-    // format is big-endian and zero-padded.
-    let cutoff_str = yoink::audit::ts_string_for(cutoff_unix);
-    let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
-    all.retain(|ev| {
-        if !seen.insert(ev.event_id.clone()) {
-            return false;
-        }
+    let mut events = outcome.events;
+    events.retain(|ev| {
         if let Some(svc) = service_filter
-            && audit_event_service(ev).is_none_or(|s| s != svc)
+            && event_service(ev).is_none_or(|s| s != svc)
         {
             return false;
         }
@@ -3431,29 +3385,21 @@ async fn cmd_audit_log(
         {
             return false;
         }
-        if let Some(o) = origin_filter
-            && ev.origin != o
-        {
+        if !event_set.is_empty() && !event_set.contains(event_name(&ev.kind)) {
             return false;
         }
-        if !event_set.is_empty() && !event_set.contains(audit_event_name(&ev.kind)) {
-            return false;
-        }
-        ev.ts >= cutoff_str
+        true
     });
+    events.truncate(limit);
 
-    // Sort newest first.
-    all.sort_by(|a, b| b.ts.cmp(&a.ts));
-    all.truncate(limit);
-
-    if all.is_empty() {
+    if events.is_empty() {
         eprintln!("no audit events match the filters");
         return Ok(());
     }
 
     match format {
         TableFormat::Json => {
-            for ev in &all {
+            for ev in &events {
                 println!("{}", serde_json::to_string(ev)?);
             }
         }
@@ -3465,9 +3411,9 @@ async fn cmd_audit_log(
                 "{:<24}  {:<8}  {:<22}  {:<24}  {:<28}  details",
                 "ts", "origin", "host", "deploy_id", "event"
             )?;
-            for ev in &all {
-                let name = audit_event_name(&ev.kind);
-                let details = audit_event_summary(&ev.kind);
+            for ev in &events {
+                let name = event_name(&ev.kind);
+                let details = event_summary(&ev.kind);
                 let id_short: String = ev.deploy_id.chars().take(24).collect();
                 let host_display = if ev.host.is_empty() { "—" } else { &ev.host };
                 writeln!(
@@ -3545,106 +3491,12 @@ async fn cmd_audit_gc(
     Ok(())
 }
 
-/// Read the operator-side audit files. Returns the concatenated bytes
-/// of `events.jsonl` plus (when `include_rotated`) every
-/// `events-*.jsonl`. Missing files are silently treated as empty.
-async fn read_operator_audit_files(include_rotated: bool) -> Result<String> {
-    use yoink::audit::{operator_audit_dir, operator_audit_file};
-    let mut out = String::new();
-    if let Ok(bytes) = tokio::fs::read_to_string(operator_audit_file()).await {
-        out.push_str(&bytes);
-    }
-    if include_rotated {
-        let dir = operator_audit_dir();
-        if let Ok(mut rd) = tokio::fs::read_dir(&dir).await {
-            while let Ok(Some(entry)) = rd.next_entry().await {
-                let name = entry.file_name();
-                let name_str = name.to_string_lossy();
-                if name_str.starts_with("events-")
-                    && name_str.ends_with(".jsonl")
-                    && let Ok(bytes) = tokio::fs::read_to_string(entry.path()).await
-                {
-                    out.push_str(&bytes);
-                }
-            }
-        }
-    }
-    Ok(out)
-}
-
-/// Parse a JSONL blob into the running `acc` vector. Malformed lines
-/// are skipped with a stderr warning labeled by `source` (the host
-/// address, or `"operator log"` for the local file).
-fn parse_into(acc: &mut Vec<yoink::audit::AuditEvent>, bytes: &str, source: &str) {
-    for line in bytes.lines() {
-        let trimmed = line.trim();
-        if trimmed.is_empty() {
-            continue;
-        }
-        match serde_json::from_str::<yoink::audit::AuditEvent>(trimmed) {
-            Ok(ev) => acc.push(ev),
-            Err(e) => eprintln!("yoink audit: skip malformed event from {source}: {e}"),
-        }
-    }
-}
-
-/// Run `script` on `host`'s shell. Local synthetic host → `sh -c`;
-/// remote → `ssh -o BatchMode=yes user@addr script`. Returns captured
-/// stdout. Used by every audit read/gc path so the local/remote split
-/// lives in one place.
-async fn run_audit_shell(host: &yoink::docker_ops::Host, script: &str) -> Result<String> {
-    let output = if host.is_local() {
-        tokio::process::Command::new("sh")
-            .arg("-c")
-            .arg(script)
-            .output()
-            .await
-            .context("local sh -c")?
-    } else {
-        tokio::process::Command::new("ssh")
-            .arg("-o")
-            .arg("BatchMode=yes")
-            .arg(format!("{}@{}", host.user, host.address))
-            .arg(script)
-            .output()
-            .await
-            .with_context(|| format!("ssh {}@{}", host.user, host.address))?
-    };
-    if !output.status.success() {
-        let prog = if host.is_local() { "sh" } else { "ssh" };
-        anyhow::bail!(
-            "{prog} exit {:?}: {}",
-            output.status.code(),
-            String::from_utf8_lossy(&output.stderr).trim()
-        );
-    }
-    Ok(String::from_utf8_lossy(&output.stdout).into_owned())
-}
-
-/// Cat the active audit file plus rotated files (when requested) on
-/// `host` and return the concatenated bytes. Empty string when the
-/// path doesn't exist (host is fresh and has never been deployed to).
-async fn fetch_audit_files(
-    host: &yoink::docker_ops::Host,
-    include_rotated: bool,
-) -> Result<String> {
-    use yoink::audit::{AUDIT_DIR, AUDIT_FILE};
-    // `cat … || true` makes a missing file (fresh host) read as empty
-    // instead of erroring; the `2>/dev/null` swallows the cat warning.
-    let script = if include_rotated {
-        format!("cat {AUDIT_FILE} {AUDIT_DIR}/events-*.jsonl 2>/dev/null || true")
-    } else {
-        format!("cat {AUDIT_FILE} 2>/dev/null || true")
-    };
-    run_audit_shell(host, &script).await
-}
-
 async fn audit_gc_one(
     host: &yoink::docker_ops::Host,
     cutoff_unix: u64,
     dry_run: bool,
 ) -> Result<usize> {
-    use yoink::audit::AUDIT_DIR;
+    use yoink::audit::{AUDIT_DIR, run_audit_shell};
     // POSIX-portable enough for the fleet we target. `-printf '%T@ %f'`
     // gives `<float-mtime> <basename>` per line.
     let list_script = format!(
@@ -3691,134 +3543,6 @@ fn parse_since(s: &str) -> Result<u64> {
     parse_humantime(s)
         .map(|d| d.as_secs())
         .map_err(|e| anyhow::anyhow!(e))
-}
-
-/// Best-effort label for `AuditEventKind` in the text-format table.
-fn audit_event_name(kind: &yoink::audit::AuditEventKind) -> &'static str {
-    use yoink::audit::AuditEventKind as K;
-    match kind {
-        K::RunStarted { .. } => "RunStarted",
-        K::RunFinished { .. } => "RunFinished",
-        K::LockAcquired => "LockAcquired",
-        K::LockReleased => "LockReleased",
-        K::HookStarted { .. } => "HookStarted",
-        K::HookFinished { .. } => "HookFinished",
-        K::PullStarted { .. } => "PullStarted",
-        K::PullFinished { .. } => "PullFinished",
-        K::NetworkReady { .. } => "NetworkReady",
-        K::ContainerStarted { .. } => "ContainerStarted",
-        K::HealthcheckHealthy { .. } => "HealthcheckHealthy",
-        K::ContainerCreated { .. } => "ContainerCreated",
-        K::AlreadyAtSpec { .. } => "AlreadyAtSpec",
-        K::OldContainerStopped { .. } => "OldContainerStopped",
-        K::ContainerRemoved { .. } => "ContainerRemoved",
-        K::DeployFailed { .. } => "DeployFailed",
-        K::RollbackStarted { .. } => "RollbackStarted",
-        K::RollbackFinished { .. } => "RollbackFinished",
-        K::ContainerPruned { .. } => "ContainerPruned",
-        K::SecretsRotated { .. } => "SecretsRotated",
-        K::FileUploaded { .. } => "FileUploaded",
-    }
-}
-
-/// Service field on event kinds that have one; `None` for envelope
-/// events (`RunStarted`, `LockAcquired`, etc.).
-fn audit_event_service(ev: &yoink::audit::AuditEvent) -> Option<&str> {
-    use yoink::audit::AuditEventKind as K;
-    match &ev.kind {
-        K::ContainerStarted { service, .. }
-        | K::ContainerCreated { service, .. }
-        | K::ContainerRemoved { service, .. }
-        | K::AlreadyAtSpec { service, .. }
-        | K::OldContainerStopped { service, .. }
-        | K::DeployFailed { service, .. }
-        | K::RollbackStarted { service, .. }
-        | K::RollbackFinished { service, .. }
-        | K::HealthcheckHealthy { service, .. }
-        | K::FileUploaded { service, .. } => Some(service.as_str()),
-        K::ContainerPruned { service, .. } => service.as_deref(),
-        _ => None,
-    }
-}
-
-/// One-line human summary of the variant payload.
-fn audit_event_summary(kind: &yoink::audit::AuditEventKind) -> String {
-    use yoink::audit::AuditEventKind as K;
-    match kind {
-        K::RunStarted { command, services } => {
-            format!("{command} services=[{}]", services.join(","))
-        }
-        K::RunFinished {
-            command, ok, error, ..
-        } => {
-            if *ok {
-                format!("{command} ok")
-            } else {
-                format!("{command} FAILED: {}", error.as_deref().unwrap_or(""))
-            }
-        }
-        K::LockAcquired | K::LockReleased => String::new(),
-        K::HookStarted { name } | K::HookFinished { name } => name.clone(),
-        K::PullStarted { image, tag } | K::PullFinished { image, tag } => {
-            format!("{image}:{tag}")
-        }
-        K::NetworkReady { network, created } => {
-            if *created {
-                format!("{network} (created)")
-            } else {
-                network.clone()
-            }
-        }
-        K::ContainerStarted {
-            service,
-            container,
-            tag,
-            ..
-        }
-        | K::ContainerCreated {
-            service,
-            container,
-            tag,
-            ..
-        } => format!("{service} {container} tag={tag}"),
-        K::AlreadyAtSpec {
-            service,
-            container,
-            spec_hash,
-        } => format!("{service} {container} spec={spec_hash}"),
-        K::HealthcheckHealthy {
-            service,
-            container,
-            attempts,
-        } => format!("{service} {container} after {attempts}"),
-        K::OldContainerStopped { service, container }
-        | K::ContainerRemoved { service, container } => format!("{service} {container}"),
-        K::DeployFailed {
-            service,
-            container,
-            log_tail,
-        } => format!("{service} {container} ({} log lines)", log_tail.len()),
-        K::RollbackStarted {
-            service,
-            target_tag,
-        } => format!("{service} → {target_tag}"),
-        K::RollbackFinished { service, ok, error } => {
-            if *ok {
-                format!("{service} ok")
-            } else {
-                format!("{service} FAILED: {}", error.as_deref().unwrap_or(""))
-            }
-        }
-        K::ContainerPruned { service, container } => {
-            format!("{} {container}", service.as_deref().unwrap_or("?"))
-        }
-        K::SecretsRotated { new_recipient } => format!("→ {new_recipient}"),
-        K::FileUploaded {
-            service,
-            sha256,
-            remote_path,
-        } => format!("{service} {sha256} → {remote_path}"),
-    }
 }
 
 struct TopRow {

--- a/yoink/src/main.rs
+++ b/yoink/src/main.rs
@@ -1865,19 +1865,25 @@ async fn do_up_once(config: &Config, up: &UpOptions<'_>, dry_run: bool) -> Resul
             drain_sink.record(ev).await;
         }
     });
-    let tag_overrides_for_lookup = tag_overrides.clone();
+    // For audit events that need a `tag` field: prefer a CLI override
+    // (`--tag service=xyz`), fall back to the service's `tag:` in
+    // yoink.yaml. `tag_overrides` already shadows yaml tags during the
+    // deploy itself; we mirror that resolution here.
+    let mut tag_lookup: std::collections::BTreeMap<String, String> = config
+        .services
+        .iter()
+        .filter_map(|s| s.tag.clone().map(|t| (s.name.clone(), t)))
+        .collect();
+    for (k, v) in &tag_overrides {
+        tag_lookup.insert(k.clone(), v.clone());
+    }
     let run_ctx_for_closure = run_ctx.clone();
     let mut sink = move |service: Option<&str>, event: deploy::DeployEvent| {
         eprintln!("{}", output::format_deploy_event(service, &event));
         if let Some((host, kind)) = yoink::audit::map_deploy_event(
             service,
             &event,
-            &|svc| {
-                tag_overrides_for_lookup
-                    .get(svc)
-                    .cloned()
-                    .unwrap_or_default()
-            },
+            &|svc| tag_lookup.get(svc).cloned().unwrap_or_default(),
         ) {
             let ev = yoink::audit::build_event(&run_ctx_for_closure, host, kind);
             let _ = audit_tx.send(ev);
@@ -3388,7 +3394,7 @@ async fn cmd_audit_log(
             return false;
         }
         if let Some(id) = deploy_id_filter
-            && ev.deploy_id != id
+            && !ev.deploy_id.starts_with(id)
         {
             return false;
         }

--- a/yoink/src/main.rs
+++ b/yoink/src/main.rs
@@ -3349,7 +3349,7 @@ async fn cmd_audit_log(
     format: TableFormat,
 ) -> Result<()> {
     use yoink::audit::{FetchOptions, event_name, event_service, event_summary, fetch_events};
-    use yoink::docker_ops::Host;
+    use yoink::docker_ops::{DockerOps as _, Host};
 
     if let Some(o) = origin_filter
         && !matches!(o, "operator" | "host")
@@ -3361,12 +3361,19 @@ async fn cmd_audit_log(
         anyhow::bail!("no hosts match the filter (or no hosts configured)");
     }
 
+    // Build the ops handle so we can resolve `ssh_key_secret:` keys
+    // for hosts that need them. `build_real_ops` short-circuits to a
+    // no-key handle when no host declares one, so the common path
+    // doesn't pay for sealed-bundle decryption.
+    let bundle = load_secrets_bundle(config).await?;
+    let ops = build_real_ops(config, bundle.as_ref()).await?;
+
     let opts = FetchOptions {
         host_filter: host_filter.map(str::to_string),
         since_secs: parse_since(since)?,
         origin: origin_filter.map(str::to_string),
     };
-    let outcome = fetch_events(&hosts, &opts).await;
+    let outcome = fetch_events(&hosts, &opts, |h| ops.ssh_keyfile(h)).await;
     for (source, msg) in &outcome.errors {
         eprintln!("yoink audit: {source}: {msg}");
     }
@@ -3451,7 +3458,7 @@ async fn cmd_audit_gc(
     host_filter: Option<&str>,
     dry_run: bool,
 ) -> Result<()> {
-    use yoink::docker_ops::Host;
+    use yoink::docker_ops::{DockerOps as _, Host};
     let secs = parse_since(keep)?;
     let cutoff_unix = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
@@ -3468,9 +3475,15 @@ async fn cmd_audit_gc(
         anyhow::bail!("no hosts match the filter (or no hosts configured)");
     }
 
+    // Resolve sealed SSH keys for hosts that need them; same shape as
+    // `cmd_audit_log`. Build once, reuse across hosts.
+    let bundle = load_secrets_bundle(config).await?;
+    let ops = build_real_ops(config, bundle.as_ref()).await?;
+
     let mut removed = 0_usize;
     for host in hosts {
-        let result = audit_gc_one(&host, cutoff_unix, dry_run).await;
+        let key_path = ops.ssh_keyfile(&host);
+        let result = audit_gc_one(&host, key_path.as_deref(), cutoff_unix, dry_run).await;
         match result {
             Ok(n) => {
                 removed += n;
@@ -3493,6 +3506,7 @@ async fn cmd_audit_gc(
 
 async fn audit_gc_one(
     host: &yoink::docker_ops::Host,
+    key_path: Option<&std::path::Path>,
     cutoff_unix: u64,
     dry_run: bool,
 ) -> Result<usize> {
@@ -3504,7 +3518,7 @@ async fn audit_gc_one(
          find . -maxdepth 1 -type f -name 'events-*.jsonl' -printf '%T@ %f\\n' 2>/dev/null \
          || true"
     );
-    let listing = run_audit_shell(host, &list_script).await?;
+    let listing = run_audit_shell(host, key_path, &list_script).await?;
 
     let mut to_remove: Vec<String> = Vec::new();
     for line in listing.lines() {
@@ -3533,7 +3547,7 @@ async fn audit_gc_one(
         .collect::<Vec<_>>()
         .join(" ");
     let rm_script = format!("cd {AUDIT_DIR} && rm -f {names}");
-    run_audit_shell(host, &rm_script).await?;
+    run_audit_shell(host, key_path, &rm_script).await?;
     Ok(to_remove.len())
 }
 

--- a/yoink/src/main.rs
+++ b/yoink/src/main.rs
@@ -1893,11 +1893,9 @@ async fn do_up_once(config: &Config, up: &UpOptions<'_>, dry_run: bool) -> Resul
     let run_ctx_for_closure = run_ctx.clone();
     let mut sink = move |service: Option<&str>, event: deploy::DeployEvent| {
         eprintln!("{}", output::format_deploy_event(service, &event));
-        if let Some((host, kind)) = yoink::audit::map_deploy_event(
-            service,
-            &event,
-            &|svc| tag_lookup.get(svc).cloned().unwrap_or_default(),
-        ) {
+        if let Some((host, kind)) = yoink::audit::map_deploy_event(service, &event, &|svc| {
+            tag_lookup.get(svc).cloned().unwrap_or_default()
+        }) {
             let ev = yoink::audit::build_event(&run_ctx_for_closure, host, kind);
             let _ = audit_tx.send(ev);
         }
@@ -3326,9 +3324,7 @@ async fn cmd_audit(config: &Config, action: AuditAction) -> Result<()> {
             )
             .await
         }
-        AuditAction::Run { deploy_id, format } => {
-            cmd_audit_run(config, &deploy_id, format).await
-        }
+        AuditAction::Run { deploy_id, format } => cmd_audit_run(config, &deploy_id, format).await,
         AuditAction::Gc {
             keep,
             host,
@@ -3486,11 +3482,7 @@ async fn cmd_audit_log(
     Ok(())
 }
 
-async fn cmd_audit_run(
-    config: &Config,
-    deploy_id: &str,
-    format: TableFormat,
-) -> Result<()> {
+async fn cmd_audit_run(config: &Config, deploy_id: &str, format: TableFormat) -> Result<()> {
     cmd_audit_log(
         config,
         None,
@@ -3762,10 +3754,7 @@ fn audit_event_summary(kind: &yoink::audit::AuditEventKind) -> String {
             if *ok {
                 format!("{command} ok")
             } else {
-                format!(
-                    "{command} FAILED: {}",
-                    error.as_deref().unwrap_or("")
-                )
+                format!("{command} FAILED: {}", error.as_deref().unwrap_or(""))
             }
         }
         K::LockAcquired | K::LockReleased => String::new(),
@@ -3808,10 +3797,7 @@ fn audit_event_summary(kind: &yoink::audit::AuditEventKind) -> String {
             service,
             container,
             log_tail,
-        } => format!(
-            "{service} {container} ({} log lines)",
-            log_tail.len()
-        ),
+        } => format!("{service} {container} ({} log lines)", log_tail.len()),
         K::RollbackStarted {
             service,
             target_tag,

--- a/yoink/src/main.rs
+++ b/yoink/src/main.rs
@@ -991,10 +991,12 @@ enum LockAction {
 /// emits new audit events.
 #[derive(clap::Subcommand)]
 enum AuditAction {
-    /// Stream the on-host audit JSONL across every host (or a filtered
-    /// subset). Default ordering: newest first.
+    /// Merge events from the operator-side log
+    /// (`$XDG_STATE_HOME/yoink/audit/events.jsonl`) with each host's
+    /// on-host log, dedupe on `event_id`, sort newest-first.
     Log {
-        /// Restrict to one host's events instead of merging the fleet.
+        /// Restrict to one host's events. Skips the operator log too;
+        /// pass `--origin operator` to keep just the operator side.
         #[arg(long)]
         host: Option<String>,
         /// Restrict to one service.
@@ -1006,6 +1008,11 @@ enum AuditAction {
         /// Filter by event name (e.g. `ContainerCreated`). Repeatable.
         #[arg(long, value_name = "NAME", action = clap::ArgAction::Append)]
         event: Vec<String>,
+        /// Restrict to events written on the operator side
+        /// (`RunStarted`/`RunFinished`, validation/build failures) or
+        /// host side (per-host container ops, lock acquire/release).
+        #[arg(long, value_name = "operator|host")]
+        origin: Option<String>,
         /// Window relative to now: `30m`, `24h`, `7d`. Default: `7d`.
         #[arg(long, value_name = "DURATION", default_value = "7d")]
         since: String,
@@ -1817,34 +1824,40 @@ async fn do_up_once(config: &Config, up: &UpOptions<'_>, dry_run: bool) -> Resul
         lock.spawn_heartbeat(ops.clone());
     }
 
-    // Audit log: one sink for the whole run. We register every host
-    // up-front so per-event SSH writes know where to land. The
-    // RunStarted/LockAcquired envelope events fire here; their
-    // counterparts (LockReleased/RunFinished) fire after reconcile.
+    // Audit log: two sinks per run. The operator sink writes locally
+    // and records run-level facts that aren't host-specific
+    // (`RunStarted`, `RunFinished`, plus operator-only failures that
+    // never reach a host). The host sink writes via SSH and records
+    // per-host events (lock acquire/release, container ops). Read-time
+    // dedup on `event_id` keeps the merged view safe even if a future
+    // change starts double-writing.
     let host_audit = std::sync::Arc::new(yoink::audit::HostAuditSink::new());
     for host_cfg in &config.hosts {
         host_audit.register(Host::from(host_cfg)).await;
     }
     let audit_sink: std::sync::Arc<dyn yoink::audit::AuditSink> = host_audit.clone();
+    let operator_sink: std::sync::Arc<dyn yoink::audit::AuditSink> =
+        std::sync::Arc::new(yoink::audit::OperatorAuditSink::new());
     let run_ctx = yoink::audit::RunContext::new("up");
     let selected_service_names: Vec<String> = config
         .selected_services(services_filter)
         .map(|s| s.name.clone())
         .collect();
-    // Emit RunStarted + LockAcquired for each host (forensic; flushes
-    // immediately).
+    // RunStarted is a fleet-wide fact — one operator-side line per
+    // run, not per host. LockAcquired is per-host (the lock is on the
+    // host's docker daemon) so it stays on each host's log.
+    yoink::audit::emit_operator(
+        &operator_sink,
+        &run_ctx,
+        "",
+        yoink::audit::AuditEventKind::RunStarted {
+            command: "up".into(),
+            services: selected_service_names.clone(),
+        },
+    )
+    .await;
     for host_cfg in &config.hosts {
         let host = Host::from(host_cfg);
-        yoink::audit::emit(
-            &audit_sink,
-            &run_ctx,
-            &host.address,
-            yoink::audit::AuditEventKind::RunStarted {
-                command: "up".into(),
-                services: selected_service_names.clone(),
-            },
-        )
-        .await;
         yoink::audit::emit(
             &audit_sink,
             &run_ctx,
@@ -1945,8 +1958,8 @@ async fn do_up_once(config: &Config, up: &UpOptions<'_>, dry_run: bool) -> Resul
         lock.release(&*ops).await;
     }
 
-    // Audit envelope: LockReleased + RunFinished per host, then a
-    // final flush to drain any remaining progress events.
+    // LockReleased is per-host (mirrors LockAcquired). RunFinished is
+    // a fleet-wide fact and lands once, operator-side.
     let ok = reconcile_result.is_ok();
     let err_msg = reconcile_result
         .as_ref()
@@ -1961,19 +1974,20 @@ async fn do_up_once(config: &Config, up: &UpOptions<'_>, dry_run: bool) -> Resul
             yoink::audit::AuditEventKind::LockReleased,
         )
         .await;
-        yoink::audit::emit(
-            &audit_sink,
-            &run_ctx,
-            &host.address,
-            yoink::audit::AuditEventKind::RunFinished {
-                command: "up".into(),
-                ok,
-                error: err_msg.clone(),
-            },
-        )
-        .await;
     }
+    yoink::audit::emit_operator(
+        &operator_sink,
+        &run_ctx,
+        "",
+        yoink::audit::AuditEventKind::RunFinished {
+            command: "up".into(),
+            ok,
+            error: err_msg.clone(),
+        },
+    )
+    .await;
     audit_sink.flush().await;
+    operator_sink.flush().await;
 
     let reports = reconcile_result.context("reconcile")?;
     eprintln!("{}", output::format_deploy_summary(&reports));
@@ -3294,6 +3308,7 @@ async fn cmd_audit(config: &Config, action: AuditAction) -> Result<()> {
             service,
             deploy_id,
             event,
+            origin,
             since,
             limit,
             format,
@@ -3304,6 +3319,7 @@ async fn cmd_audit(config: &Config, action: AuditAction) -> Result<()> {
                 service.as_deref(),
                 deploy_id.as_deref(),
                 &event,
+                origin.as_deref(),
                 &since,
                 limit,
                 format,
@@ -3321,10 +3337,9 @@ async fn cmd_audit(config: &Config, action: AuditAction) -> Result<()> {
     }
 }
 
-/// Pull `/var/lib/yoink/audit/events.jsonl` from each host (and any
-/// rotated files when `--since` reaches further back), parse each line,
-/// filter, sort newest-first, format. Failures on any individual host
-/// print a stderr warning but don't abort the whole listing.
+/// Read the operator-side JSONL log + every host's on-host JSONL log,
+/// merge, dedupe on `event_id`, filter, sort newest-first, format.
+/// Per-host fetch failures print a stderr warning but don't abort.
 #[allow(clippy::too_many_arguments)]
 async fn cmd_audit_log(
     config: &Config,
@@ -3332,6 +3347,7 @@ async fn cmd_audit_log(
     service_filter: Option<&str>,
     deploy_id_filter: Option<&str>,
     event_filter: &[String],
+    origin_filter: Option<&str>,
     since: &str,
     limit: usize,
     format: TableFormat,
@@ -3341,10 +3357,15 @@ async fn cmd_audit_log(
     let cutoff_secs = parse_since(since)?;
     let cutoff_unix = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
-        .map(|d| d.as_secs())
-        .unwrap_or(0)
+        .map_or(0, |d| d.as_secs())
         .saturating_sub(cutoff_secs);
     let want_rotated = cutoff_secs > 24 * 3600;
+
+    if let Some(o) = origin_filter
+        && !matches!(o, "operator" | "host")
+    {
+        anyhow::bail!("--origin must be 'operator' or 'host', got {o:?}");
+    }
 
     let hosts: Vec<Host> = config
         .hosts
@@ -3352,44 +3373,60 @@ async fn cmd_audit_log(
         .filter(|h| host_filter.is_none_or(|f| h.address == f))
         .map(Host::from)
         .collect();
-    if hosts.is_empty() {
-        anyhow::bail!("no hosts match the filter (or no hosts configured)");
-    }
     let event_set: std::collections::HashSet<&str> =
         event_filter.iter().map(String::as_str).collect();
 
-    let fetches = hosts.iter().map(|h| async move {
-        let host = h.clone();
-        let bytes = fetch_audit_files(&host, want_rotated).await;
-        (host, bytes)
-    });
-    let results = futures_util::future::join_all(fetches).await;
-
+    // Fetch in parallel: operator log (always) + each host's log.
+    // `--host <ADDR>` scopes the host fetch to one entry; the operator
+    // log is still pulled because operator events list the run, not a
+    // specific host. Pass `--origin host` together with `--host` to
+    // see only the named host.
     let mut all: Vec<AuditEvent> = Vec::new();
-    for (host, fetch) in results {
-        match fetch {
-            Ok(bytes) => {
-                for line in bytes.lines() {
-                    let trimmed = line.trim();
-                    if trimmed.is_empty() {
-                        continue;
-                    }
-                    match serde_json::from_str::<AuditEvent>(trimmed) {
-                        Ok(ev) => all.push(ev),
-                        Err(e) => eprintln!(
-                            "yoink audit: skip malformed event from {}: {e}",
-                            host.address
-                        ),
-                    }
-                }
-            }
-            Err(e) => eprintln!("yoink audit: fetch failed on {}: {e}", host.address),
+
+    // Operator side — local file read, no SSH. Skipped only if the
+    // caller explicitly asked for `--origin host`.
+    let want_operator = origin_filter != Some("host");
+    if want_operator {
+        match read_operator_audit_files(want_rotated).await {
+            Ok(bytes) => parse_into(&mut all, &bytes, "operator log"),
+            Err(e) => eprintln!("yoink audit: read operator log failed: {e}"),
         }
     }
 
+    // Host side — SSH cat each host. Skipped if the caller asked for
+    // `--origin operator`. With no configured hosts and origin=host,
+    // we'd otherwise leave the user with an empty result; bail loud.
+    let want_host = origin_filter != Some("operator");
+    if want_host {
+        if hosts.is_empty() && origin_filter == Some("host") {
+            anyhow::bail!("no hosts match the filter (or no hosts configured)");
+        }
+        let fetches = hosts.iter().map(|h| async move {
+            let host = h.clone();
+            let bytes = fetch_audit_files(&host, want_rotated).await;
+            (host, bytes)
+        });
+        let results = futures_util::future::join_all(fetches).await;
+        for (host, fetch) in results {
+            match fetch {
+                Ok(bytes) => parse_into(&mut all, &bytes, &host.address),
+                Err(e) => eprintln!("yoink audit: fetch failed on {}: {e}", host.address),
+            }
+        }
+    }
+
+    // One pass: dedupe on event_id (an SSH retry double-write would
+    // otherwise show twice) plus apply filters. Lexicographic compare
+    // on the RFC3339 `ts` against the cutoff is correct because the
+    // format is big-endian and zero-padded.
+    let cutoff_str = yoink::audit::ts_string_for(cutoff_unix);
+    let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
     all.retain(|ev| {
+        if !seen.insert(ev.event_id.clone()) {
+            return false;
+        }
         if let Some(svc) = service_filter
-            && !audit_event_service(ev).is_some_and(|s| s == svc)
+            && audit_event_service(ev).is_none_or(|s| s != svc)
         {
             return false;
         }
@@ -3398,16 +3435,14 @@ async fn cmd_audit_log(
         {
             return false;
         }
-        if !event_set.is_empty() {
-            let name = audit_event_name(&ev.kind);
-            if !event_set.contains(name) {
-                return false;
-            }
+        if let Some(o) = origin_filter
+            && ev.origin != o
+        {
+            return false;
         }
-        // Cheap "is this newer than cutoff" filter on the RFC3339
-        // string. Lexicographic compare works because the format is
-        // big-endian (year first, padded).
-        let cutoff_str = yoink::audit::ts_string_for(cutoff_unix);
+        if !event_set.is_empty() && !event_set.contains(audit_event_name(&ev.kind)) {
+            return false;
+        }
         ev.ts >= cutoff_str
     });
 
@@ -3431,17 +3466,18 @@ async fn cmd_audit_log(
             let mut buf = String::new();
             writeln!(
                 buf,
-                "{:<24}  {:<22}  {:<24}  {:<28}  {}",
-                "ts", "host", "deploy_id", "event", "details"
+                "{:<24}  {:<8}  {:<22}  {:<24}  {:<28}  details",
+                "ts", "origin", "host", "deploy_id", "event"
             )?;
             for ev in &all {
                 let name = audit_event_name(&ev.kind);
                 let details = audit_event_summary(&ev.kind);
                 let id_short: String = ev.deploy_id.chars().take(24).collect();
+                let host_display = if ev.host.is_empty() { "—" } else { &ev.host };
                 writeln!(
                     buf,
-                    "{:<24}  {:<22}  {:<24}  {:<28}  {}",
-                    ev.ts, ev.host, id_short, name, details
+                    "{:<24}  {:<8}  {:<22}  {:<24}  {:<28}  {}",
+                    ev.ts, ev.origin, host_display, id_short, name, details
                 )?;
             }
             page_output(&buf);
@@ -3461,6 +3497,7 @@ async fn cmd_audit_run(
         None,
         Some(deploy_id),
         &[],
+        None,
         // Pulling rotated files too: a run from weeks ago could have
         // landed in a rotated file already.
         "365d",
@@ -3480,8 +3517,7 @@ async fn cmd_audit_gc(
     let secs = parse_since(keep)?;
     let cutoff_unix = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
-        .map(|d| d.as_secs())
-        .unwrap_or(0)
+        .map_or(0, |d| d.as_secs())
         .saturating_sub(secs);
 
     let hosts: Vec<Host> = config
@@ -3517,6 +3553,82 @@ async fn cmd_audit_gc(
     Ok(())
 }
 
+/// Read the operator-side audit files. Returns the concatenated bytes
+/// of `events.jsonl` plus (when `include_rotated`) every
+/// `events-*.jsonl`. Missing files are silently treated as empty.
+async fn read_operator_audit_files(include_rotated: bool) -> Result<String> {
+    use yoink::audit::{operator_audit_dir, operator_audit_file};
+    let mut out = String::new();
+    if let Ok(bytes) = tokio::fs::read_to_string(operator_audit_file()).await {
+        out.push_str(&bytes);
+    }
+    if include_rotated {
+        let dir = operator_audit_dir();
+        if let Ok(mut rd) = tokio::fs::read_dir(&dir).await {
+            while let Ok(Some(entry)) = rd.next_entry().await {
+                let name = entry.file_name();
+                let name_str = name.to_string_lossy();
+                if name_str.starts_with("events-")
+                    && name_str.ends_with(".jsonl")
+                    && let Ok(bytes) = tokio::fs::read_to_string(entry.path()).await
+                {
+                    out.push_str(&bytes);
+                }
+            }
+        }
+    }
+    Ok(out)
+}
+
+/// Parse a JSONL blob into the running `acc` vector. Malformed lines
+/// are skipped with a stderr warning labeled by `source` (the host
+/// address, or `"operator log"` for the local file).
+fn parse_into(acc: &mut Vec<yoink::audit::AuditEvent>, bytes: &str, source: &str) {
+    for line in bytes.lines() {
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        match serde_json::from_str::<yoink::audit::AuditEvent>(trimmed) {
+            Ok(ev) => acc.push(ev),
+            Err(e) => eprintln!("yoink audit: skip malformed event from {source}: {e}"),
+        }
+    }
+}
+
+/// Run `script` on `host`'s shell. Local synthetic host → `sh -c`;
+/// remote → `ssh -o BatchMode=yes user@addr script`. Returns captured
+/// stdout. Used by every audit read/gc path so the local/remote split
+/// lives in one place.
+async fn run_audit_shell(host: &yoink::docker_ops::Host, script: &str) -> Result<String> {
+    let output = if host.is_local() {
+        tokio::process::Command::new("sh")
+            .arg("-c")
+            .arg(script)
+            .output()
+            .await
+            .context("local sh -c")?
+    } else {
+        tokio::process::Command::new("ssh")
+            .arg("-o")
+            .arg("BatchMode=yes")
+            .arg(format!("{}@{}", host.user, host.address))
+            .arg(script)
+            .output()
+            .await
+            .with_context(|| format!("ssh {}@{}", host.user, host.address))?
+    };
+    if !output.status.success() {
+        let prog = if host.is_local() { "sh" } else { "ssh" };
+        anyhow::bail!(
+            "{prog} exit {:?}: {}",
+            output.status.code(),
+            String::from_utf8_lossy(&output.stderr).trim()
+        );
+    }
+    Ok(String::from_utf8_lossy(&output.stdout).into_owned())
+}
+
 /// Cat the active audit file plus rotated files (when requested) on
 /// `host` and return the concatenated bytes. Empty string when the
 /// path doesn't exist (host is fresh and has never been deployed to).
@@ -3525,44 +3637,14 @@ async fn fetch_audit_files(
     include_rotated: bool,
 ) -> Result<String> {
     use yoink::audit::{AUDIT_DIR, AUDIT_FILE};
-    let cmd = if include_rotated {
-        // Glob for active + rotated. cat ignores missing files
-        // gracefully via 2>/dev/null.
-        format!(
-            "cat {file} {dir}/events-*.jsonl 2>/dev/null || true",
-            dir = AUDIT_DIR,
-            file = AUDIT_FILE
-        )
+    // `cat … || true` makes a missing file (fresh host) read as empty
+    // instead of erroring; the `2>/dev/null` swallows the cat warning.
+    let script = if include_rotated {
+        format!("cat {AUDIT_FILE} {AUDIT_DIR}/events-*.jsonl 2>/dev/null || true")
     } else {
         format!("cat {AUDIT_FILE} 2>/dev/null || true")
     };
-    let out = if host.is_local() {
-        let output = tokio::process::Command::new("sh")
-            .arg("-c")
-            .arg(&cmd)
-            .output()
-            .await
-            .with_context(|| format!("local sh -c {cmd:?}"))?;
-        String::from_utf8_lossy(&output.stdout).into_owned()
-    } else {
-        let output = tokio::process::Command::new("ssh")
-            .arg("-o")
-            .arg("BatchMode=yes")
-            .arg(format!("{}@{}", host.user, host.address))
-            .arg(&cmd)
-            .output()
-            .await
-            .with_context(|| format!("ssh {}@{}", host.user, host.address))?;
-        if !output.status.success() {
-            anyhow::bail!(
-                "ssh exit {:?}: {}",
-                output.status.code(),
-                String::from_utf8_lossy(&output.stderr).trim()
-            );
-        }
-        String::from_utf8_lossy(&output.stdout).into_owned()
-    };
-    Ok(out)
+    run_audit_shell(host, &script).await
 }
 
 async fn audit_gc_one(
@@ -3571,30 +3653,14 @@ async fn audit_gc_one(
     dry_run: bool,
 ) -> Result<usize> {
     use yoink::audit::AUDIT_DIR;
-    // List rotated files with mtime in unix seconds — `find` is
-    // POSIX-portable enough for the fleet we target.
-    let list_cmd = format!(
+    // POSIX-portable enough for the fleet we target. `-printf '%T@ %f'`
+    // gives `<float-mtime> <basename>` per line.
+    let list_script = format!(
         "cd {AUDIT_DIR} 2>/dev/null && \
          find . -maxdepth 1 -type f -name 'events-*.jsonl' -printf '%T@ %f\\n' 2>/dev/null \
          || true"
     );
-    let listing = if host.is_local() {
-        let out = tokio::process::Command::new("sh")
-            .arg("-c")
-            .arg(&list_cmd)
-            .output()
-            .await?;
-        String::from_utf8_lossy(&out.stdout).into_owned()
-    } else {
-        let out = tokio::process::Command::new("ssh")
-            .arg("-o")
-            .arg("BatchMode=yes")
-            .arg(format!("{}@{}", host.user, host.address))
-            .arg(&list_cmd)
-            .output()
-            .await?;
-        String::from_utf8_lossy(&out.stdout).into_owned()
-    };
+    let listing = run_audit_shell(host, &list_script).await?;
 
     let mut to_remove: Vec<String> = Vec::new();
     for line in listing.lines() {
@@ -3603,8 +3669,13 @@ async fn audit_gc_one(
             continue;
         };
         let Some(name) = parts.next() else { continue };
-        let mtime: f64 = mtime_str.parse().unwrap_or(0.0);
-        if (mtime as u64) < cutoff_unix {
+        // `find -printf '%T@'` emits a float "<seconds>.<nanos>"; we
+        // only need second-resolution for the retention compare. Cast
+        // is safe: mtimes are non-negative, and 2^64 seconds is ~5.8e11
+        // years past the heat death of the universe.
+        #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+        let mtime_secs = mtime_str.parse::<f64>().unwrap_or(0.0) as u64;
+        if mtime_secs < cutoff_unix {
             to_remove.push(name.trim_start_matches("./").to_string());
         }
     }
@@ -3612,38 +3683,22 @@ async fn audit_gc_one(
         return Ok(to_remove.len());
     }
 
-    let rm_cmd = {
-        let names = to_remove
-            .iter()
-            .map(|n| format!("'{}'", n.replace('\'', "'\\''")))
-            .collect::<Vec<_>>()
-            .join(" ");
-        format!("cd {AUDIT_DIR} && rm -f {names}")
-    };
-    if host.is_local() {
-        tokio::process::Command::new("sh")
-            .arg("-c")
-            .arg(&rm_cmd)
-            .status()
-            .await?;
-    } else {
-        tokio::process::Command::new("ssh")
-            .arg("-o")
-            .arg("BatchMode=yes")
-            .arg(format!("{}@{}", host.user, host.address))
-            .arg(&rm_cmd)
-            .status()
-            .await?;
-    }
+    let names = to_remove
+        .iter()
+        .map(|n| format!("'{}'", n.replace('\'', "'\\''")))
+        .collect::<Vec<_>>()
+        .join(" ");
+    let rm_script = format!("cd {AUDIT_DIR} && rm -f {names}");
+    run_audit_shell(host, &rm_script).await?;
     Ok(to_remove.len())
 }
 
-/// Parse a `humantime`-style duration like `7d`, `30m`, `24h` into
-/// seconds. Defaults to 0 on parse failure with an error.
+/// Whole-second view of [`parse_humantime`], for the audit-side
+/// `--since` / `--keep` flags that operate on epoch seconds.
 fn parse_since(s: &str) -> Result<u64> {
-    humantime::parse_duration(s)
+    parse_humantime(s)
         .map(|d| d.as_secs())
-        .with_context(|| format!("invalid duration {s:?}"))
+        .map_err(|e| anyhow::anyhow!(e))
 }
 
 /// Best-effort label for `AuditEventKind` in the text-format table.
@@ -3675,7 +3730,7 @@ fn audit_event_name(kind: &yoink::audit::AuditEventKind) -> &'static str {
 }
 
 /// Service field on event kinds that have one; `None` for envelope
-/// events (RunStarted, LockAcquired, etc.).
+/// events (`RunStarted`, `LockAcquired`, etc.).
 fn audit_event_service(ev: &yoink::audit::AuditEvent) -> Option<&str> {
     use yoink::audit::AuditEventKind as K;
     match &ev.kind {
@@ -3713,8 +3768,7 @@ fn audit_event_summary(kind: &yoink::audit::AuditEventKind) -> String {
                 )
             }
         }
-        K::LockAcquired => String::new(),
-        K::LockReleased => String::new(),
+        K::LockAcquired | K::LockReleased => String::new(),
         K::HookStarted { name } | K::HookFinished { name } => name.clone(),
         K::PullStarted { image, tag } | K::PullFinished { image, tag } => {
             format!("{image}:{tag}")

--- a/yoink/src/main.rs
+++ b/yoink/src/main.rs
@@ -3361,19 +3361,23 @@ async fn cmd_audit_log(
         anyhow::bail!("no hosts match the filter (or no hosts configured)");
     }
 
-    // Build the ops handle so we can resolve `ssh_key_secret:` keys
-    // for hosts that need them. `build_real_ops` short-circuits to a
-    // no-key handle when no host declares one, so the common path
-    // doesn't pay for sealed-bundle decryption.
-    let bundle = load_secrets_bundle(config).await?;
-    let ops = build_real_ops(config, bundle.as_ref()).await?;
-
     let opts = FetchOptions {
         host_filter: host_filter.map(str::to_string),
         since_secs: parse_since(since)?,
         origin: origin_filter.map(str::to_string),
     };
-    let outcome = fetch_events(&hosts, &opts, |h| ops.ssh_keyfile(h)).await;
+    // Resolve `ssh_key_secret:` keypair tempfiles only when we'll
+    // actually SSH out — `--origin operator` reads the local file
+    // and never touches a host, so skip the bundle load entirely.
+    let ops = if origin_filter == Some("operator") {
+        None
+    } else {
+        Some(build_real_ops(config, None).await?)
+    };
+    let outcome = fetch_events(&hosts, &opts, |h| {
+        ops.as_ref().and_then(|o| o.ssh_keyfile(h))
+    })
+    .await;
     for (source, msg) in &outcome.errors {
         eprintln!("yoink audit: {source}: {msg}");
     }
@@ -3475,10 +3479,10 @@ async fn cmd_audit_gc(
         anyhow::bail!("no hosts match the filter (or no hosts configured)");
     }
 
-    // Resolve sealed SSH keys for hosts that need them; same shape as
-    // `cmd_audit_log`. Build once, reuse across hosts.
-    let bundle = load_secrets_bundle(config).await?;
-    let ops = build_real_ops(config, bundle.as_ref()).await?;
+    // Resolve sealed SSH keys for hosts that need them. `build_real_ops`
+    // short-circuits to a no-key handle when no host declares one, so
+    // the common path doesn't pay for sealed-bundle decryption.
+    let ops = build_real_ops(config, None).await?;
 
     let mut removed = 0_usize;
     for host in hosts {

--- a/yoink/src/tui/app.rs
+++ b/yoink/src/tui/app.rs
@@ -1902,10 +1902,7 @@ impl App {
         // supports filtering — Logs handles its own filter inline,
         // and Audit owns its filter state outside the shared
         // `FilterState`, so both fall through to pane-local dispatch).
-        if key.code == KeyCode::Char('/')
-            && !logs_view
-            && !matches!(self.view, View::Audit)
-        {
+        if key.code == KeyCode::Char('/') && !logs_view && !matches!(self.view, View::Audit) {
             self.begin_pane_filter_input();
             return false;
         }

--- a/yoink/src/tui/app.rs
+++ b/yoink/src/tui/app.rs
@@ -89,6 +89,7 @@ pub enum Mode {
     Logs,
     Resources,
     Secrets,
+    Audit,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -130,6 +131,10 @@ pub enum View {
     /// containers — Images / Volumes / Networks tabs. Reaches lazydocker
     /// feature parity for browsing local docker state.
     Resources,
+    /// On-host JSONL audit log, merged with the operator-side log,
+    /// rendered as a sortable / filterable table. Same data path as
+    /// `yoink audit log`. Activated with `A` from the dashboard.
+    Audit,
 }
 
 impl View {
@@ -148,6 +153,7 @@ impl View {
             View::Logs => 3,
             View::Resources => 4,
             View::Secrets => 5,
+            View::Audit => 6,
         }
     }
 
@@ -159,8 +165,8 @@ impl View {
         let global = vec![
             "global",
             "  q / Ctrl-C    quit yoink",
-            "  1 2 3 4 5 6   dashboard / hosts / services / logs / resources / secrets",
-            "  d h s l R e   same panes, letter aliases (R = resources, e = secrets)",
+            "  1 2 3 4 5 6 7  dashboard / hosts / services / logs / resources / secrets / audit",
+            "  d h s l R e a same panes, letter aliases (R = resources, e = secrets, a = audit)",
             "  Tab / S-Tab   cycle panes forward / backward",
             "  D             doctor — diagnose deploy-blockers",
             "  E             edit config in $EDITOR (jumps to focused service/host)",
@@ -300,6 +306,14 @@ impl View {
                 "  Ctrl-C/D     forwarded into the in-shell process",
                 "  exit / Ctrl-D end the in-container shell",
             ],
+            View::Audit => vec![
+                "audit log",
+                "  ↑↓ / j k     select row",
+                "  enter        toggle detail (event_id, log_tail for failed deploys)",
+                "  /            filter substring (host / event / summary / actor)",
+                "  r            refresh",
+                "  esc          clear filter or back to dashboard",
+            ],
         };
         let mut out = global;
         out.extend(view_specific);
@@ -350,6 +364,7 @@ impl View {
             ],
             View::Secrets => vec![root, "Secrets".into()],
             View::Resources => vec![root, "Resources".into()],
+            View::Audit => vec![root, "Audit".into()],
         }
     }
 }
@@ -363,6 +378,7 @@ impl From<Mode> for View {
             Mode::Logs => View::Logs,
             Mode::Secrets => View::Secrets,
             Mode::Resources => View::Resources,
+            Mode::Audit => View::Audit,
         }
     }
 }
@@ -463,6 +479,14 @@ enum Update {
         url: String,
         tunnel: crate::transport::tunnel::SshTunnel,
         sidecar: crate::pf::SidecarHandle,
+    },
+    /// Result of `schedule_audit_refresh` — merged operator + per-host
+    /// JSONL events, deduped on `event_id`, sorted newest-first.
+    /// `errors` carries per-source failures so the pane can surface
+    /// them instead of silently dropping unreachable hosts.
+    Audit {
+        events: Vec<crate::audit::AuditEvent>,
+        errors: Vec<(String, String)>,
     },
 }
 
@@ -812,6 +836,7 @@ pub struct App {
     pub services: ServicesState,
     pub service_detail: ServiceDetailState,
     pub history: super::history::HistoryState,
+    pub audit: super::audit::AuditState,
     pub container_detail: ContainerDetailState,
     pub logs: LogsState,
     pub resources: ResourcesState,
@@ -905,6 +930,7 @@ pub struct App {
     dashboard_in_flight: bool,
     container_detail_in_flight: bool,
     history_in_flight: bool,
+    audit_in_flight: bool,
     resources_in_flight: bool,
     /// Per-host docker-event ring buffer (formatted for display).
     /// Newest entries pushed at the back. Drives the events panel
@@ -973,6 +999,7 @@ impl App {
             services: ServicesState::new(),
             service_detail: ServiceDetailState::new(),
             history: super::history::HistoryState::new(),
+            audit: super::audit::AuditState::new(),
             container_detail: ContainerDetailState::new(),
             logs: LogsState::new(),
             resources: ResourcesState::new(),
@@ -1005,6 +1032,7 @@ impl App {
             dashboard_in_flight: false,
             container_detail_in_flight: false,
             history_in_flight: false,
+            audit_in_flight: false,
             resources_in_flight: false,
             host_events: std::collections::HashMap::new(),
             container_history: std::collections::HashMap::new(),
@@ -1810,6 +1838,21 @@ impl App {
             return false;
         }
 
+        // Audit pane owns its own substring filter input — same shape
+        // as the secrets edit gate. Captured before navigation so a
+        // digit / `s` / `q` typed into the filter can't shoot off a
+        // tab transition or quit.
+        if matches!(self.view, View::Audit) && self.audit.editing_filter() {
+            match key.code {
+                KeyCode::Esc => self.audit.cancel_filter(),
+                KeyCode::Enter => self.audit.commit_filter(),
+                KeyCode::Backspace => self.audit.backspace_filter(),
+                KeyCode::Char(c) => self.audit.type_filter(c),
+                _ => {}
+            }
+            return false;
+        }
+
         // Reconcile-progress modal: while running, eat all keys
         // (Ctrl-C/Q already handled above) so a stray j/k can't
         // navigate the underlying view. `y` always works to yank
@@ -1856,8 +1899,13 @@ impl App {
         }
 
         // `/` enters filter input mode for the current pane (when it
-        // supports filtering — Logs handled separately above).
-        if key.code == KeyCode::Char('/') && !logs_view {
+        // supports filtering — Logs handles its own filter inline,
+        // and Audit owns its filter state outside the shared
+        // `FilterState`, so both fall through to pane-local dispatch).
+        if key.code == KeyCode::Char('/')
+            && !logs_view
+            && !matches!(self.view, View::Audit)
+        {
             self.begin_pane_filter_input();
             return false;
         }
@@ -1892,6 +1940,13 @@ impl App {
             }
             KeyCode::Char('6' | 'e') => {
                 self.transition(View::Secrets).await;
+                return false;
+            }
+            // `7` is the canonical tab digit; `a` is the letter alias.
+            // Lowercase `a` is unused elsewhere as a global; capital `A`
+            // is taken on Dashboard ("reconcile ALL").
+            KeyCode::Char('7' | 'a') => {
+                self.transition(View::Audit).await;
                 return false;
             }
             // Capital `D` opens the doctor modal — runs the same checks
@@ -2001,6 +2056,7 @@ impl App {
                     2 => View::Logs,
                     3 => View::Resources,
                     4 => View::Secrets,
+                    5 => View::Audit,
                     _ => View::Dashboard,
                 };
                 self.transition(next).await;
@@ -2008,12 +2064,13 @@ impl App {
             }
             KeyCode::BackTab => {
                 let prev = match self.view.top_section() {
-                    0 => View::Secrets,
+                    0 => View::Audit,
                     1 => View::Dashboard,
                     2 => View::Hosts,
                     3 => View::Services,
                     4 => View::Logs,
-                    _ => View::Resources,
+                    5 => View::Resources,
+                    _ => View::Secrets,
                 };
                 self.transition(prev).await;
                 return false;
@@ -2410,6 +2467,26 @@ impl App {
                 KeyCode::Char('r') => self.schedule_resources_refresh(),
                 _ => {}
             },
+            View::Audit => match key.code {
+                // Filter-edit mode is intercepted at the top of `on_key`,
+                // so by the time we get here we're in the navigation
+                // mode of the audit pane.
+                KeyCode::Up | KeyCode::Char('k') => self.audit.select_prev(),
+                KeyCode::Down | KeyCode::Char('j') => self.audit.select_next(),
+                KeyCode::Enter => self.audit.toggle_expand(),
+                KeyCode::Char('/') => self.audit.begin_filter(),
+                KeyCode::Char('r') => self.schedule_audit_refresh(),
+                // Two-stage Esc: clears the filter on the first press
+                // if one is set, then exits to Dashboard on the second.
+                KeyCode::Esc => {
+                    if self.audit.filter_active() {
+                        self.audit.clear_filter();
+                    } else {
+                        self.transition(View::Dashboard).await;
+                    }
+                }
+                _ => {}
+            },
         }
         false
     }
@@ -2616,6 +2693,9 @@ impl App {
             View::Resources => {
                 self.schedule_resources_refresh();
             }
+            View::Audit => {
+                self.schedule_audit_refresh();
+            }
         }
         self.view = new_view;
     }
@@ -2669,6 +2749,33 @@ impl App {
                 service,
                 rows,
                 errors,
+            });
+        });
+    }
+
+    /// Read the merged operator + per-host audit JSONL via
+    /// `audit::fetch_events`. Local file I/O for the operator log,
+    /// SSH `cat` for each host. Posts `Update::Audit` back to the run
+    /// loop.
+    fn schedule_audit_refresh(&mut self) {
+        if self.audit_in_flight {
+            return;
+        }
+        self.audit_in_flight = true;
+        let hosts: Vec<Host> = self.config.hosts.iter().map(Host::from).collect();
+        let tx = self.update_tx.clone();
+        tokio::spawn(async move {
+            // 7-day window matches the CLI default. The pane reads
+            // both active and rotated files when we reach back > 24h.
+            let opts = crate::audit::FetchOptions {
+                host_filter: None,
+                since_secs: 7 * 24 * 3600,
+                origin: None,
+            };
+            let outcome = crate::audit::fetch_events(&hosts, &opts).await;
+            let _ = tx.send(Update::Audit {
+                events: outcome.events,
+                errors: outcome.errors,
             });
         });
     }
@@ -2998,6 +3105,10 @@ impl App {
             } => {
                 self.history.apply(&service, rows, errors);
                 self.history_in_flight = false;
+            }
+            Update::Audit { events, errors } => {
+                self.audit.apply(events, errors);
+                self.audit_in_flight = false;
             }
             Update::Event { host, event } => self.on_docker_event(&host, &event),
             Update::Toast(msg) => self.push_toast(msg),
@@ -3699,6 +3810,9 @@ impl App {
             View::Resources => {
                 self.resources
                     .render(frame, pane_area, &self.config, &self.throbber_state);
+            }
+            View::Audit => {
+                self.audit.render(frame, pane_area, &self.throbber_state);
             }
         }
 

--- a/yoink/src/tui/app.rs
+++ b/yoink/src/tui/app.rs
@@ -2761,6 +2761,13 @@ impl App {
         self.audit_in_flight = true;
         let hosts: Vec<Host> = self.config.hosts.iter().map(Host::from).collect();
         let tx = self.update_tx.clone();
+        // Pre-resolve sealed `ssh_key_secret` keypair paths per host
+        // so the fetch closure stays `Send + Sync`. The TUI's `ops`
+        // owns the `KeyManager` that materialized those tempfiles.
+        let key_paths: std::collections::HashMap<String, std::path::PathBuf> = hosts
+            .iter()
+            .filter_map(|h| self.ops.ssh_keyfile(h).map(|p| (h.address.clone(), p)))
+            .collect();
         tokio::spawn(async move {
             // 7-day window matches the CLI default. The pane reads
             // both active and rotated files when we reach back > 24h.
@@ -2769,7 +2776,9 @@ impl App {
                 since_secs: 7 * 24 * 3600,
                 origin: None,
             };
-            let outcome = crate::audit::fetch_events(&hosts, &opts).await;
+            let outcome =
+                crate::audit::fetch_events(&hosts, &opts, |h| key_paths.get(&h.address).cloned())
+                    .await;
             let _ = tx.send(Update::Audit {
                 events: outcome.events,
                 errors: outcome.errors,
@@ -3700,6 +3709,7 @@ impl App {
             "4 Logs",
             "5 Resources",
             "6 Secrets",
+            "7 Audit",
         ];
         let selected_tab = Some(self.view.top_section());
         super::ui::render_header(

--- a/yoink/src/tui/audit.rs
+++ b/yoink/src/tui/audit.rs
@@ -1,0 +1,534 @@
+//! Audit-log pane. Renders the same merged operator + per-host JSONL
+//! stream that `yoink audit log` produces, with a stable selection
+//! anchored on `event_id`, an `Enter`-to-expand detail view, and a `/`
+//! substring filter.
+//!
+//! Data flow mirrors `tui::history`: the pane owns rendered rows; the
+//! `App` schedules an async `audit::fetch_events` and posts the result
+//! back through the update bus.
+
+use ratatui::Frame;
+use ratatui::layout::{Constraint, Layout, Rect};
+use ratatui::style::{Color, Modifier, Style};
+use ratatui::widgets::{Block, Borders, Cell, Paragraph, Row, Table, TableState, Wrap};
+
+use crate::audit::{AuditEvent, AuditEventKind, event_name, event_summary};
+
+use super::ui::{TABLE_HIGHLIGHT_SYMBOL, bold, pane_layout, table_highlight_style};
+
+/// One pre-formatted row in the audit table. Holds the raw event so
+/// the detail-expand pane can render the full payload without re-
+/// querying the source.
+#[derive(Debug, Clone)]
+pub struct AuditRow {
+    pub event_id: String,
+    pub ts: String,
+    pub origin: String,
+    pub host: String,
+    pub deploy_id: String,
+    pub kind_name: &'static str,
+    pub summary: String,
+    pub raw: AuditEvent,
+}
+
+impl From<AuditEvent> for AuditRow {
+    fn from(ev: AuditEvent) -> Self {
+        Self {
+            event_id: ev.event_id.clone(),
+            ts: ev.ts.clone(),
+            origin: ev.origin.clone(),
+            host: ev.host.clone(),
+            deploy_id: ev.deploy_id.clone(),
+            kind_name: event_name(&ev.kind),
+            summary: event_summary(&ev.kind),
+            raw: ev,
+        }
+    }
+}
+
+#[derive(Default)]
+pub struct AuditState {
+    rows: Vec<AuditRow>,
+    table: TableState,
+    loaded: bool,
+    /// `(source, message)` from the last fetch. Surfaced in the footer
+    /// so the operator can tell "fleet is quiet" from "we couldn't
+    /// reach a host".
+    errors: Vec<(String, String)>,
+    /// Current `/`-substring filter applied to (host, kind, summary,
+    /// `deploy_id`, actor) for live narrowing. `None` means show all.
+    filter: Option<String>,
+    /// True while the operator is typing into the filter input. The
+    /// footer renders the prompt and key dispatch routes characters
+    /// into `pending_filter`.
+    editing_filter: bool,
+    pending_filter: String,
+    /// `Enter` toggles the detail panel below the table.
+    expanded: bool,
+}
+
+impl AuditState {
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Apply a fresh fetch result (already deduped + sorted newest-
+    /// first by `audit::fetch_events`). Pins the selection to the
+    /// previously-selected `event_id` when it survives the refresh.
+    pub fn apply(&mut self, events: Vec<AuditEvent>, errors: Vec<(String, String)>) {
+        let prev_id = self.selected_event_id().map(str::to_string);
+        self.rows = events.into_iter().map(AuditRow::from).collect();
+        self.errors = errors;
+        self.loaded = true;
+        let visible_len = self.visible_rows().count();
+        if visible_len == 0 {
+            self.table.select(None);
+            return;
+        }
+        let new_idx = prev_id
+            .and_then(|id| {
+                self.visible_rows()
+                    .position(|(_, r)| r.event_id == id)
+            })
+            .unwrap_or(0);
+        self.table.select(Some(new_idx.min(visible_len - 1)));
+    }
+
+    /// Iterator over `(absolute_index, row)` for rows that pass the
+    /// current substring filter. Used by both render and selection
+    /// math so the indexed positions agree.
+    fn visible_rows(&self) -> impl Iterator<Item = (usize, &AuditRow)> {
+        let needle = self.filter.as_deref().map(str::to_lowercase);
+        self.rows.iter().enumerate().filter(move |(_, r)| {
+            let Some(needle) = needle.as_deref() else {
+                return true;
+            };
+            row_matches(r, needle)
+        })
+    }
+
+    pub fn select_next(&mut self) {
+        let len = self.visible_rows().count();
+        if len == 0 {
+            return;
+        }
+        let next = self.table.selected().map_or(0, |i| (i + 1) % len);
+        self.table.select(Some(next));
+    }
+
+    pub fn select_prev(&mut self) {
+        let len = self.visible_rows().count();
+        if len == 0 {
+            return;
+        }
+        let prev = self
+            .table
+            .selected()
+            .map_or(0, |i| if i == 0 { len - 1 } else { i - 1 });
+        self.table.select(Some(prev));
+    }
+
+    pub fn toggle_expand(&mut self) {
+        self.expanded = !self.expanded;
+    }
+
+    pub fn begin_filter(&mut self) {
+        self.editing_filter = true;
+        self.pending_filter = self.filter.clone().unwrap_or_default();
+    }
+
+    pub fn type_filter(&mut self, c: char) {
+        if self.editing_filter {
+            self.pending_filter.push(c);
+        }
+    }
+
+    pub fn backspace_filter(&mut self) {
+        if self.editing_filter {
+            self.pending_filter.pop();
+        }
+    }
+
+    /// Commit the in-flight filter. Empty input clears the filter.
+    pub fn commit_filter(&mut self) {
+        self.editing_filter = false;
+        self.filter = if self.pending_filter.is_empty() {
+            None
+        } else {
+            Some(std::mem::take(&mut self.pending_filter))
+        };
+        self.pending_filter.clear();
+        // Selection may have moved out of the new visible range.
+        let len = self.visible_rows().count();
+        match self.table.selected() {
+            Some(i) if i >= len && len > 0 => self.table.select(Some(len - 1)),
+            Some(_) if len == 0 => self.table.select(None),
+            None if len > 0 => self.table.select(Some(0)),
+            _ => {}
+        }
+    }
+
+    pub fn cancel_filter(&mut self) {
+        self.editing_filter = false;
+        self.pending_filter.clear();
+    }
+
+    pub fn clear_filter(&mut self) {
+        self.filter = None;
+        self.editing_filter = false;
+        self.pending_filter.clear();
+    }
+
+    #[must_use]
+    pub fn editing_filter(&self) -> bool {
+        self.editing_filter
+    }
+
+    /// True when a substring filter is set (Esc semantics: first press
+    /// clears the filter, second press leaves the pane).
+    #[must_use]
+    pub fn filter_active(&self) -> bool {
+        self.filter.is_some()
+    }
+
+    /// `event_id` of the currently selected row, if any visible row
+    /// is selected.
+    fn selected_event_id(&self) -> Option<&str> {
+        let i = self.table.selected()?;
+        self.visible_rows()
+            .nth(i)
+            .map(|(_, r)| r.event_id.as_str())
+    }
+
+    fn selected_row(&self) -> Option<&AuditRow> {
+        let i = self.table.selected()?;
+        self.visible_rows().nth(i).map(|(_, r)| r)
+    }
+
+    pub fn render(
+        &mut self,
+        frame: &mut Frame<'_>,
+        area: Rect,
+        throbber: &throbber_widgets_tui::ThrobberState,
+    ) {
+        let layout = pane_layout(area);
+
+        // Title bar shows totals + filter status; mirrors history.rs's
+        // single-line header.
+        let total = self.rows.len();
+        let visible = self.visible_rows().count();
+        let title_left = format!("yoink audit · {visible}/{total} events");
+        let title_filter = match (&self.filter, self.editing_filter) {
+            (_, true) => format!(" · filter (editing): {}", self.pending_filter),
+            (Some(f), _) => format!(" · filter: {f}"),
+            (None, _) => String::new(),
+        };
+        let title_errors = if self.errors.is_empty() {
+            String::new()
+        } else {
+            format!(" · {} error(s)", self.errors.len())
+        };
+        let header = Paragraph::new(format!("{title_left}{title_filter}{title_errors}"))
+            .style(bold());
+        frame.render_widget(header, layout[0]);
+
+        // Split body: table on top, optional detail panel below when
+        // expanded. When not expanded the detail panel collapses to 0.
+        let body_layout = if self.expanded {
+            Layout::vertical([Constraint::Min(5), Constraint::Length(10)]).split(layout[1])
+        } else {
+            Layout::vertical([Constraint::Min(5), Constraint::Length(0)]).split(layout[1])
+        };
+
+        self.render_table(frame, body_layout[0], throbber);
+        if self.expanded {
+            self.render_detail(frame, body_layout[1]);
+        }
+
+        let footer = self.footer_line();
+        frame.render_widget(footer, layout[2]);
+    }
+
+    fn render_table(
+        &mut self,
+        frame: &mut Frame<'_>,
+        area: Rect,
+        throbber: &throbber_widgets_tui::ThrobberState,
+    ) {
+        let widths = [
+            Constraint::Length(24), // ts
+            Constraint::Length(8),  // origin
+            Constraint::Length(20), // host
+            Constraint::Length(20), // event
+            Constraint::Min(20),    // summary
+        ];
+
+        let visible: Vec<&AuditRow> = self.visible_rows().map(|(_, r)| r).collect();
+
+        let body_rows: Vec<Row<'_>> = if !self.loaded {
+            vec![Row::new(vec![Cell::from(super::ui::loading_line(throbber))])]
+        } else if self.rows.is_empty() && !self.errors.is_empty() {
+            vec![Row::new(vec![Cell::from(
+                "(no audit events fetched — every source failed; see footer)",
+            )])]
+        } else if self.rows.is_empty() {
+            vec![Row::new(vec![Cell::from(
+                "(no audit events — fleet has had no state-changing yoink runs)",
+            )])]
+        } else if visible.is_empty() {
+            vec![Row::new(vec![Cell::from(
+                "(filter matches no rows — esc to clear)",
+            )])]
+        } else {
+            visible
+                .iter()
+                .map(|r| {
+                    Row::new(vec![
+                        Cell::from(r.ts.clone()),
+                        Cell::from(r.origin.clone()).style(origin_style(&r.origin)),
+                        Cell::from(host_display(&r.host).to_string()),
+                        Cell::from(r.kind_name).style(event_kind_style(&r.raw.kind)),
+                        Cell::from(r.summary.clone()),
+                    ])
+                })
+                .collect()
+        };
+
+        let table = Table::new(body_rows, widths)
+            .header(Row::new(vec![
+                Cell::from("ts").style(bold()),
+                Cell::from("origin").style(bold()),
+                Cell::from("host").style(bold()),
+                Cell::from("event").style(bold()),
+                Cell::from("summary").style(bold()),
+            ]))
+            .row_highlight_style(table_highlight_style())
+            .highlight_symbol(TABLE_HIGHLIGHT_SYMBOL)
+            .block(Block::default().borders(Borders::ALL).title("audit"));
+        frame.render_stateful_widget(table, area, &mut self.table);
+    }
+
+    fn render_detail(&self, frame: &mut Frame<'_>, area: Rect) {
+        use std::fmt::Write as _;
+        let body = self.selected_row().map_or_else(
+            || "(no row selected)".to_string(),
+            |row| {
+                let mut out = String::new();
+                let actor_line = match &row.raw.git_sha {
+                    Some(sha) => format!(
+                        "{} · yoink {} · git_sha:{}",
+                        row.raw.actor, row.raw.yoink_version, sha
+                    ),
+                    None => format!("{} · yoink {}", row.raw.actor, row.raw.yoink_version),
+                };
+                let _ = writeln!(out, "event_id  : {}", row.event_id);
+                let _ = writeln!(out, "deploy_id : {}", row.deploy_id);
+                let _ = writeln!(out, "actor     : {actor_line}");
+                let _ = writeln!(out, "summary   : {}", row.summary);
+                if let AuditEventKind::DeployFailed { log_tail, .. } = &row.raw.kind {
+                    let _ = writeln!(out, "log_tail  : {} line(s)", log_tail.len());
+                    for line in log_tail.iter().take(6) {
+                        let _ = writeln!(out, "  {}", line.trim_end());
+                    }
+                    if log_tail.len() > 6 {
+                        let _ = writeln!(out, "  … ({} more)", log_tail.len() - 6);
+                    }
+                }
+                out
+            },
+        );
+        let detail = Paragraph::new(body)
+            .wrap(Wrap { trim: false })
+            .block(Block::default().borders(Borders::ALL).title("detail"));
+        frame.render_widget(detail, area);
+    }
+
+    fn footer_line(&self) -> Paragraph<'_> {
+        let (text, style) = if self.editing_filter {
+            (
+                format!(
+                    "/ {} · enter commit · esc cancel",
+                    self.pending_filter
+                ),
+                Style::default().fg(Color::Cyan),
+            )
+        } else if !self.errors.is_empty() {
+            let detail = self
+                .errors
+                .iter()
+                .map(|(s, m)| format!("{s}: {m}"))
+                .collect::<Vec<_>>()
+                .join(" · ");
+            (
+                format!("⚠ {} source(s) failed: {detail}", self.errors.len()),
+                Style::default().fg(Color::Yellow),
+            )
+        } else {
+            (
+                "↑↓/jk select · enter expand · / filter · r refresh · esc back".to_string(),
+                Style::default(),
+            )
+        };
+        Paragraph::new(text).style(style)
+    }
+}
+
+fn row_matches(r: &AuditRow, needle: &str) -> bool {
+    r.host.to_lowercase().contains(needle)
+        || r.kind_name.to_lowercase().contains(needle)
+        || r.summary.to_lowercase().contains(needle)
+        || r.deploy_id.to_lowercase().contains(needle)
+        || r.raw.actor.to_lowercase().contains(needle)
+}
+
+fn host_display(host: &str) -> &str {
+    if host.is_empty() { "—" } else { host }
+}
+
+fn origin_style(origin: &str) -> Style {
+    if origin == "operator" {
+        Style::default().fg(Color::Magenta)
+    } else {
+        Style::default().fg(Color::Cyan)
+    }
+}
+
+fn event_kind_style(kind: &AuditEventKind) -> Style {
+    use AuditEventKind as K;
+    match kind {
+        K::DeployFailed { .. } | K::RunFinished { ok: false, .. } => {
+            Style::default().fg(Color::Red).add_modifier(Modifier::BOLD)
+        }
+        K::ContainerCreated { .. } | K::RunFinished { ok: true, .. } => {
+            Style::default().fg(Color::Green)
+        }
+        K::RollbackStarted { .. } | K::RollbackFinished { .. } => Style::default().fg(Color::Yellow),
+        _ => Style::default(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::audit::{AuditEventKind, build_event, RunContext};
+    use pretty_assertions::assert_eq;
+
+    fn ctx() -> RunContext {
+        RunContext {
+            deploy_id: "01HFE9TESTTESTTESTTESTTEST".into(),
+            actor: "alice@laptop".into(),
+            yoink_version: "0.18.0".into(),
+            git_sha: Some("abc1234".into()),
+            command: "up".into(),
+        }
+    }
+
+    fn ev(host: &str, kind: AuditEventKind) -> AuditEvent {
+        build_event(&ctx(), host, kind)
+    }
+
+    #[test]
+    fn apply_loads_rows_and_keeps_first_selected() {
+        let mut s = AuditState::new();
+        s.apply(
+            vec![
+                ev("h1", AuditEventKind::LockAcquired),
+                ev("h1", AuditEventKind::LockReleased),
+            ],
+            Vec::new(),
+        );
+        assert!(s.loaded);
+        assert_eq!(s.rows.len(), 2);
+        assert_eq!(s.table.selected(), Some(0));
+    }
+
+    #[test]
+    fn filter_narrows_visible_rows() {
+        let mut s = AuditState::new();
+        s.apply(
+            vec![
+                ev("h1", AuditEventKind::LockAcquired),
+                ev(
+                    "h2",
+                    AuditEventKind::ContainerCreated {
+                        service: "api".into(),
+                        container: "api-ab12cd34".into(),
+                        spec_hash: "ab12cd34".into(),
+                        tag: "v1".into(),
+                    },
+                ),
+            ],
+            Vec::new(),
+        );
+        s.begin_filter();
+        for c in "lock".chars() {
+            s.type_filter(c);
+        }
+        s.commit_filter();
+        let visible: Vec<&AuditRow> = s.visible_rows().map(|(_, r)| r).collect();
+        assert_eq!(visible.len(), 1);
+        assert_eq!(visible[0].kind_name, "LockAcquired");
+    }
+
+    #[test]
+    fn filter_empty_input_clears_filter() {
+        let mut s = AuditState::new();
+        s.apply(
+            vec![ev("h1", AuditEventKind::LockAcquired)],
+            Vec::new(),
+        );
+        s.begin_filter();
+        s.commit_filter();
+        assert!(s.filter.is_none());
+    }
+
+    #[test]
+    fn navigation_wraps_within_visible() {
+        let mut s = AuditState::new();
+        s.apply(
+            vec![
+                ev("h1", AuditEventKind::LockAcquired),
+                ev("h1", AuditEventKind::LockReleased),
+            ],
+            Vec::new(),
+        );
+        s.select_next();
+        assert_eq!(s.table.selected(), Some(1));
+        s.select_next();
+        assert_eq!(s.table.selected(), Some(0));
+        s.select_prev();
+        assert_eq!(s.table.selected(), Some(1));
+    }
+
+    #[test]
+    fn apply_preserves_selection_by_event_id_across_refresh() {
+        let mut s = AuditState::new();
+        let first = ev("h1", AuditEventKind::LockAcquired);
+        let second = ev("h1", AuditEventKind::LockReleased);
+        s.apply(vec![first.clone(), second.clone()], Vec::new());
+        s.select_next();
+        let pinned_id = s.selected_event_id().map(str::to_string);
+        // Refresh injects a new (newer) event at the top; pinned row
+        // should still be the same logical event.
+        let third = ev("h1", AuditEventKind::HookStarted { name: "post".into() });
+        s.apply(vec![third, first, second], Vec::new());
+        assert_eq!(
+            s.selected_event_id().map(str::to_string),
+            pinned_id,
+            "selection should follow the event_id across refreshes",
+        );
+    }
+
+    #[test]
+    fn errors_propagate_to_state() {
+        let mut s = AuditState::new();
+        s.apply(
+            Vec::new(),
+            vec![("nonexistent.invalid".into(), "DNS failed".into())],
+        );
+        assert!(s.rows.is_empty());
+        assert_eq!(s.errors.len(), 1);
+        assert!(s.loaded);
+    }
+}

--- a/yoink/src/tui/audit.rs
+++ b/yoink/src/tui/audit.rs
@@ -87,10 +87,7 @@ impl AuditState {
             return;
         }
         let new_idx = prev_id
-            .and_then(|id| {
-                self.visible_rows()
-                    .position(|(_, r)| r.event_id == id)
-            })
+            .and_then(|id| self.visible_rows().position(|(_, r)| r.event_id == id))
             .unwrap_or(0);
         self.table.select(Some(new_idx.min(visible_len - 1)));
     }
@@ -196,9 +193,7 @@ impl AuditState {
     /// is selected.
     fn selected_event_id(&self) -> Option<&str> {
         let i = self.table.selected()?;
-        self.visible_rows()
-            .nth(i)
-            .map(|(_, r)| r.event_id.as_str())
+        self.visible_rows().nth(i).map(|(_, r)| r.event_id.as_str())
     }
 
     fn selected_row(&self) -> Option<&AuditRow> {
@@ -229,8 +224,8 @@ impl AuditState {
         } else {
             format!(" · {} error(s)", self.errors.len())
         };
-        let header = Paragraph::new(format!("{title_left}{title_filter}{title_errors}"))
-            .style(bold());
+        let header =
+            Paragraph::new(format!("{title_left}{title_filter}{title_errors}")).style(bold());
         frame.render_widget(header, layout[0]);
 
         // Split body: table on top, optional detail panel below when
@@ -267,7 +262,9 @@ impl AuditState {
         let visible: Vec<&AuditRow> = self.visible_rows().map(|(_, r)| r).collect();
 
         let body_rows: Vec<Row<'_>> = if !self.loaded {
-            vec![Row::new(vec![Cell::from(super::ui::loading_line(throbber))])]
+            vec![Row::new(vec![Cell::from(super::ui::loading_line(
+                throbber,
+            ))])]
         } else if self.rows.is_empty() && !self.errors.is_empty() {
             vec![Row::new(vec![Cell::from(
                 "(no audit events fetched — every source failed; see footer)",
@@ -347,10 +344,7 @@ impl AuditState {
     fn footer_line(&self) -> Paragraph<'_> {
         let (text, style) = if self.editing_filter {
             (
-                format!(
-                    "/ {} · enter commit · esc cancel",
-                    self.pending_filter
-                ),
+                format!("/ {} · enter commit · esc cancel", self.pending_filter),
                 Style::default().fg(Color::Cyan),
             )
         } else if !self.errors.is_empty() {
@@ -403,7 +397,9 @@ fn event_kind_style(kind: &AuditEventKind) -> Style {
         K::ContainerCreated { .. } | K::RunFinished { ok: true, .. } => {
             Style::default().fg(Color::Green)
         }
-        K::RollbackStarted { .. } | K::RollbackFinished { .. } => Style::default().fg(Color::Yellow),
+        K::RollbackStarted { .. } | K::RollbackFinished { .. } => {
+            Style::default().fg(Color::Yellow)
+        }
         _ => Style::default(),
     }
 }
@@ -411,7 +407,7 @@ fn event_kind_style(kind: &AuditEventKind) -> Style {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::audit::{AuditEventKind, build_event, RunContext};
+    use crate::audit::{AuditEventKind, RunContext, build_event};
     use pretty_assertions::assert_eq;
 
     fn ctx() -> RunContext {
@@ -474,10 +470,7 @@ mod tests {
     #[test]
     fn filter_empty_input_clears_filter() {
         let mut s = AuditState::new();
-        s.apply(
-            vec![ev("h1", AuditEventKind::LockAcquired)],
-            Vec::new(),
-        );
+        s.apply(vec![ev("h1", AuditEventKind::LockAcquired)], Vec::new());
         s.begin_filter();
         s.commit_filter();
         assert!(s.filter.is_none());
@@ -511,7 +504,12 @@ mod tests {
         let pinned_id = s.selected_event_id().map(str::to_string);
         // Refresh injects a new (newer) event at the top; pinned row
         // should still be the same logical event.
-        let third = ev("h1", AuditEventKind::HookStarted { name: "post".into() });
+        let third = ev(
+            "h1",
+            AuditEventKind::HookStarted {
+                name: "post".into(),
+            },
+        );
         s.apply(vec![third, first, second], Vec::new());
         assert_eq!(
             s.selected_event_id().map(str::to_string),

--- a/yoink/src/tui/mod.rs
+++ b/yoink/src/tui/mod.rs
@@ -2,6 +2,7 @@
 //! rendering.
 
 mod app;
+mod audit;
 mod chrome;
 mod container_detail;
 mod dashboard;


### PR DESCRIPTION
## Summary

Today, \"what did this host do\" is reconstructed from container labels. The moment a container is `docker rm`'d — by `prune`, by a swap, by a manual cleanup — its history vanishes. Failed deploys whose containers got swept leave no record. Lock hold time, hook exit codes, secret rotations: all invisible after the fact.

This PR adds an append-only JSONL log at `/var/lib/yoink/audit/events.jsonl` on each managed host, written by the operator over SSH on every state-changing run (`up`, `rollback`, `prune`, `secrets rotate`). Read via a new `yoink audit log|run|gc` subcommand.

### Design

Follows yoink's no-daemon / no-DB bet:

- **Storage**: one JSONL file per host, sibling of the existing `/var/lib/yoink/files/`.
- **Schema**: per-event `v: 1` versioning, flat `event` discriminator, `deploy_id` is `UUIDv7` (time-sortable; sort lexicographically to order runs).
- **Hybrid flush**:
  - **Forensic** (per-event SSH flush, tolerates partial runs): `RunStarted`/`RunFinished`, `LockAcquired`/`LockReleased`, `HookFinished`, `ContainerCreated`/`Removed`, `DeployFailed`, `Rollback*`, `ContainerPruned`, `SecretsRotated`, `FileUploaded`.
  - **Progress** (buffered, flushed at end of run): `Pull*`, `NetworkReady`, `HealthcheckHealthy`, `HookStarted`, `ContainerStarted`, `AlreadyAtSpec`, `OldContainerStopped`.
- **Failure-soft**: audit-write failures warn to stderr; deploys never block on audit.
- **Rotation**: active file rotates at 5 MiB to `events-<UTC-stamp>.jsonl`. `yoink audit gc --keep <DURATION>` prunes rotated files.
- **Read**: SSH-on-demand from each host, no client-side cache.
- **Scope**: state-changing runs only. Read commands (`status`, `history`, `doctor`, `tui`, `audit log`, `secrets show`/`env`) emit nothing — your `audit log` invocation does not show up in its own output.

### What's wired in Phase 1

- New `yoink/src/audit.rs` (~600 LoC) — types, `AuditSink` trait, `HostAuditSink` (raw SSH transport, same pattern as `files::upload`), `MemorySink` for tests, `RunContext` envelope.
- `cmd_up` in `main.rs` — emits `RunStarted` + `LockAcquired` per host before reconcile, bridges `DeployEvent` → audit via mpsc + drain task, emits `LockReleased` + `RunFinished` per host after, final `flush()`.
- `cmd_rollback` inherits via its inner `cmd_up` invocation (Phase 1 caveat: events show `command: \"up\"` from a rollback path).
- Adds `uuid` (v7 feature) as a direct dep.

### Phase 1.5 / 2 (deferred)

- `FileUploaded` emission from `files::upload` (currently no-op).
- `cmd_prune` / `cmd_secrets_rotate` envelope emission (state-changing but not yet hooked).
- TUI `Audit` pane mirroring `tui/history.rs`.
- Webhook hook on `RunFinished`.

## Test plan

- [x] `cargo build -p yoink` clean
- [x] `cargo test -p yoink` — 476 passed (5 suites). 12 new audit unit tests cover JSONL round-trip, forensic classification, ring buffering, RFC3339 formatter, container-name → spec_hash extraction, DeployEvent → AuditEventKind mapping.
- [x] `cargo clippy --lib --bin yoink -- -D warnings` — no new lints introduced (2 pre-existing on `main` unchanged).
- [x] `yoink audit --help` / `yoink audit log --help` render expected surface.
- [x] `cd docs && pnpm build` — 148 pages prerendered (was 144), no errors. New how-to + schema reference + sidebar entries verified in rendered HTML.
- [ ] DinD integration test (deferred — we don't have a Phase 1 e2e harness for the audit path yet; manual smoke against the dogfood docs deploy is the next step).

Read more at:
- New how-to: `docs/content/docs/how-to/audit-log.mdx`
- Schema reference: `docs/content/docs/reference/audit-event-schema.md`
- CLI ref: `docs/content/docs/reference/cli.md` (audit block under `history`)