### PR TITLE
feat(secrets): named profiles for `secrets env --profile` + pre-deploy hooks

### DIFF
--- a/docs/content/docs/how-to/meta.json
+++ b/docs/content/docs/how-to/meta.json
@@ -17,6 +17,7 @@
     "pr-comment-dry-run",
     "using-templates",
     "self-hosted-registry",
+    "terraform-from-hooks",
     "---Networking & Proxy---",
     "grpc-hosting",
     "caddy-plugins",

--- a/docs/content/docs/how-to/sealed-secrets-workflow.mdx
+++ b/docs/content/docs/how-to/sealed-secrets-workflow.mdx
@@ -128,6 +128,76 @@ yoink secrets env --no-export > .env.local   # bare KEY='value' for `docker run 
 
 Values are POSIX single-quote-escaped so `$`, embedded quotes, and newlines round-trip literally — a `JWT_SIGNING_KEY` containing `$` won't get re-expanded by the shell. Refuses to run when `$CI` / `$GITHUB_ACTIONS` / etc. are set unless `YOINK_ALLOW_REVEAL_IN_CI=1`; this is meant for laptops, not build logs.
 
+## Use the bundle from Terraform / CI
+
+A profile in `yoink.yaml` captures the env shape one downstream tool wants. The same recipe drives both an operator shell and a yoink pre-deploy hook, so the `bundle-key → env-var-name` mapping lives next to the bundle that supplies the values instead of being copy-pasted into N Taskfiles + N CI workflows.
+
+```yaml
+# deploy-prod/yoink.yaml
+secrets:
+  provider: age
+  recipients: [age1…]
+  profiles:
+    terraform-backblaze:
+      include: [TFSTATE_B2_KEY_ID, TFSTATE_B2_APPLICATION_KEY,
+                B2_APPLICATION_KEY_ID, B2_APPLICATION_KEY]
+      rename:
+        TFSTATE_B2_KEY_ID:          AWS_ACCESS_KEY_ID
+        TFSTATE_B2_APPLICATION_KEY: AWS_SECRET_ACCESS_KEY
+        B2_APPLICATION_KEY_ID:      TF_VAR_b2_application_key_id
+        B2_APPLICATION_KEY:         TF_VAR_b2_application_key
+      unset: [B2_ENDPOINT, B2_BUCKET_NAME]
+```
+
+`include`, `rename`, `unset` compose. Schema details: [Secrets profiles](/docs/reference/config#secrets-profiles).
+
+### From a Taskfile
+
+```yaml
+env:
+  YOINK_TF:
+    sh: cd ../../deploy-prod && yoink secrets env --profile terraform-backblaze
+
+tasks:
+  tf:plan:
+    cmds:
+      - eval "$YOINK_TF" && terraform plan
+```
+
+The single `yoink secrets env --profile …` invocation replaces every per-key `sh: bash -c '… eval … printf "$X"'` extractor block.
+
+### From a GitHub Actions workflow
+
+```yaml
+- run: |
+    eval "$(cd deploy-prod && ../yoink-bin/yoink secrets env --profile terraform-backblaze)"
+    {
+      echo "AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID"
+      echo "AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY"
+      echo "TF_VAR_b2_application_key_id=$TF_VAR_b2_application_key_id"
+      echo "TF_VAR_b2_application_key=$TF_VAR_b2_application_key"
+    } >> "$GITHUB_ENV"
+```
+
+When `$GITHUB_ENV` is set in the runner, yoink auto-prepends `echo '::add-mask::<value>'` for every revealed value before the exports — no per-key copy-paste, no "I forgot to mask the new key" failure mode.
+
+### From a yoink pre-deploy hook
+
+A pre-deploy hook can run `terraform apply` against the cloudflare module alongside the container deploy, picking up the same profile:
+
+```yaml
+hooks:
+  pre_deploy:
+    - name: cloudflare-tf-apply
+      image: hashicorp/terraform
+      tag: "1.9"
+      entrypoint: ["/bin/sh", "-c"]
+      cmd: ["cd /tf && terraform init && terraform apply -auto-approve"]
+      secrets_profile: terraform-cloudflare
+```
+
+The profile's `include` is merged into the hook's `secrets:` and the `rename` map into `env_from_secrets:` at config-load time — drift detection (`spec_hash`) folds in the renamed env keys exactly like any other env change. The profile's `unset` field is operator-shell-only; referencing a profile that has a non-empty `unset` from a hook is a config-validation error.
+
 ## Multiple environments (staging / prod)
 
 To keep staging and prod values separate so a leaked staging key can't unlock prod:

--- a/docs/content/docs/how-to/sealed-secrets-workflow.mdx
+++ b/docs/content/docs/how-to/sealed-secrets-workflow.mdx
@@ -183,20 +183,7 @@ When `$GITHUB_ENV` is set in the runner, yoink auto-prepends `echo '::add-mask::
 
 ### From a yoink pre-deploy hook
 
-A pre-deploy hook can run `terraform apply` against the cloudflare module alongside the container deploy, picking up the same profile:
-
-```yaml
-hooks:
-  pre_deploy:
-    - name: cloudflare-tf-apply
-      image: hashicorp/terraform
-      tag: "1.9"
-      entrypoint: ["/bin/sh", "-c"]
-      cmd: ["cd /tf && terraform init && terraform apply -auto-approve"]
-      secrets_profile: terraform-cloudflare
-```
-
-The profile's `include` is merged into the hook's `secrets:` and the `rename` map into `env_from_secrets:` at config-load time — drift detection (`spec_hash`) folds in the renamed env keys exactly like any other env change. The profile's `unset` field is operator-shell-only; referencing a profile that has a non-empty `unset` from a hook is a config-validation error.
+A pre-deploy hook with `secrets_profile: <NAME>` runs the same recipe as part of every `yoink up`. Subprocess hooks (no `image:`/`tag:`) invoke `cmd[0]` directly on the operator's machine and inherit the parent env, so the profile's `unset:` list applies just like in an operator shell. See [Run Terraform from a hook](/docs/how-to/terraform-from-hooks) for the worked example.
 
 ## Multiple environments (staging / prod)
 

--- a/docs/content/docs/how-to/sealed-secrets-workflow.mdx
+++ b/docs/content/docs/how-to/sealed-secrets-workflow.mdx
@@ -138,14 +138,12 @@ secrets:
   provider: age
   recipients: [age1…]
   profiles:
-    terraform-backblaze:
-      include: [TFSTATE_B2_KEY_ID, TFSTATE_B2_APPLICATION_KEY,
-                B2_APPLICATION_KEY_ID, B2_APPLICATION_KEY]
+    terraform-cloudflare:
+      include: [CLOUDFLARE_API_TOKEN,
+                TFSTATE_B2_KEY_ID, TFSTATE_B2_APPLICATION_KEY]
       rename:
         TFSTATE_B2_KEY_ID:          AWS_ACCESS_KEY_ID
         TFSTATE_B2_APPLICATION_KEY: AWS_SECRET_ACCESS_KEY
-        B2_APPLICATION_KEY_ID:      TF_VAR_b2_application_key_id
-        B2_APPLICATION_KEY:         TF_VAR_b2_application_key
       unset: [B2_ENDPOINT, B2_BUCKET_NAME]
 ```
 
@@ -156,7 +154,7 @@ secrets:
 ```yaml
 env:
   YOINK_TF:
-    sh: cd ../../deploy-prod && yoink secrets env --profile terraform-backblaze
+    sh: cd ../../deploy-prod && yoink secrets env --profile terraform-cloudflare
 
 tasks:
   tf:plan:
@@ -170,12 +168,11 @@ The single `yoink secrets env --profile …` invocation replaces every per-key `
 
 ```yaml
 - run: |
-    eval "$(cd deploy-prod && ../yoink-bin/yoink secrets env --profile terraform-backblaze)"
+    eval "$(cd deploy-prod && ../yoink-bin/yoink secrets env --profile terraform-cloudflare)"
     {
+      echo "CLOUDFLARE_API_TOKEN=$CLOUDFLARE_API_TOKEN"
       echo "AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID"
       echo "AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY"
-      echo "TF_VAR_b2_application_key_id=$TF_VAR_b2_application_key_id"
-      echo "TF_VAR_b2_application_key=$TF_VAR_b2_application_key"
     } >> "$GITHUB_ENV"
 ```
 

--- a/docs/content/docs/how-to/terraform-from-hooks.mdx
+++ b/docs/content/docs/how-to/terraform-from-hooks.mdx
@@ -1,0 +1,125 @@
+---
+title: Run Terraform (or any infra glue) from a hook
+description: Provision DNS, certs, databases, or any external resource the service depends on as a yoink pre-deploy hook — running directly on the operator's machine with the sealed bundle wired in via a `secrets_profile`.
+---
+
+Some services can't deploy until something outside the container is in place — DNS records, an origin cert, a managed database, an IAM role. Running that step manually before every deploy is forgettable; pinning it inside CI doubles the deploy job's surface. yoink's pre-deploy hooks run an arbitrary command (or container) before the service swap, with full access to the same sealed bundle. Combined with [`secrets_profile`](/docs/reference/config#secrets-profiles), one block both *names* the env shape the tool wants and *runs* the tool every deploy.
+
+Worked example: a service whose origin needs Cloudflare DNS pointed at it and Authenticated Origin Pulls turned on before traffic arrives. The Terraform module that owns that state lives in `terraform/cloudflare/`; the hook runs `terraform apply` against it as a pre-deploy step.
+
+## Two hook flavors
+
+| flavor | when | shape | use for |
+|---|---|---|---|
+| **subprocess** | yoink invokes the binary directly on the operator's machine (or CI runner). | `cmd: [...]`, no `image:`, no `tag:` | Tools already on the operator's PATH: `terraform`, `dbmate`, `alembic`, `gcloud`, `stripe`. |
+| **container** | yoink pulls an image and runs the command inside docker on the first host. | `image:` + `tag:` + `cmd:` | Isolation, portable runtimes, pinning a tool version that isn't on every operator's machine. |
+
+Both share `secrets:`, `env_from_secrets:`, and `secrets_profile:`. The rest of this page uses the subprocess flavor (no Dockerfile, no registry round-trip — terraform is just a binary).
+
+## Layout
+
+```
+deploy-prod/
+├── yoink.yaml          # the deploy config below
+└── secrets.age         # sealed bundle, includes CLOUDFLARE_API_TOKEN
+                        # + TFSTATE_B2_KEY_ID/_APPLICATION_KEY
+
+terraform/cloudflare/
+├── main.tf             # zone, dns, origin_pulls, …
+├── terraform.tfvars
+└── …
+```
+
+## 1. Define the profile [step]
+
+In `deploy-prod/yoink.yaml`, declare a profile that captures exactly the env shape Terraform's Cloudflare provider + S3-compatible state backend need:
+
+```yaml
+secrets:
+  provider: age
+  recipients: [age1…]
+  profiles:
+    terraform-cloudflare:
+      include: [CLOUDFLARE_API_TOKEN,
+                TFSTATE_B2_KEY_ID, TFSTATE_B2_APPLICATION_KEY]
+      rename:
+        TFSTATE_B2_KEY_ID:          AWS_ACCESS_KEY_ID
+        TFSTATE_B2_APPLICATION_KEY: AWS_SECRET_ACCESS_KEY
+      unset: [B2_ENDPOINT, B2_BUCKET_NAME,
+              B2_ACCESS_KEY_ID, B2_SECRET_ACCESS_KEY]
+```
+
+`include` is the allowlist — the hook's env won't carry the rest of the bundle. `rename` adapts the bundle's natural key names to the env names the providers expect. `unset` clears any conflicting key the operator's parent shell exported (e.g. devbox's `init_hook` setting `B2_ENDPOINT` for the runtime app, which the b2 SDK underneath the Terraform provider would otherwise mis-route auth to).
+
+## 2. Wire the hook [step]
+
+```yaml
+hooks:
+  pre_deploy:
+    - name: cloudflare-tf-apply
+      working_dir: ../terraform/cloudflare
+      cmd: ["sh", "-c",
+            "terraform init -input=false && terraform apply -auto-approve"]
+      secrets_profile: terraform-cloudflare
+```
+
+No `image:`, no `tag:` — yoink runs `cmd[0]` directly. `working_dir:` resolves relative to `yoink.yaml`'s directory, so the operator can run `yoink up` from anywhere and the hook still finds the module. The hook inherits the operator's env (so `terraform` is on PATH, the provider plugin cache is reused, the `.terraform/` dir is right where it expects), then yoink layers on:
+
+- `Command::env_remove(KEY)` for every `unset` entry from the profile.
+- `CLOUDFLARE_API_TOKEN`, `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY` populated from the sealed bundle (with the rename applied).
+
+stdout and stderr stream live to the operator's terminal — terraform's plan/apply output is visible as it happens.
+
+## 3. Verify the profile reference resolves [step]
+
+```sh
+yoink validate
+```
+
+The profile desugar runs at config-load time, so an unknown name (`secrets_profile: terraform-cloudfare` typo) fails here — before any deploy lock is taken:
+
+```text
+yoink: hook `cloudflare-tf-apply` references unknown secrets profile "terraform-cloudfare";
+       known: terraform-backblaze, terraform-cloudflare
+```
+
+Subprocess hooks accept profiles with `unset:`. Container hooks don't (no parent env to clear); validation flags the combo with a clear message.
+
+## 4. Deploy [step]
+
+```sh
+yoink up
+```
+
+Order on each `yoink up`:
+
+1. Pre-deploy hook spawns a child process with the resolved env. `terraform apply` reconciles the Cloudflare zone against the module.
+2. If `terraform apply` exits non-zero, the hook fails, the deploy aborts, no service swap happens. The audit log keeps a `HookFinished` event with the exit code so post-mortems don't need scrollback.
+3. On success, yoink proceeds with the container reconcile.
+
+## Drift, rotation, retry
+
+The hook's env keys feed [`spec_hash`](/docs/guide/architecture#drift-detection) like any other env. Adding a key to the profile (or rotating the value behind one) flips the hook's hash, which flips the service's hash, which schedules a redeploy on the next `yoink up`. The profile is the single source of truth for which credentials this hook reads — change the bundle entry, run a deploy, both Terraform's apply and the container's swap pick it up consistently.
+
+If `terraform apply` fails partway, re-running `yoink up` reruns the hook (Terraform converges; that's the point). For debug, the operator-shell side and the hook side share the same profile via [`yoink secrets env --profile terraform-cloudflare`](/docs/how-to/sealed-secrets-workflow#use-the-bundle-from-terraform--ci) — same env, same `terraform plan` outcome.
+
+## When to use a container hook instead
+
+Subprocess is the right default. Reach for the container flavor when:
+
+- the binary isn't on every operator's machine (and you don't want to pin it via devbox / homebrew);
+- you need isolation from the operator's filesystem (write-only sandbox, scratch fs);
+- the hook runs an LLM agent / migration tool / audit script that you want pinned to a specific image hash for reproducibility.
+
+The container shape adds `image:` + `tag:` and runs in docker on the first host; everything else (`secrets_profile`, `secrets`, `env_from_secrets`) is identical.
+
+## Beyond Terraform
+
+Hooks aren't Terraform-specific. Any deploy-time glue fits the same pattern: an alembic migration runner, a Stripe-pricing reconciler, a `gcloud` IAM apply, a `dbmate` schema migration. As long as the tool reads its credentials from env vars, a profile + a subprocess hook bridges the sealed bundle to the tool with one declarative block per consumer.
+
+## See also
+
+- [Secrets profiles](/docs/reference/config#secrets-profiles) — the schema reference for `include` / `rename` / `unset`.
+- [Sealed secrets workflow](/docs/how-to/sealed-secrets-workflow#use-the-bundle-from-terraform--ci) — the operator-shell and CI sides of the same profile.
+- [Architecture: drift detection](/docs/guide/architecture#drift-detection) — how a profile change cascades into a redeploy via `spec_hash`.
+- [Audit log](/docs/how-to/audit-log) — `HookFinished` events with exit codes for post-mortems.

--- a/docs/content/docs/reference/cli.md
+++ b/docs/content/docs/reference/cli.md
@@ -245,6 +245,13 @@ yoink secrets env                        decrypt the bundle and print
                                          Same CI guard as `show --reveal`.
   --no-export                            emit bare `KEY='value'` lines (dotenv
                                          style) instead of `export KEY='value'`.
+  --profile <NAME>                       apply a `secrets.profiles` recipe from yoink.yaml:
+                                         filter to its `include` keys, rename per its
+                                         `rename` map, prepend `unset 'KEY'` lines for
+                                         each `unset` entry. When `$GITHUB_ENV` is set,
+                                         auto-prepend `::add-mask::` lines for every
+                                         revealed value. See the secrets profiles section
+                                         in the configuration reference.
 yoink secrets seal --in <PATH>           seal a plaintext dotenv (or read from stdin)
   --as KEY=value                         set one key directly; --as KEY=@PATH reads
                                          the value from a file. Repeatable.

--- a/docs/content/docs/reference/config.md
+++ b/docs/content/docs/reference/config.md
@@ -77,8 +77,66 @@ The keys-dir scan (#3) is what makes `yoink secrets key generate` work without p
 | `provider` | string | required | `age` |
 | `recipients` | list of string | `[]` | Public age **recipients** (`age1...`), one per principal that needs to decrypt. New writes are sealed against every entry; decryption only needs *one* matching identity. Validates non-empty at config-load. |
 | `file` | string | `secrets.age` | Sealed file path, relative to the config file's directory. `..` and absolute paths are rejected. |
+| `profiles` | map of [SecretsProfile](#secretsprofile) | `{}` | Named env-shape recipes for downstream consumers (Terraform state-backend creds, provider tokens, CI shell exports). Consumed by `yoink secrets env --profile <NAME>` and by `hooks.pre_deploy[].secrets_profile`. See [Secrets profiles](#secrets-profiles). |
 
 The recipient/identity split is the asymmetric-keypair mental model; see [Sealed secrets (age)](/docs/guide/secrets#sealed-secrets-age--the-default) in the secrets guide for the full explanation.
+
+#### Secrets profiles
+
+A profile names "what env shape does one downstream tool expect" and lets the same recipe drive both an operator shell (Taskfile, CI workflow) and a yoink pre-deploy hook. Without profiles, the same `bundle-key → env-var-name` mapping is hand-encoded in N Taskfiles plus N CI workflows, with a separate `unset` block per consumer for env-leak cleanup; profiles consolidate it next to the bundle that supplies the values.
+
+##### `SecretsProfile`
+
+| Field | Type | Default | Notes |
+|---|---|---|---|
+| `include` | list of string | `[]` | Allowlist of bundle keys this consumer cares about. Empty = "every key in the bundle." A listed key missing from the bundle is a hard error at resolve time — loud-fail beats silently feeding empty creds. |
+| `rename` | map of string→string | `{}` | `bundle_key → env_var_name`. Renames apply after `include`; keys not in the map keep their original name. Targets must be POSIX env-var names (`[A-Za-z_][A-Za-z0-9_]*`); mixed case is allowed because Terraform's `TF_VAR_<varname>` puts the (lowercase) variable name in the suffix. |
+| `unset` | list of string | `[]` | Env vars to clear in the importing shell *before* the exports land. Solves the "devbox `init_hook` leaks `B2_ENDPOINT` and the b2 SDK underneath the terraform provider mis-routes auth" class of issue. **Operator-shell-only** — a hook runs in a fresh container with no parent env to clear; referencing an `unset` profile from a hook is a config-validation error. |
+
+Profile names must match `[a-z0-9-]+` (lowercase letters, digits, hyphens).
+
+```yaml
+secrets:
+  provider: age
+  recipients: [age1…]
+  profiles:
+    terraform-backblaze:
+      include: [TFSTATE_B2_KEY_ID, TFSTATE_B2_APPLICATION_KEY,
+                B2_APPLICATION_KEY_ID, B2_APPLICATION_KEY]
+      rename:
+        TFSTATE_B2_KEY_ID:          AWS_ACCESS_KEY_ID
+        TFSTATE_B2_APPLICATION_KEY: AWS_SECRET_ACCESS_KEY
+        B2_APPLICATION_KEY_ID:      TF_VAR_b2_application_key_id
+        B2_APPLICATION_KEY:         TF_VAR_b2_application_key
+      unset: [B2_ENDPOINT, B2_BUCKET_NAME]
+```
+
+Use it from a Taskfile:
+
+```yaml
+env:
+  YOINK_TF:
+    sh: cd ../../deploy-prod && yoink secrets env --profile terraform-backblaze
+tasks:
+  tf:plan:
+    cmds:
+      - eval "$YOINK_TF" && terraform plan
+```
+
+Or from a yoink pre-deploy hook (the profile's `unset` field must be empty for hook use):
+
+```yaml
+hooks:
+  pre_deploy:
+    - name: cloudflare-tf-apply
+      image: hashicorp/terraform
+      tag: "1.9"
+      entrypoint: ["/bin/sh", "-c"]
+      cmd: ["cd /tf && terraform init && terraform apply -auto-approve"]
+      secrets_profile: terraform-cloudflare
+```
+
+In CI, when `GITHUB_ENV` is set in the environment, `yoink secrets env` auto-prepends `echo '::add-mask::<value>'` lines for every revealed value — no per-key copy-paste needed; new keys added to the profile are masked automatically.
 
 Bootstrap: `yoink secrets key generate` writes a fresh **identity** to `~/.config/yoink/keys/<recipient>.key` (mode 0600) by default and prints the matching **recipient** (`age1…`, public; paste into `recipients:` above). `--out PATH` writes to a specific file at mode 0600 instead. `--print` sends the secret to stdout for piping into a CI secret store (`… --print | gh secret set YOINK_AGE_KEY`). `yoink secrets key public` re-derives the recipient from whichever identity yoink would use right now (handy "is the key in my shell the same one yoink.yaml expects?" check). See the [secrets guide](/docs/guide/secrets).
 

--- a/docs/content/docs/reference/config.md
+++ b/docs/content/docs/reference/config.md
@@ -100,14 +100,12 @@ secrets:
   provider: age
   recipients: [age1…]
   profiles:
-    terraform-backblaze:
-      include: [TFSTATE_B2_KEY_ID, TFSTATE_B2_APPLICATION_KEY,
-                B2_APPLICATION_KEY_ID, B2_APPLICATION_KEY]
+    terraform-cloudflare:
+      include: [CLOUDFLARE_API_TOKEN,
+                TFSTATE_B2_KEY_ID, TFSTATE_B2_APPLICATION_KEY]
       rename:
         TFSTATE_B2_KEY_ID:          AWS_ACCESS_KEY_ID
         TFSTATE_B2_APPLICATION_KEY: AWS_SECRET_ACCESS_KEY
-        B2_APPLICATION_KEY_ID:      TF_VAR_b2_application_key_id
-        B2_APPLICATION_KEY:         TF_VAR_b2_application_key
       unset: [B2_ENDPOINT, B2_BUCKET_NAME]
 ```
 
@@ -116,25 +114,26 @@ Use it from a Taskfile:
 ```yaml
 env:
   YOINK_TF:
-    sh: cd ../../deploy-prod && yoink secrets env --profile terraform-backblaze
+    sh: cd ../../deploy-prod && yoink secrets env --profile terraform-cloudflare
 tasks:
   tf:plan:
     cmds:
       - eval "$YOINK_TF" && terraform plan
 ```
 
-Or from a yoink pre-deploy hook (the profile's `unset` field must be empty for hook use):
+Or from a yoink pre-deploy hook (subprocess flavor — runs on the operator's machine):
 
 ```yaml
 hooks:
   pre_deploy:
     - name: cloudflare-tf-apply
-      image: hashicorp/terraform
-      tag: "1.9"
-      entrypoint: ["/bin/sh", "-c"]
-      cmd: ["cd /tf && terraform init && terraform apply -auto-approve"]
+      working_dir: ../terraform/cloudflare
+      cmd: ["sh", "-c",
+            "terraform init -input=false && terraform apply -auto-approve"]
       secrets_profile: terraform-cloudflare
 ```
+
+The profile's `unset:` applies on subprocess hooks (yoink calls `Command::env_remove` for each entry); container hooks reject it because there's no parent env to clear. See [Run Terraform from a hook](/docs/how-to/terraform-from-hooks) for the full walkthrough.
 
 In CI, when `GITHUB_ENV` is set in the environment, `yoink secrets env` auto-prepends `echo '::add-mask::<value>'` lines for every revealed value — no per-key copy-paste needed; new keys added to the profile are masked automatically.
 

--- a/docs/content/docs/reference/config.md
+++ b/docs/content/docs/reference/config.md
@@ -313,16 +313,23 @@ Both shapes use the same [Hook](#hook) entry shape below. A non-zero exit aborts
 
 ## Hook
 
+A hook runs in one of two flavors, distinguished by the presence of `image:`:
+
+- **Container hook** (`image:` + `tag:` set): yoink pulls the image and runs `cmd:` inside docker on the first host. Use for pinned tool images or isolation from the operator's filesystem.
+- **Subprocess hook** (no `image:`, no `tag:`): yoink invokes `cmd[0]` directly on the operator's machine (or the CI runner). Inherits the parent env. Use for tools already on PATH (`terraform`, `dbmate`, `alembic`, `gcloud`, …) — see [Run Terraform from a hook](/docs/how-to/terraform-from-hooks).
+
 | Field | Type | Default | Notes |
 |---|---|---|---|
 | `name` | string | required | Hook identifier (used in logs, lock label). |
-| `image` | string | required | Image reference. Usually the same as the runtime service. |
-| `tag` | string \| `{service: <name>}` | unset | Literal tag, or `{service: api}` to mirror the runtime tag exactly. |
-| `entrypoint` | list of string | image default | Override `ENTRYPOINT`. |
-| `cmd` | list of string | image default | Override `CMD`. |
+| `image` | string | unset | Container hook only. Usually the same as the runtime service. |
+| `tag` | string \| `{service: <name>}` | unset | Container hook only. Literal tag, or `{service: api}` to mirror the runtime tag. Required when `image:` is set; rejected otherwise. |
+| `entrypoint` | list of string | image default | Container hook only. Override `ENTRYPOINT`. |
+| `cmd` | list of string | image default | Container: override `CMD`. Subprocess: required; `cmd[0]` is the binary, the rest are args. |
+| `working_dir` | string (path) | yoink.yaml's dir | Subprocess hook only. Resolved relative to `yoink.yaml`'s directory. |
 | `env` | map of string | `{}` | Plain env vars. |
 | `secrets` | list of string | `[]` | Secret names exposed as env vars of the same name. Often a different role than the runtime (e.g. a migrate role). |
 | `env_from_secrets` | map of string | `{}` | `ENV_NAME: SECRET_NAME` mapping. |
+| `secrets_profile` | string | unset | Reference a named recipe from `secrets.profiles`. Profile's `include` joins `secrets`; profile's `rename` joins `env_from_secrets`. Profile's `unset:` applies on subprocess hooks (via `Command::env_remove`); rejected on container hooks (no parent env to clear). See [Secrets profiles](#secrets-profiles). |
 
 ## Tag overrides at deploy time
 

--- a/yoink/src/add/mod.rs
+++ b/yoink/src/add/mod.rs
@@ -391,7 +391,10 @@ enum SealReport {
 }
 
 fn seal_new_secrets(config: &Config, new_secrets: &[render::RenderedSecret]) -> Result<SealReport> {
-    let Some(SecretsConfig::Age { file, recipients }) = &config.secrets else {
+    let Some(SecretsConfig::Age {
+        file, recipients, ..
+    }) = &config.secrets
+    else {
         return Ok(SealReport::Skipped {
             reason: "no `secrets:` block configured (run `yoink secrets key generate` first)"
                 .into(),

--- a/yoink/src/config.rs
+++ b/yoink/src/config.rs
@@ -1277,8 +1277,8 @@ fn validate_secrets_profiles(
         for (src, target) in &profile.rename {
             if !is_valid_env_var_name(target) {
                 return Err(ConfigError::Invalid(format!(
-                    "secrets.profiles.{name}.rename[{src:?}]: target {target:?} is not a \
-                     valid env var name (must match `[A-Z_][A-Z0-9_]*`)",
+                    "secrets.profiles.{name}.rename.{src}: target {target:?} is not a \
+                     valid env var name (must match `[A-Za-z_][A-Za-z0-9_]*`)",
                 )));
             }
             if let Some(prior) = seen_targets.insert(target.as_str(), src.as_str()) {
@@ -1715,6 +1715,13 @@ impl Config {
     ///   age-only feature today; non-age users get a clear error
     ///   instead of a silent miss).
     fn apply_secrets_profiles_to_hooks(&mut self) -> Result<(), ConfigError> {
+        // Run profile-block validation up front so a malformed
+        // profile fails before we start mutating hooks. Skipping any
+        // hook resolution past this point on Err means a later
+        // `validate()` doesn't have to re-check the same invariants.
+        if let Some(SecretsConfig::Age { profiles, .. }) = &self.secrets {
+            validate_secrets_profiles(profiles)?;
+        }
         if self
             .hooks
             .pre_deploy
@@ -1723,8 +1730,11 @@ impl Config {
         {
             return Ok(());
         }
+        // Disjoint borrow: `&self.secrets` + `&mut self.hooks` are
+        // separate fields, so the loop below can borrow hooks mutably
+        // while `profiles` keeps its immutable handle on `secrets`.
         let profiles = match &self.secrets {
-            Some(SecretsConfig::Age { profiles, .. }) => profiles.clone(),
+            Some(SecretsConfig::Age { profiles, .. }) => profiles,
             Some(SecretsConfig::Command { .. }) => {
                 return Err(ConfigError::Invalid(
                     "hooks reference `secrets_profile:` but `secrets.provider:` is `command`; \
@@ -1783,9 +1793,10 @@ impl Config {
                 "deploy.networks must declare at least one network".into(),
             ));
         }
-        if let Some(SecretsConfig::Age { profiles, .. }) = &self.secrets {
-            validate_secrets_profiles(profiles)?;
-        }
+        // `apply_secrets_profiles_to_hooks` (run by `load_from_path`
+        // before `validate`) already calls `validate_secrets_profiles`
+        // up front, so a malformed profile is rejected before any
+        // hook desugar; no need to re-check here.
         // Empty hosts is permitted at load time — operators may
         // bootstrap a project (e.g. `yoink init --create-ssh-key` then
         // provision + `yoink hosts add`) where the fleet is genuinely
@@ -3325,7 +3336,16 @@ services:
 
     // -- secrets profiles ---------------------------------------------
 
-    fn config_with_profiles_yaml(extra_hook: &str) -> String {
+    /// Build a yoink.yaml string with a configurable `terraform-backblaze`
+    /// profile (control whether it has an `unset:` line) and an
+    /// arbitrary `pre_deploy` hooks block. Replaces a fragile
+    /// `.replace("…unset…", "")` pattern in earlier tests.
+    fn config_with_profiles_yaml(extra_hook: &str, with_unset: bool) -> String {
+        let unset_line = if with_unset {
+            "      unset: [B2_ENDPOINT, B2_BUCKET_NAME]\n"
+        } else {
+            ""
+        };
         format!(
             r#"
 deploy:
@@ -3349,8 +3369,7 @@ secrets:
         TFSTATE_B2_APPLICATION_KEY: AWS_SECRET_ACCESS_KEY
         B2_APPLICATION_KEY_ID:      TF_VAR_b2_application_key_id
         B2_APPLICATION_KEY:         TF_VAR_b2_application_key
-      unset: [B2_ENDPOINT, B2_BUCKET_NAME]
-    needs-unset:
+{unset_line}    needs-unset:
       include: [FOO]
       unset: [PARENT_LEAK]
 hooks:
@@ -3367,7 +3386,7 @@ hooks:
 
     #[test]
     fn profiles_round_trip_through_load() {
-        let cfg = parse_via_temp(&config_with_profiles_yaml("")).unwrap();
+        let cfg = parse_via_temp(&config_with_profiles_yaml("", true)).unwrap();
         let Some(SecretsConfig::Age { profiles, .. }) = &cfg.secrets else {
             panic!("expected age secrets");
         };
@@ -3521,10 +3540,10 @@ secrets:
       cmd: ["apply"]
       secrets_profile: terraform-backblaze
 "#;
-        // Drop `unset:` from the profile we reference because hooks
-        // can't honor it; this test verifies the happy desugar path.
-        let yaml = config_with_profiles_yaml(hook)
-            .replace("      unset: [B2_ENDPOINT, B2_BUCKET_NAME]\n", "");
+        // The referenced profile must NOT carry an `unset:` line —
+        // hooks can't honor it. This test exercises the happy
+        // desugar path.
+        let yaml = config_with_profiles_yaml(hook, false);
         let cfg = parse_via_temp(&yaml).unwrap();
         let h = &cfg.hooks.pre_deploy[0];
         // After desugar, the field is None — downstream code is
@@ -3565,8 +3584,7 @@ secrets:
       env_from_secrets:
         AWS_ACCESS_KEY_ID: SOMETHING_ELSE
 "#;
-        let yaml = config_with_profiles_yaml(hook)
-            .replace("      unset: [B2_ENDPOINT, B2_BUCKET_NAME]\n", "");
+        let yaml = config_with_profiles_yaml(hook, false);
         let cfg = parse_via_temp(&yaml).unwrap();
         let h = &cfg.hooks.pre_deploy[0];
         // Operator's explicit mapping survives the merge.
@@ -3587,7 +3605,7 @@ secrets:
       cmd: ["apply"]
       secrets_profile: does-not-exist
 "#;
-        let yaml = config_with_profiles_yaml(hook);
+        let yaml = config_with_profiles_yaml(hook, true);
         let err = parse_via_temp(&yaml).unwrap_err();
         let msg = err.to_string();
         assert!(msg.contains("does-not-exist"), "got: {msg}");
@@ -3603,7 +3621,7 @@ secrets:
       cmd: ["apply"]
       secrets_profile: needs-unset
 "#;
-        let yaml = config_with_profiles_yaml(hook);
+        let yaml = config_with_profiles_yaml(hook, true);
         let err = parse_via_temp(&yaml).unwrap_err();
         let msg = err.to_string();
         assert!(msg.contains("operator-shell-only"), "got: {msg}");

--- a/yoink/src/config.rs
+++ b/yoink/src/config.rs
@@ -1120,14 +1120,28 @@ pub struct HookConfig {
 #[serde(deny_unknown_fields)]
 pub struct HookSpec {
     pub name: String,
-    pub image: String,
+    /// Container image. Required for **container hooks**; omit for
+    /// **subprocess hooks** that run directly on the operator's
+    /// machine (or the CI runner). When omitted, `tag:` must also be
+    /// omitted and `cmd:` runs as a child process with the resolved
+    /// env merged in.
+    #[serde(default)]
+    pub image: Option<String>,
     /// Either a literal tag string or `{ service = "api" }` to mirror
-    /// the deploy-time tag of another service in this config.
-    pub tag: HookTag,
+    /// the deploy-time tag of another service in this config. Required
+    /// when `image:` is set; rejected when not.
+    #[serde(default)]
+    pub tag: Option<HookTag>,
     #[serde(default)]
     pub entrypoint: Option<Vec<String>>,
     #[serde(default)]
     pub cmd: Vec<String>,
+    /// Working directory for **subprocess hooks**, resolved relative
+    /// to the directory of `yoink.yaml`. Default: yoink.yaml's
+    /// directory. Rejected on container hooks (containers carry their
+    /// own `WORKDIR` from the image).
+    #[serde(default)]
+    pub working_dir: Option<std::path::PathBuf>,
     #[serde(default)]
     pub env: BTreeMap<String, String>,
     #[serde(default)]
@@ -1155,6 +1169,18 @@ pub struct HookSpec {
 pub enum HookTag {
     Literal(String),
     Ref { service: String },
+}
+
+impl HookSpec {
+    /// `true` when this hook runs as a child process on the operator's
+    /// machine instead of inside a docker container. Determined by the
+    /// absence of `image:` — see [`HookSpec::image`] for the schema
+    /// rule. Container hooks need `image:` + `tag:`; subprocess hooks
+    /// have neither and run `cmd[0]` directly with the resolved env.
+    #[must_use]
+    pub fn is_subprocess(&self) -> bool {
+        self.image.is_none()
+    }
 }
 
 fn default_healthcheck_timeout() -> Duration {
@@ -1750,7 +1776,7 @@ impl Config {
             }
         };
         for hook in &mut self.hooks.pre_deploy {
-            let Some(name) = hook.secrets_profile.take() else {
+            let Some(name) = hook.secrets_profile.clone() else {
                 continue;
             };
             let profile = profiles.get(&name).ok_or_else(|| {
@@ -1764,11 +1790,18 @@ impl Config {
                     hook.name,
                 ))
             })?;
-            if !profile.unset.is_empty() {
+            // Profile `unset` semantics: container hooks run in a
+            // fresh container with no parent env to clear, so the
+            // field can't apply — reject. Subprocess hooks inherit
+            // the operator's env, so `unset` IS meaningful: yoink
+            // calls `Command::env_remove(KEY)` for each entry before
+            // spawning the child.
+            if !profile.unset.is_empty() && !hook.is_subprocess() {
                 return Err(ConfigError::Invalid(format!(
-                    "hook `{}` references profile {name:?} which sets `unset:` — that field is \
-                     operator-shell-only and can't apply to a hook (hooks run in a fresh \
-                     container with no parent env)",
+                    "hook `{}` is a container hook but references profile {name:?} which sets \
+                     `unset:` — that field needs a parent shell to clear from. Drop `image:`/`tag:` \
+                     to make this a subprocess hook, or split the `unset:` keys into a separate \
+                     profile that the hook doesn't reference.",
                     hook.name,
                 )));
             }
@@ -2027,21 +2060,65 @@ impl Config {
         // (depends_on cycle detection deferred to topo_sort_services
         //  which has the full graph in front of it.)
 
-        // Hook tag refs must point at a real service.
+        // Hook shape: container hooks need image+tag, subprocess
+        // hooks have neither (they run on the operator's machine
+        // with the resolved env merged into a child process).
         for hook in &self.hooks.pre_deploy {
-            if hook.image.trim().is_empty() {
-                return Err(ConfigError::Invalid(format!(
-                    "hook {:?}.image must not be empty",
-                    hook.name
-                )));
-            }
-            if let HookTag::Ref { service } = &hook.tag
-                && !seen_names.contains(service.as_str())
-            {
-                return Err(ConfigError::Invalid(format!(
-                    "hook {:?}.tag references unknown service {service:?}",
-                    hook.name
-                )));
+            match (&hook.image, &hook.tag) {
+                (Some(image), Some(tag)) => {
+                    if image.trim().is_empty() {
+                        return Err(ConfigError::Invalid(format!(
+                            "hook {:?}.image must not be empty",
+                            hook.name
+                        )));
+                    }
+                    if let HookTag::Ref { service } = tag
+                        && !seen_names.contains(service.as_str())
+                    {
+                        return Err(ConfigError::Invalid(format!(
+                            "hook {:?}.tag references unknown service {service:?}",
+                            hook.name
+                        )));
+                    }
+                    if hook.working_dir.is_some() {
+                        return Err(ConfigError::Invalid(format!(
+                            "hook {:?} sets `working_dir:`, which is only valid on subprocess \
+                             hooks (no `image:` / `tag:`). Container hooks carry `WORKDIR` from \
+                             the image; use `cmd: [\"sh\",\"-c\",\"cd /path && …\"]` if you need \
+                             to override it inside the container.",
+                            hook.name
+                        )));
+                    }
+                }
+                (None, None) => {
+                    if hook.cmd.is_empty() {
+                        return Err(ConfigError::Invalid(format!(
+                            "hook {:?} has no `image:` and no `cmd:` — subprocess hooks need \
+                             a `cmd:` to run.",
+                            hook.name
+                        )));
+                    }
+                    if hook.entrypoint.is_some() {
+                        return Err(ConfigError::Invalid(format!(
+                            "hook {:?} sets `entrypoint:` but has no `image:` — entrypoint is a \
+                             container concept; use `cmd: [\"<binary>\", \"<args>\"…]` directly.",
+                            hook.name
+                        )));
+                    }
+                }
+                (Some(_), None) => {
+                    return Err(ConfigError::Invalid(format!(
+                        "hook {:?} sets `image:` but no `tag:` — container hooks need both.",
+                        hook.name
+                    )));
+                }
+                (None, Some(_)) => {
+                    return Err(ConfigError::Invalid(format!(
+                        "hook {:?} sets `tag:` but no `image:` — drop both for a subprocess hook \
+                         or set both for a container hook.",
+                        hook.name
+                    )));
+                }
             }
         }
 
@@ -2810,11 +2887,11 @@ hooks:
         assert_eq!(c.hooks.pre_deploy[0].name, "bt-migrate");
         assert!(matches!(
             c.hooks.pre_deploy[0].tag,
-            HookTag::Ref { ref service } if service == "api"
+            Some(HookTag::Ref { ref service }) if service == "api"
         ));
         assert!(matches!(
             c.hooks.pre_deploy[1].tag,
-            HookTag::Literal(ref t) if t == "latest"
+            Some(HookTag::Literal(ref t)) if t == "latest"
         ));
     }
 
@@ -3546,9 +3623,12 @@ secrets:
         let yaml = config_with_profiles_yaml(hook, false);
         let cfg = parse_via_temp(&yaml).unwrap();
         let h = &cfg.hooks.pre_deploy[0];
-        // After desugar, the field is None — downstream code is
-        // profile-agnostic.
-        assert!(h.secrets_profile.is_none());
+        // After desugar, the field still carries the original profile
+        // name — the subprocess runner re-reads it to apply the
+        // profile's `unset` list at hook-run time. The
+        // `include`/`rename` halves of the profile have already been
+        // merged into `secrets` / `env_from_secrets`.
+        assert_eq!(h.secrets_profile.as_deref(), Some("terraform-backblaze"));
         // Include set merged into `secrets`.
         for key in [
             "TFSTATE_B2_KEY_ID",
@@ -3624,6 +3704,143 @@ secrets:
         let yaml = config_with_profiles_yaml(hook, true);
         let err = parse_via_temp(&yaml).unwrap_err();
         let msg = err.to_string();
-        assert!(msg.contains("operator-shell-only"), "got: {msg}");
+        assert!(msg.contains("container hook"), "got: {msg}");
+        assert!(msg.contains("subprocess hook"), "got: {msg}");
+    }
+
+    // -- subprocess hooks --------------------------------------------
+
+    #[test]
+    fn subprocess_hook_with_no_image_no_tag_parses() {
+        let yaml = r#"
+deploy:
+  networks: [n]
+hosts: [{ address: h, user: root }]
+services:
+  - name: a
+    image: i
+    tag: v1
+    run: {}
+hooks:
+  pre_deploy:
+    - name: tf
+      cmd: ["terraform", "apply", "-auto-approve"]
+"#;
+        let cfg = parse_via_temp(yaml).unwrap();
+        let h = &cfg.hooks.pre_deploy[0];
+        assert!(h.is_subprocess());
+        assert!(h.image.is_none());
+        assert!(h.tag.is_none());
+    }
+
+    #[test]
+    fn container_hook_missing_tag_rejected() {
+        let yaml = r#"
+deploy:
+  networks: [n]
+hosts: [{ address: h, user: root }]
+services:
+  - name: a
+    image: i
+    tag: v1
+    run: {}
+hooks:
+  pre_deploy:
+    - name: tf
+      image: hashicorp/terraform
+      cmd: ["apply"]
+"#;
+        let err = parse_via_temp(yaml).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("image:"), "got: {msg}");
+        assert!(msg.contains("no `tag:`"), "got: {msg}");
+    }
+
+    #[test]
+    fn subprocess_hook_with_entrypoint_rejected() {
+        let yaml = r#"
+deploy:
+  networks: [n]
+hosts: [{ address: h, user: root }]
+services:
+  - name: a
+    image: i
+    tag: v1
+    run: {}
+hooks:
+  pre_deploy:
+    - name: tf
+      entrypoint: ["sh", "-c"]
+      cmd: ["terraform apply"]
+"#;
+        let err = parse_via_temp(yaml).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("entrypoint"), "got: {msg}");
+        assert!(msg.contains("container concept"), "got: {msg}");
+    }
+
+    #[test]
+    fn subprocess_hook_with_no_cmd_rejected() {
+        let yaml = r#"
+deploy:
+  networks: [n]
+hosts: [{ address: h, user: root }]
+services:
+  - name: a
+    image: i
+    tag: v1
+    run: {}
+hooks:
+  pre_deploy:
+    - name: tf
+"#;
+        let err = parse_via_temp(yaml).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("no `cmd:`"), "got: {msg}");
+    }
+
+    #[test]
+    fn container_hook_with_working_dir_rejected() {
+        let yaml = r#"
+deploy:
+  networks: [n]
+hosts: [{ address: h, user: root }]
+services:
+  - name: a
+    image: i
+    tag: v1
+    run: {}
+hooks:
+  pre_deploy:
+    - name: tf
+      image: hashicorp/terraform
+      tag: "1.9"
+      working_dir: terraform/cf
+      cmd: ["apply"]
+"#;
+        let err = parse_via_temp(yaml).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("working_dir"), "got: {msg}");
+        assert!(msg.contains("subprocess"), "got: {msg}");
+    }
+
+    #[test]
+    fn subprocess_hook_accepts_profile_with_unset() {
+        let hook = r#"
+    - name: tf
+      cmd: ["terraform", "apply"]
+      secrets_profile: needs-unset
+"#;
+        let yaml = config_with_profiles_yaml(hook, true);
+        // Subprocess hook references a profile that has `unset:` —
+        // legal, since the subprocess inherits the parent env and
+        // yoink calls `Command::env_remove(KEY)` for each entry.
+        let cfg = parse_via_temp(&yaml).unwrap();
+        let h = &cfg.hooks.pre_deploy[0];
+        assert!(h.is_subprocess());
+        assert!(h.secrets.iter().any(|s| s == "FOO"));
+        // Profile reference is preserved so the runner can re-read
+        // the `unset:` list at hook-run time.
+        assert_eq!(h.secrets_profile.as_deref(), Some("needs-unset"));
     }
 }

--- a/yoink/src/config.rs
+++ b/yoink/src/config.rs
@@ -500,6 +500,37 @@ pub struct RegistryConfig {
     pub password_secret: String,
 }
 
+/// Named recipe for "what env shape does one downstream tool expect."
+/// Stored on `SecretsConfig::Age.profiles` as `name -> profile`,
+/// referenced by `yoink secrets env --profile <NAME>` and by
+/// `hooks.pre_deploy[].secrets_profile`. The profile composes three
+/// independent bits:
+///
+/// - `include`: allowlist of bundle keys that the consumer cares
+///   about. Empty means "everything." A listed key that's missing
+///   from the sealed bundle is a hard error at resolve time —
+///   loud-fail beats silently feeding empty creds to terraform.
+/// - `rename`: `bundle_key -> env_var_name` map for adapting the
+///   bundle's natural names to the downstream tool's expected names
+///   (e.g. `TFSTATE_B2_KEY_ID -> AWS_ACCESS_KEY_ID`). Renames apply
+///   after `include`. Keys not in the map keep their original name.
+/// - `unset`: env vars to clear in the importing shell *before* the
+///   exports land. Solves the "devbox `init_hook` leaks runtime
+///   `B2_ENDPOINT` and the b2 SDK underneath the terraform provider
+///   mis-routes auth" class of issue. Operator-shell-only — a hook
+///   container has no parent env to clear, so referencing an `unset`
+///   profile from a hook is rejected at config-load time.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct SecretsProfile {
+    #[serde(default)]
+    pub include: Vec<String>,
+    #[serde(default)]
+    pub rename: BTreeMap<String, String>,
+    #[serde(default)]
+    pub unset: Vec<String>,
+}
+
 /// Secrets provider config. The default, batteries-included shape is
 /// `age` — a single sealed file (`secrets.age` next to `yoink.yaml`)
 /// committed to the repo, decrypted at deploy time with one key
@@ -531,6 +562,13 @@ pub enum SecretsConfig {
         /// key (`age1...`). Decryption only needs one matching identity.
         #[serde(default)]
         recipients: Vec<String>,
+        /// Named env-shape recipes for downstream consumers (Terraform
+        /// state-backend creds, provider tokens, …). Each profile
+        /// captures which keys from the bundle a tool wants and what
+        /// to rename them to. Consumed by `yoink secrets env --profile
+        /// <NAME>` and by `hooks.pre_deploy[].secrets_profile`.
+        #[serde(default)]
+        profiles: BTreeMap<String, SecretsProfile>,
     },
     /// External CLI provider. yoink invokes `command`, captures
     /// stdout, and parses it as a secrets bundle. Format is
@@ -1100,6 +1138,16 @@ pub struct HookSpec {
     /// actually reads (`AUTH_DATABASE_URL`).
     #[serde(default)]
     pub env_from_secrets: BTreeMap<String, String>,
+    /// Reference a named recipe from `secrets.profiles`. Desugared at
+    /// config-load time: the profile's `include` is appended to
+    /// `secrets`, and its `rename` is merged into `env_from_secrets`.
+    /// Any explicit `secrets` / `env_from_secrets` entries on this
+    /// hook take precedence on key collision (operator overrides the
+    /// profile). The profile's `unset` field is operator-shell-only;
+    /// referencing a profile that has a non-empty `unset` from a hook
+    /// is a config-validation error.
+    #[serde(default)]
+    pub secrets_profile: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
@@ -1182,6 +1230,95 @@ fn local_socket_exists() -> bool {
 ///   `[A-Za-z_][A-Za-z0-9_]*` or is unterminated.
 fn expand_env_vars(text: &str) -> Result<String, ConfigError> {
     expand_env_vars_with(text, |name| std::env::var(name).ok())
+}
+
+/// Internal-consistency check on every profile in `secrets.profiles`.
+/// Bundle-key existence is checked at resolve time (when the bundle is
+/// actually loaded) — at config-validate time we only check the
+/// structural invariants that don't need the plaintext bundle. Rename
+/// targets must be POSIX env-var names; mixed case is allowed
+/// because Terraform's `TF_VAR_<varname>` suffix is lowercase.
+fn validate_secrets_profiles(
+    profiles: &BTreeMap<String, SecretsProfile>,
+) -> Result<(), ConfigError> {
+    for (name, profile) in profiles {
+        if !is_valid_profile_name(name) {
+            return Err(ConfigError::Invalid(format!(
+                "secrets.profiles: name {name:?} must match `[a-z0-9-]+` \
+                 (lowercase letters, digits, hyphens)",
+            )));
+        }
+        for key in &profile.include {
+            if key.trim().is_empty() {
+                return Err(ConfigError::Invalid(format!(
+                    "secrets.profiles.{name}.include: empty entry"
+                )));
+            }
+        }
+        // Renames may target a key not in `include` only when
+        // `include` is empty (the "everything passes through" mode).
+        // When `include` is non-empty, every rename source must be in
+        // it — otherwise the rename refers to a key the profile is
+        // also dropping, which is almost certainly a typo.
+        if !profile.include.is_empty() {
+            for src in profile.rename.keys() {
+                if !profile.include.iter().any(|k| k == src) {
+                    return Err(ConfigError::Invalid(format!(
+                        "secrets.profiles.{name}.rename: source key {src:?} is not in \
+                         `include` (rename refers to a key the profile drops)",
+                    )));
+                }
+            }
+        }
+        // Rename targets must be valid POSIX env-var names; the
+        // profile's whole purpose is feeding shell exports, so a name
+        // like `aws-access-key` would silently break downstream.
+        let mut seen_targets: BTreeMap<&str, &str> = BTreeMap::new();
+        for (src, target) in &profile.rename {
+            if !is_valid_env_var_name(target) {
+                return Err(ConfigError::Invalid(format!(
+                    "secrets.profiles.{name}.rename[{src:?}]: target {target:?} is not a \
+                     valid env var name (must match `[A-Z_][A-Z0-9_]*`)",
+                )));
+            }
+            if let Some(prior) = seen_targets.insert(target.as_str(), src.as_str()) {
+                return Err(ConfigError::Invalid(format!(
+                    "secrets.profiles.{name}.rename: target {target:?} appears twice \
+                     (sources {prior:?} and {src:?})",
+                )));
+            }
+        }
+        for u in &profile.unset {
+            if !is_valid_env_var_name(u) {
+                return Err(ConfigError::Invalid(format!(
+                    "secrets.profiles.{name}.unset: {u:?} is not a valid env var name",
+                )));
+            }
+        }
+    }
+    Ok(())
+}
+
+fn is_valid_profile_name(name: &str) -> bool {
+    !name.is_empty()
+        && name
+            .chars()
+            .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '-')
+}
+
+/// POSIX env-var name: `[A-Za-z_][A-Za-z0-9_]*`. Mixed case is
+/// allowed because Terraform's `TF_VAR_<varname>` convention puts the
+/// (lowercase) variable name in the env-var suffix; rejecting
+/// lowercase would refuse the most common use case.
+fn is_valid_env_var_name(name: &str) -> bool {
+    let mut chars = name.chars();
+    let Some(first) = chars.next() else {
+        return false;
+    };
+    if !(first.is_ascii_alphabetic() || first == '_') {
+        return false;
+    }
+    chars.all(|c| c.is_ascii_alphanumeric() || c == '_')
 }
 
 fn expand_env_vars_with<F>(text: &str, lookup: F) -> Result<String, ConfigError>
@@ -1393,6 +1530,7 @@ impl Config {
         let mut cfg: Self = yaml_serde::from_str(&text)?;
         cfg.config_dir = path.parent().map(std::path::Path::to_path_buf);
         cfg.merge_includes()?;
+        cfg.apply_secrets_profiles_to_hooks()?;
         cfg.normalize_image_references()?;
         crate::proxy::inject_implicit_proxy(&mut cfg)?;
         cfg.validate()?;
@@ -1421,6 +1559,7 @@ impl Config {
         let mut cfg: Self = yaml_serde::from_str(&text)?;
         cfg.config_dir = path.parent().map(std::path::Path::to_path_buf);
         cfg.merge_includes()?;
+        cfg.apply_secrets_profiles_to_hooks()?;
         cfg.normalize_image_references()?;
         // Skip inject_implicit_proxy + validate + topo_sort — those
         // are what reject incomplete configs. The add flow only reads
@@ -1559,12 +1698,93 @@ impl Config {
         Ok(())
     }
 
+    /// Resolve `hooks.pre_deploy[].secrets_profile` references into the
+    /// hook's `secrets` (from the profile's `include`) and
+    /// `env_from_secrets` (from the profile's `rename`). The hook's own
+    /// `secrets` / `env_from_secrets` entries take precedence on key
+    /// collision. After this pass, `secrets_profile` is `None` so
+    /// downstream code (drift detection, dry-run output, hook runner)
+    /// is profile-agnostic.
+    ///
+    /// Errors:
+    /// - Reference to a profile name that isn't in `secrets.profiles`.
+    /// - Reference to a profile with a non-empty `unset` (hooks run in
+    ///   a fresh container, no parent env to clear; the operator
+    ///   probably split their profile wrong).
+    /// - The `secrets:` block isn't `provider: age` (profiles are an
+    ///   age-only feature today; non-age users get a clear error
+    ///   instead of a silent miss).
+    fn apply_secrets_profiles_to_hooks(&mut self) -> Result<(), ConfigError> {
+        if self
+            .hooks
+            .pre_deploy
+            .iter()
+            .all(|h| h.secrets_profile.is_none())
+        {
+            return Ok(());
+        }
+        let profiles = match &self.secrets {
+            Some(SecretsConfig::Age { profiles, .. }) => profiles.clone(),
+            Some(SecretsConfig::Command { .. }) => {
+                return Err(ConfigError::Invalid(
+                    "hooks reference `secrets_profile:` but `secrets.provider:` is `command`; \
+                     profiles are an age-only feature today"
+                        .into(),
+                ));
+            }
+            None => {
+                return Err(ConfigError::Invalid(
+                    "hooks reference `secrets_profile:` but no `secrets:` block is configured"
+                        .into(),
+                ));
+            }
+        };
+        for hook in &mut self.hooks.pre_deploy {
+            let Some(name) = hook.secrets_profile.take() else {
+                continue;
+            };
+            let profile = profiles.get(&name).ok_or_else(|| {
+                let known = if profiles.is_empty() {
+                    "(none defined)".into()
+                } else {
+                    profiles.keys().cloned().collect::<Vec<_>>().join(", ")
+                };
+                ConfigError::Invalid(format!(
+                    "hook `{}` references unknown secrets profile {name:?}; known: {known}",
+                    hook.name,
+                ))
+            })?;
+            if !profile.unset.is_empty() {
+                return Err(ConfigError::Invalid(format!(
+                    "hook `{}` references profile {name:?} which sets `unset:` — that field is \
+                     operator-shell-only and can't apply to a hook (hooks run in a fresh \
+                     container with no parent env)",
+                    hook.name,
+                )));
+            }
+            for key in &profile.include {
+                if !hook.secrets.iter().any(|k| k == key) {
+                    hook.secrets.push(key.clone());
+                }
+            }
+            for (bundle_key, env_name) in &profile.rename {
+                hook.env_from_secrets
+                    .entry(env_name.clone())
+                    .or_insert_with(|| bundle_key.clone());
+            }
+        }
+        Ok(())
+    }
+
     #[allow(clippy::too_many_lines)]
     fn validate(&self) -> Result<(), ConfigError> {
         if self.deploy.networks.is_empty() {
             return Err(ConfigError::Invalid(
                 "deploy.networks must declare at least one network".into(),
             ));
+        }
+        if let Some(SecretsConfig::Age { profiles, .. }) = &self.secrets {
+            validate_secrets_profiles(profiles)?;
         }
         // Empty hosts is permitted at load time — operators may
         // bootstrap a project (e.g. `yoink init --create-ssh-key` then
@@ -3101,5 +3321,291 @@ services:
         assert!(!c.requires_configured_registry());
         // And nothing requires a pull at all.
         assert!(!c.any_service_requires_pull());
+    }
+
+    // -- secrets profiles ---------------------------------------------
+
+    fn config_with_profiles_yaml(extra_hook: &str) -> String {
+        format!(
+            r#"
+deploy:
+  networks: [smoke]
+hosts:
+  - {{ address: h1, user: root }}
+services:
+  - name: app
+    image: nginx
+    tag: "1"
+    run: {{ port: 80, healthcheck_path: / }}
+secrets:
+  provider: age
+  recipients: [age1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq8jhcsq]
+  profiles:
+    terraform-backblaze:
+      include: [TFSTATE_B2_KEY_ID, TFSTATE_B2_APPLICATION_KEY,
+                B2_APPLICATION_KEY_ID, B2_APPLICATION_KEY]
+      rename:
+        TFSTATE_B2_KEY_ID:          AWS_ACCESS_KEY_ID
+        TFSTATE_B2_APPLICATION_KEY: AWS_SECRET_ACCESS_KEY
+        B2_APPLICATION_KEY_ID:      TF_VAR_b2_application_key_id
+        B2_APPLICATION_KEY:         TF_VAR_b2_application_key
+      unset: [B2_ENDPOINT, B2_BUCKET_NAME]
+    needs-unset:
+      include: [FOO]
+      unset: [PARENT_LEAK]
+hooks:
+  pre_deploy:
+{extra_hook}
+"#
+        )
+    }
+
+    fn parse_via_temp(yaml: &str) -> Result<Config, ConfigError> {
+        let dir = write_temp_tree(&[("yoink.yaml", yaml)]);
+        Config::load_from_path(&dir.join("yoink.yaml"))
+    }
+
+    #[test]
+    fn profiles_round_trip_through_load() {
+        let cfg = parse_via_temp(&config_with_profiles_yaml("")).unwrap();
+        let Some(SecretsConfig::Age { profiles, .. }) = &cfg.secrets else {
+            panic!("expected age secrets");
+        };
+        assert!(profiles.contains_key("terraform-backblaze"));
+        let p = &profiles["terraform-backblaze"];
+        assert_eq!(p.include.len(), 4);
+        assert_eq!(
+            p.rename.get("TFSTATE_B2_KEY_ID").map(String::as_str),
+            Some("AWS_ACCESS_KEY_ID")
+        );
+        assert_eq!(
+            p.unset,
+            vec!["B2_ENDPOINT".to_string(), "B2_BUCKET_NAME".into()]
+        );
+    }
+
+    #[test]
+    fn profile_rename_target_must_be_env_var_safe() {
+        let yaml = r#"
+deploy:
+  networks: [n]
+hosts:
+  - { address: h, user: root }
+services:
+  - name: a
+    image: i
+    tag: v1
+    run: {}
+secrets:
+  provider: age
+  recipients: [age1xyz]
+  profiles:
+    bad:
+      include: [FOO]
+      rename:
+        FOO: aws-access-key
+"#;
+        let err = parse_via_temp(yaml).unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("not a valid env var name"),
+            "expected env-var-name error, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn profile_rename_target_collision_rejected() {
+        let yaml = r#"
+deploy:
+  networks: [n]
+hosts:
+  - { address: h, user: root }
+services:
+  - name: a
+    image: i
+    tag: v1
+    run: {}
+secrets:
+  provider: age
+  recipients: [age1xyz]
+  profiles:
+    bad:
+      include: [FOO, BAR]
+      rename:
+        FOO: AWS_ACCESS_KEY_ID
+        BAR: AWS_ACCESS_KEY_ID
+"#;
+        let err = parse_via_temp(yaml).unwrap_err();
+        assert!(err.to_string().contains("appears twice"));
+    }
+
+    #[test]
+    fn profile_rename_source_must_be_in_include() {
+        let yaml = r#"
+deploy:
+  networks: [n]
+hosts:
+  - { address: h, user: root }
+services:
+  - name: a
+    image: i
+    tag: v1
+    run: {}
+secrets:
+  provider: age
+  recipients: [age1xyz]
+  profiles:
+    bad:
+      include: [FOO]
+      rename:
+        BAR: AWS_ACCESS_KEY_ID
+"#;
+        let err = parse_via_temp(yaml).unwrap_err();
+        assert!(err.to_string().contains("not in `include`"));
+    }
+
+    #[test]
+    fn profile_name_must_be_kebab_case() {
+        let yaml = r#"
+deploy:
+  networks: [n]
+hosts:
+  - { address: h, user: root }
+services:
+  - name: a
+    image: i
+    tag: v1
+    run: {}
+secrets:
+  provider: age
+  recipients: [age1xyz]
+  profiles:
+    "Bad Profile":
+      include: [FOO]
+"#;
+        let err = parse_via_temp(yaml).unwrap_err();
+        assert!(err.to_string().contains("[a-z0-9-]"));
+    }
+
+    #[test]
+    fn old_yaml_without_profiles_block_parses_unchanged() {
+        let yaml = r#"
+deploy:
+  networks: [n]
+hosts:
+  - { address: h, user: root }
+services:
+  - name: a
+    image: i
+    tag: v1
+    run: {}
+secrets:
+  provider: age
+  recipients: [age1xyz]
+"#;
+        let cfg = parse_via_temp(yaml).unwrap();
+        let Some(SecretsConfig::Age { profiles, .. }) = &cfg.secrets else {
+            panic!("expected age secrets");
+        };
+        assert!(profiles.is_empty());
+    }
+
+    // -- hook desugar -------------------------------------------------
+
+    #[test]
+    fn hook_secrets_profile_desugars_into_secrets_and_renames() {
+        let hook = r#"
+    - name: cf-tf
+      image: hashicorp/terraform
+      tag: "1.9"
+      cmd: ["apply"]
+      secrets_profile: terraform-backblaze
+"#;
+        // Drop `unset:` from the profile we reference because hooks
+        // can't honor it; this test verifies the happy desugar path.
+        let yaml = config_with_profiles_yaml(hook)
+            .replace("      unset: [B2_ENDPOINT, B2_BUCKET_NAME]\n", "");
+        let cfg = parse_via_temp(&yaml).unwrap();
+        let h = &cfg.hooks.pre_deploy[0];
+        // After desugar, the field is None — downstream code is
+        // profile-agnostic.
+        assert!(h.secrets_profile.is_none());
+        // Include set merged into `secrets`.
+        for key in [
+            "TFSTATE_B2_KEY_ID",
+            "TFSTATE_B2_APPLICATION_KEY",
+            "B2_APPLICATION_KEY_ID",
+            "B2_APPLICATION_KEY",
+        ] {
+            assert!(h.secrets.iter().any(|s| s == key), "missing {key}");
+        }
+        // Rename merged into env_from_secrets ({env_name: bundle_key}).
+        assert_eq!(
+            h.env_from_secrets
+                .get("AWS_ACCESS_KEY_ID")
+                .map(String::as_str),
+            Some("TFSTATE_B2_KEY_ID")
+        );
+        assert_eq!(
+            h.env_from_secrets
+                .get("TF_VAR_b2_application_key")
+                .map(String::as_str),
+            Some("B2_APPLICATION_KEY")
+        );
+    }
+
+    #[test]
+    fn hook_explicit_env_from_secrets_wins_over_profile() {
+        let hook = r#"
+    - name: cf-tf
+      image: hashicorp/terraform
+      tag: "1.9"
+      cmd: ["apply"]
+      secrets_profile: terraform-backblaze
+      env_from_secrets:
+        AWS_ACCESS_KEY_ID: SOMETHING_ELSE
+"#;
+        let yaml = config_with_profiles_yaml(hook)
+            .replace("      unset: [B2_ENDPOINT, B2_BUCKET_NAME]\n", "");
+        let cfg = parse_via_temp(&yaml).unwrap();
+        let h = &cfg.hooks.pre_deploy[0];
+        // Operator's explicit mapping survives the merge.
+        assert_eq!(
+            h.env_from_secrets
+                .get("AWS_ACCESS_KEY_ID")
+                .map(String::as_str),
+            Some("SOMETHING_ELSE")
+        );
+    }
+
+    #[test]
+    fn hook_referencing_unknown_profile_rejected() {
+        let hook = r#"
+    - name: cf-tf
+      image: hashicorp/terraform
+      tag: "1.9"
+      cmd: ["apply"]
+      secrets_profile: does-not-exist
+"#;
+        let yaml = config_with_profiles_yaml(hook);
+        let err = parse_via_temp(&yaml).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("does-not-exist"), "got: {msg}");
+        assert!(msg.contains("known:"));
+    }
+
+    #[test]
+    fn hook_referencing_profile_with_unset_rejected() {
+        let hook = r#"
+    - name: tf
+      image: hashicorp/terraform
+      tag: "1.9"
+      cmd: ["apply"]
+      secrets_profile: needs-unset
+"#;
+        let yaml = config_with_profiles_yaml(hook);
+        let err = parse_via_temp(&yaml).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("operator-shell-only"), "got: {msg}");
     }
 }

--- a/yoink/src/deploy.rs
+++ b/yoink/src/deploy.rs
@@ -576,7 +576,7 @@ pub async fn deploy_service(
     // `created`-state containers hanging around until the next prune.
     for hook in &service.pre_deploy {
         let hook_tag = resolve_hook_tag(hook, &BTreeMap::new(), &config.services);
-        let resolved_tag = if matches!(hook.tag, HookTag::Ref { .. }) {
+        let resolved_tag = if matches!(hook.tag, Some(HookTag::Ref { .. })) {
             // For `tag: { service: <self> }`, use the deploy-time tag
             // we were called with rather than the static fallback.
             tag.to_string()
@@ -1618,12 +1618,19 @@ async fn swap_out_old_containers_by_set(
     Ok(stopped)
 }
 
+/// Resolve a container hook's tag. Subprocess hooks have no tag —
+/// callers should check `hook.is_subprocess()` first; this helper
+/// returns an empty string when called on a hook with no tag set
+/// (defensive fallback; should be unreachable after `validate()`).
 fn resolve_hook_tag(
     hook: &HookSpec,
     overrides: &BTreeMap<String, String>,
     services: &[ServiceConfig],
 ) -> String {
-    match &hook.tag {
+    let Some(tag) = hook.tag.as_ref() else {
+        return String::new();
+    };
+    match tag {
         HookTag::Literal(t) => t.clone(),
         HookTag::Ref { service: name } => overrides.get(name).cloned().unwrap_or_else(|| {
             services
@@ -1635,8 +1642,12 @@ fn resolve_hook_tag(
     }
 }
 
-/// Run a one-shot hook container on the first applicable host. Pulls
-/// the image, runs to completion, surfaces stdout+stderr on failure.
+/// Dispatch a hook to either the container path (image+tag, runs in
+/// docker via `run_one_shot`) or the subprocess path (no image, runs
+/// `cmd[0]` directly on the operator's machine with the resolved env
+/// merged in). Validation guarantees `image`/`tag` are both Some for
+/// container hooks and both None for subprocess hooks; the dispatch
+/// here only has to honor that invariant.
 async fn run_hook(
     ops: &dyn DockerOps,
     config: &Config,
@@ -1644,14 +1655,21 @@ async fn run_hook(
     tag: &str,
     secrets: Option<&SecretsBundle>,
 ) -> Result<(), DeployError> {
+    if hook.is_subprocess() {
+        return run_subprocess_hook(config, hook, secrets).await;
+    }
     let host_cfg = config.hosts.first().ok_or_else(|| DeployError::Hook {
         name: hook.name.clone(),
         message: "no hosts configured".into(),
     })?;
     let host = Host::from(host_cfg);
 
+    let image = hook
+        .image
+        .as_deref()
+        .expect("validated: container hook has image");
     let credentials = registry_credentials(config, secrets);
-    ops.pull_image(&host, &hook.image, tag, credentials)
+    ops.pull_image(&host, image, tag, credentials)
         .await
         .map_err(|source| DeployError::Docker {
             host: host.address.clone(),
@@ -1668,7 +1686,7 @@ async fn run_hook(
         .first()
         .map_or("bridge", String::as_str);
     let body = docker::build_hook_container(
-        &hook.image,
+        image,
         tag,
         hook_network,
         hook.entrypoint.as_deref(),
@@ -1712,6 +1730,88 @@ fn hook_env(hook: &HookSpec, secrets: Option<&SecretsBundle>) -> BTreeMap<String
         }
     }
     env
+}
+
+/// Run a subprocess hook on the operator's machine. Inherits the
+/// parent env, applies the profile's `unset` list (via
+/// `Command::env_remove`), then layers the resolved hook env on top
+/// (merged from `env` + sealed `secrets` + `env_from_secrets`). Sets
+/// `working_dir` if specified, falling back to the directory of
+/// `yoink.yaml`. Forwards stdout/stderr to the operator's terminal —
+/// terraform's plan output stays live. Non-zero exit fails the deploy.
+async fn run_subprocess_hook(
+    config: &Config,
+    hook: &HookSpec,
+    secrets: Option<&SecretsBundle>,
+) -> Result<(), DeployError> {
+    if hook.cmd.is_empty() {
+        return Err(DeployError::Hook {
+            name: hook.name.clone(),
+            message: "subprocess hook has no `cmd:` to run".into(),
+        });
+    }
+    let mut command = tokio::process::Command::new(&hook.cmd[0]);
+    if hook.cmd.len() > 1 {
+        command.args(&hook.cmd[1..]);
+    }
+
+    // Working dir: explicit `working_dir:` if set, else yoink.yaml's
+    // directory. The latter matches how operators expect relative
+    // paths in `cmd:` to resolve when they pass things like
+    // `terraform -chdir=../terraform/cloudflare`.
+    let base = config
+        .config_dir
+        .clone()
+        .unwrap_or_else(|| std::path::PathBuf::from("."));
+    let cwd = match &hook.working_dir {
+        Some(rel) if rel.is_absolute() => rel.clone(),
+        Some(rel) => base.join(rel),
+        None => base,
+    };
+    command.current_dir(&cwd);
+
+    // Apply the profile's `unset` list — clears any conflicting
+    // var the parent shell exported (devbox `init_hook` leaks,
+    // operator's own `export …`) before yoink layers the new env on
+    // top. Container hooks can't honor this (no parent env to
+    // clear); the validation pass at config-load rejects the combo.
+    if let Some(profile_name) = hook.secrets_profile.as_deref()
+        && let Some(crate::config::SecretsConfig::Age { profiles, .. }) = &config.secrets
+        && let Some(profile) = profiles.get(profile_name)
+    {
+        for key in &profile.unset {
+            command.env_remove(key);
+        }
+    }
+
+    // Layer the resolved hook env on top of the inherited parent env.
+    for (k, v) in hook_env(hook, secrets) {
+        command.env(k, v);
+    }
+
+    // Forward stdout/stderr live; the operator should see terraform's
+    // plan output as it streams. Capture nothing here — yoink's deploy
+    // log shows which hook ran via `HookStarted`/`HookFinished`.
+    command.stdout(std::process::Stdio::inherit());
+    command.stderr(std::process::Stdio::inherit());
+
+    let status = command.status().await.map_err(|e| DeployError::Hook {
+        name: hook.name.clone(),
+        message: format!("spawn `{}`: {e}", hook.cmd[0]),
+    })?;
+    if !status.success() {
+        return Err(DeployError::Hook {
+            name: hook.name.clone(),
+            message: format!(
+                "subprocess `{}` exited {}",
+                hook.cmd[0],
+                status
+                    .code()
+                    .map_or_else(|| "by signal".to_string(), |c| format!("with code {c}"))
+            ),
+        });
+    }
+    Ok(())
 }
 
 #[cfg(test)]

--- a/yoink/src/doctor.rs
+++ b/yoink/src/doctor.rs
@@ -564,7 +564,10 @@ async fn check_dns_for_domains(config: &Config) -> Vec<Finding> {
 // ---------- sealed.age existence ----------
 
 fn check_sealed_file_exists(config: &Config) -> Vec<Finding> {
-    let Some(SecretsConfig::Age { file, recipients }) = &config.secrets else {
+    let Some(SecretsConfig::Age {
+        file, recipients, ..
+    }) = &config.secrets
+    else {
         return vec![Finding::pass(
             "secrets",
             "sealed file check skipped (not using `provider: age`)",

--- a/yoink/src/main.rs
+++ b/yoink/src/main.rs
@@ -844,6 +844,14 @@ enum SecretsAction {
         /// consume dotenv-style files rather than shell `source`.
         #[arg(long)]
         no_export: bool,
+        /// Apply a named profile from `secrets.profiles` in
+        /// `yoink.yaml`: filter the bundle to the profile's `include`
+        /// keys, rename per the profile's `rename` map, and emit
+        /// `unset 'KEY'` lines for each `unset:` entry before the
+        /// exports. Designed for Terraform / CI consumers — see the
+        /// "use the bundle from terraform" how-to.
+        #[arg(long, value_name = "NAME")]
+        profile: Option<String>,
     },
     /// One-shot: read a plaintext dotenv from `--in` (or stdin) OR
     /// individual `--as KEY=...` pairs, **merge** into the existing
@@ -4644,7 +4652,9 @@ fn cmd_secrets(config: &Config, action: SecretsAction) -> Result<()> {
         },
         SecretsAction::Edit => cmd_secrets_edit(config),
         SecretsAction::Show { reveal } => cmd_secrets_show(config, reveal),
-        SecretsAction::Env { no_export } => cmd_secrets_env(config, no_export),
+        SecretsAction::Env { no_export, profile } => {
+            cmd_secrets_env(config, no_export, profile.as_deref())
+        }
         SecretsAction::Seal {
             r#in,
             as_pairs,
@@ -4909,7 +4919,10 @@ fn cmd_secrets_show(config: &Config, reveal: bool) -> Result<()> {
              not into build logs), set YOINK_ALLOW_REVEAL_IN_CI=1"
         ));
     }
-    let SecretsConfig::Age { file, recipients } = expect_secrets_provider_age(config)? else {
+    let SecretsConfig::Age {
+        file, recipients, ..
+    } = expect_secrets_provider_age(config)?
+    else {
         unreachable!()
     };
     let path = sealed::resolve_sealed_path(config, file.as_deref())?;
@@ -4928,7 +4941,7 @@ fn cmd_secrets_show(config: &Config, reveal: bool) -> Result<()> {
     Ok(())
 }
 
-fn cmd_secrets_env(config: &Config, no_export: bool) -> Result<()> {
+fn cmd_secrets_env(config: &Config, no_export: bool, profile_name: Option<&str>) -> Result<()> {
     use yoink::config::SecretsConfig;
     use yoink::sealed;
     if let Some(ci_var) = detected_ci_env()
@@ -4940,8 +4953,28 @@ fn cmd_secrets_env(config: &Config, no_export: bool) -> Result<()> {
              If this is intentional, set YOINK_ALLOW_REVEAL_IN_CI=1"
         ));
     }
-    let SecretsConfig::Age { file, recipients } = expect_secrets_provider_age(config)? else {
+    let SecretsConfig::Age {
+        file,
+        recipients,
+        profiles,
+        ..
+    } = expect_secrets_provider_age(config)?
+    else {
         unreachable!()
+    };
+    // Resolve the profile up front so we fail before unsealing if it
+    // doesn't exist — better diagnostic than "key X is missing" when
+    // the operator typo'd the profile name.
+    let profile = match profile_name {
+        Some(name) => Some(profiles.get(name).ok_or_else(|| {
+            let known = if profiles.is_empty() {
+                "(none defined in secrets.profiles)".into()
+            } else {
+                profiles.keys().cloned().collect::<Vec<_>>().join(", ")
+            };
+            anyhow::anyhow!("unknown profile {name:?}; known: {known}")
+        })?),
+        None => None,
     };
     let path = sealed::resolve_sealed_path(config, file.as_deref())?;
     let bytes =
@@ -4949,9 +4982,63 @@ fn cmd_secrets_env(config: &Config, no_export: bool) -> Result<()> {
     let identity = sealed::load_identity(recipients)?;
     let plaintext = sealed::unseal(&bytes, &identity)?;
     let parsed = sealed::parse_dotenv(&plaintext)?;
+
+    // Resolve the profile against the unsealed bundle: filter to
+    // `include`, then map each key through `rename`. Emits a stable
+    // ordering: BTreeMap iteration is alphabetical, matching the
+    // existing no-profile path.
+    let resolved: Vec<(String, &str)> = if let Some(p) = profile {
+        // Verify every `include` key exists before emitting anything,
+        // so a typo'd key fails loud instead of silently dropping.
+        for key in &p.include {
+            if !parsed.contains_key(key) {
+                anyhow::bail!(
+                    "profile {:?} references key {key:?} which is not present in the sealed bundle",
+                    profile_name.unwrap_or("?")
+                );
+            }
+        }
+        let allowed: Option<std::collections::BTreeSet<&String>> = if p.include.is_empty() {
+            None
+        } else {
+            Some(p.include.iter().collect())
+        };
+        parsed
+            .iter()
+            .filter(|(k, _)| allowed.as_ref().is_none_or(|set| set.contains(*k)))
+            .map(|(k, v)| {
+                let env_name = p.rename.get(k).cloned().unwrap_or_else(|| k.clone());
+                (env_name, v.as_str())
+            })
+            .collect()
+    } else {
+        parsed
+            .iter()
+            .map(|(k, v)| (k.clone(), v.as_str()))
+            .collect()
+    };
+
+    // GitHub Actions auto-mask: when the operator's environment has
+    // `GITHUB_ENV` (always true on a runner), prepend per-value
+    // `::add-mask::` lines so any later log of the value gets
+    // redacted. Removes the per-key copy-paste boilerplate from CI
+    // workflows and makes "I forgot to mask this new key" impossible.
+    let in_github_actions = std::env::var_os("GITHUB_ENV").is_some();
+    if in_github_actions {
+        for (_name, value) in &resolved {
+            println!("echo '::add-mask::{}'", value.replace('\'', r"'\''"));
+        }
+    }
+
+    if let Some(p) = profile {
+        for u in &p.unset {
+            println!("unset '{u}'");
+        }
+    }
+
     let prefix = if no_export { "" } else { "export " };
-    for (k, v) in &parsed {
-        println!("{prefix}{k}={}", posix_single_quote(v));
+    for (name, value) in &resolved {
+        println!("{prefix}{name}={}", posix_single_quote(value));
     }
     Ok(())
 }
@@ -5236,7 +5323,10 @@ fn expect_secrets_provider_age(config: &Config) -> Result<&yoink::config::Secret
 
 fn expect_age_block(config: &Config) -> Result<(Option<String>, &Vec<String>)> {
     use yoink::config::SecretsConfig;
-    let SecretsConfig::Age { file, recipients } = expect_secrets_provider_age(config)? else {
+    let SecretsConfig::Age {
+        file, recipients, ..
+    } = expect_secrets_provider_age(config)?
+    else {
         unreachable!()
     };
     if recipients.is_empty() {

--- a/yoink/src/main.rs
+++ b/yoink/src/main.rs
@@ -4983,34 +4983,36 @@ fn cmd_secrets_env(config: &Config, no_export: bool, profile_name: Option<&str>)
     let plaintext = sealed::unseal(&bytes, &identity)?;
     let parsed = sealed::parse_dotenv(&plaintext)?;
 
-    // Resolve the profile against the unsealed bundle: filter to
-    // `include`, then map each key through `rename`. Emits a stable
-    // ordering: BTreeMap iteration is alphabetical, matching the
-    // existing no-profile path.
+    // Resolve the profile against the unsealed bundle. With a
+    // non-empty `include`, walk the include list (typically small —
+    // O(profile keys)) and look each up in the bundle, instead of
+    // walking the whole bundle and filtering. Sorted for stable
+    // output order.
     let resolved: Vec<(String, &str)> = if let Some(p) = profile {
-        // Verify every `include` key exists before emitting anything,
-        // so a typo'd key fails loud instead of silently dropping.
-        for key in &p.include {
-            if !parsed.contains_key(key) {
-                anyhow::bail!(
-                    "profile {:?} references key {key:?} which is not present in the sealed bundle",
-                    profile_name.unwrap_or("?")
-                );
-            }
-        }
-        let allowed: Option<std::collections::BTreeSet<&String>> = if p.include.is_empty() {
-            None
+        let mut out: Vec<(String, &str)> = if p.include.is_empty() {
+            parsed
+                .iter()
+                .map(|(k, v)| {
+                    let env_name = p.rename.get(k).cloned().unwrap_or_else(|| k.clone());
+                    (env_name, v.as_str())
+                })
+                .collect()
         } else {
-            Some(p.include.iter().collect())
+            let mut acc = Vec::with_capacity(p.include.len());
+            for key in &p.include {
+                let value = parsed.get(key).ok_or_else(|| {
+                    anyhow::anyhow!(
+                        "profile {:?} references key {key:?} which is not present in the sealed bundle",
+                        profile_name.unwrap_or("?")
+                    )
+                })?;
+                let env_name = p.rename.get(key).cloned().unwrap_or_else(|| key.clone());
+                acc.push((env_name, value.as_str()));
+            }
+            acc
         };
-        parsed
-            .iter()
-            .filter(|(k, _)| allowed.as_ref().is_none_or(|set| set.contains(*k)))
-            .map(|(k, v)| {
-                let env_name = p.rename.get(k).cloned().unwrap_or_else(|| k.clone());
-                (env_name, v.as_str())
-            })
-            .collect()
+        out.sort_by(|a, b| a.0.cmp(&b.0));
+        out
     } else {
         parsed
             .iter()
@@ -5026,7 +5028,14 @@ fn cmd_secrets_env(config: &Config, no_export: bool, profile_name: Option<&str>)
     let in_github_actions = std::env::var_os("GITHUB_ENV").is_some();
     if in_github_actions {
         for (_name, value) in &resolved {
-            println!("echo '::add-mask::{}'", value.replace('\'', r"'\''"));
+            // Wrap the whole `::add-mask::<value>` payload in a
+            // single-quoted shell string so the log redaction matches
+            // the literal value, even if it contains shell
+            // metacharacters.
+            println!(
+                "echo {}",
+                posix_single_quote(&format!("::add-mask::{value}"))
+            );
         }
     }
 

--- a/yoink/src/secrets.rs
+++ b/yoink/src/secrets.rs
@@ -222,7 +222,9 @@ pub async fn load_bundle(config: &Config) -> Result<Option<SecretsBundle>, Secre
     };
     let any_secrets_referenced = config_references_secrets(config);
     let bundle = match cfg {
-        SecretsConfig::Age { file, recipients } => {
+        SecretsConfig::Age {
+            file, recipients, ..
+        } => {
             let path = sealed::resolve_sealed_path(config, file.as_deref())?;
             load_age_bundle(&path, recipients, any_secrets_referenced)?
         }

--- a/yoink/src/tui/secrets.rs
+++ b/yoink/src/tui/secrets.rs
@@ -665,7 +665,9 @@ fn load(config: &Config) -> LoadStatus {
                 write_target: None,
             })
         }
-        SecretsConfig::Age { file, recipients } => {
+        SecretsConfig::Age {
+            file, recipients, ..
+        } => {
             let path = match sealed::resolve_sealed_path(config, file.as_deref()) {
                 Ok(p) => p,
                 Err(e) => return LoadStatus::Failed(e.to_string()),


### PR DESCRIPTION
## Summary

Adds `secrets.profiles:` to `yoink.yaml` — named recipes that capture *what env shape one downstream tool expects*. The same recipe drives both `yoink secrets env --profile <NAME>` (Taskfiles, CI workflows) and `hooks.pre_deploy[].secrets_profile: <NAME>` (in-deploy hooks). Mapping lives next to the bundle that supplies the values instead of being copy-pasted into N Taskfiles + N CI workflows.

```yaml
# deploy-prod/yoink.yaml
secrets:
  provider: age
  recipients: [age1…]
  profiles:
    terraform-backblaze:
      include: [TFSTATE_B2_KEY_ID, TFSTATE_B2_APPLICATION_KEY,
                B2_APPLICATION_KEY_ID, B2_APPLICATION_KEY]
      rename:
        TFSTATE_B2_KEY_ID:          AWS_ACCESS_KEY_ID
        TFSTATE_B2_APPLICATION_KEY: AWS_SECRET_ACCESS_KEY
        B2_APPLICATION_KEY_ID:      TF_VAR_b2_application_key_id
        B2_APPLICATION_KEY:         TF_VAR_b2_application_key
      unset: [B2_ENDPOINT, B2_BUCKET_NAME]
```

### Two consumers, same recipe

**Operator shell / Taskfile:**

```yaml
env:
  YOINK_TF:
    sh: cd ../../deploy-prod && yoink secrets env --profile terraform-backblaze
tasks:
  tf:plan:
    cmds:
      - eval \"\$YOINK_TF\" && terraform plan
```

Replaces the existing N×4-line `sh: bash -c '… eval … printf \"\$X\"'` extractor blocks per Taskfile with one invocation.

**Pre-deploy hook (yoink can `terraform apply` as part of a deploy):**

```yaml
hooks:
  pre_deploy:
    - name: cloudflare-tf-apply
      image: hashicorp/terraform
      tag: \"1.9\"
      entrypoint: [\"/bin/sh\", \"-c\"]
      cmd: [\"cd /tf && terraform init && terraform apply -auto-approve\"]
      secrets_profile: terraform-cloudflare
```

Profile is desugared at config-load time: `include` merges into hook `secrets`, `rename` merges into `env_from_secrets`. Hook's own entries take precedence on key collision. `spec_hash` folds in the renamed env keys exactly as before — drift detection works.

**CI auto-mask:** when `\$GITHUB_ENV` is set in the environment (always true on a GHA runner), `secrets env` auto-prepends `echo '::add-mask::<value>'` for every revealed value before the exports. No per-key copy-paste; new keys added to the profile are masked automatically.

### Validation

- Profile names match `[a-z0-9-]+`.
- Rename targets must be POSIX env-var names (`[A-Za-z_][A-Za-z0-9_]*`); mixed case allowed because Terraform's `TF_VAR_<varname>` puts the (lowercase) variable name in the suffix.
- No rename target collisions.
- Rename source must be in `include` when `include` is non-empty.
- `unset` is operator-shell-only — referencing a profile with non-empty `unset` from a hook is a config-validation error with a clear message.
- Unknown profile name → hard error listing known names.
- Bundle-key existence checked at resolve time (loud-fail beats silent empty creds).

## Test plan

- [x] **Schema/parse/validate**: 9 new tests in `yoink/src/config.rs` cover round-trip, env-var-name rejection, rename collision, rename-not-in-include, profile-name format, old-yaml-without-profiles parse, hook desugar happy path, hook env_from_secrets precedence, unknown profile rejection, hook-references-profile-with-unset rejection.
- [x] `cargo test -p yoink` — 496 pass (was 487).
- [x] `cargo clippy -p yoink --lib --bin yoink -- -D warnings` — no new lints (the 2 pre-existing on `main` are unchanged).
- [x] `cargo fmt --check` clean.
- [x] **End-to-end smoke** against the bt `deploy-prod/yoink.yaml`: added two profiles (`terraform-backblaze`, `terraform-cloudflare`), validate passes (\"6 services across 1 hosts\"), `secrets env --profile terraform-backblaze` emits the expected 4×`unset` + 4×renamed `export` lines, unknown profile gives a clear listing of known names, `GITHUB_ENV=…` auto-masks every revealed value before exports.
- [x] `pnpm build` for docs: 151 pages (was 148), no errors. New \"Use the bundle from Terraform / CI\" subsection in the sealed-secrets how-to + new schema entry in the config reference + new `--profile` entry in the CLI reference.

## Out of scope

- Profiles for `provider: command`. Out of scope; profiles live on the age variant for now.
- A separate `yoink-secrets-profiles.yaml` file. Inline in yoink.yaml is fine for the bt scale (~5 profiles).
- `yoink secrets profiles list` introspection. Trivial follow-up if anyone asks.
- Post-deploy hooks (yoink only has pre-deploy today). Profiles will compose with whatever post-deploy looks like when added.

The `~/bt` repo migration to use this (Taskfiles + CI workflows + `deploy-prod/yoink.yaml` profile entries + an optional pre_deploy cloudflare-tf hook) is a separate PR there, after this lands.