### PR TITLE
feat(webhooks): outbound HTTP notifications on run-level events

### DIFF
--- a/docs/content/docs/how-to/meta.json
+++ b/docs/content/docs/how-to/meta.json
@@ -27,6 +27,7 @@
     "multi-host-redis-storage",
     "---Operations---",
     "audit-log",
+    "notify-on-deploy",
     "---Developer Tooling---",
     "vscode"
   ]

--- a/docs/content/docs/how-to/notify-on-deploy.md
+++ b/docs/content/docs/how-to/notify-on-deploy.md
@@ -1,0 +1,158 @@
+---
+title: Notify chat / paging / observability on deploy
+description: Fire HTTP webhooks on `RunStarted` / `RunFinished` to ntfy, Slack, Grafana, or any other receiver. Templated bodies, `${secret:NAME}` for auth, audited via `WebhookFired`.
+---
+
+A deploy that succeeds quietly is fine until the room wants to know it shipped. The `webhooks:` block declares outbound HTTP calls that fire on the run's lifecycle events — `run_started`, `run_succeeded`, `run_failed` — with templated url, headers, and body, and `${secret:NAME}` placeholders resolved against the sealed bundle so bearer tokens never sit in the config plaintext.
+
+Webhooks are operator-side and best-effort: the call goes out from the box running `yoink up`, a failure is recorded as a `WebhookFired { ok: false }` audit event, and the deploy never aborts on a webhook error.
+
+## Triggers
+
+| trigger | fired after | template `event` | `error` populated |
+|---|---|---|---|
+| `run_started` | the `RunStarted` audit line lands | `"run_started"` | no |
+| `run_succeeded` | `RunFinished { ok: true }` | `"run_succeeded"` | no |
+| `run_failed` | `RunFinished { ok: false }` | `"run_failed"` | yes — operator-facing error message |
+
+Subscribe each webhook to a subset; `on:` must list at least one trigger.
+
+## Template context
+
+Every templated field renders through minijinja with strict undefined-variable behavior — a typo in `{{ servicse }}` fails the render and lands as `WebhookFired { ok: false }` instead of silently sending an empty string.
+
+| variable | type | notes |
+|---|---|---|
+| `event` | string | `"run_started"`, `"run_succeeded"`, `"run_failed"`. |
+| `ok` | bool | `true` for `run_started` / `run_succeeded`, `false` for `run_failed`. |
+| `command` | string | `up`, `rollback`, etc. |
+| `services` | array&lt;string&gt; | Selected services. Empty for fleet-wide commands. |
+| `deploy_id` | string | `UUIDv7` matching the `deploy_id` in the audit log. |
+| `actor` | string | `$USER@$HOSTNAME` of the operator. |
+| `host` | string | Operator's hostname. |
+| `git_sha` | string \| null | Short SHA of the operator's working tree. |
+| `yoink_version` | string |  |
+| `error` | string \| null | Operator-visible failure message; only set on `run_failed`. |
+| `ts` | string | RFC 3339 timestamp the webhook rendered at. |
+
+## ntfy.sh
+
+Public push notifications, no auth, GET-or-POST to `https://ntfy.sh/<topic>`. Subscribe to the topic in the ntfy app or `ntfy sub <topic>`.
+
+```yaml
+webhooks:
+  - name: ntfy
+    url: https://ntfy.sh/my-deploys
+    on: [run_started, run_succeeded, run_failed]
+    headers:
+      Title: "yoink {{ event }}"
+      Tags: "{% if ok %}rocket{% else %}warning{% endif %}"
+    body: >
+      {{ command }} {{ services | join(",") }} on {{ host }}
+      ({{ deploy_id }}){% if error %} — {{ error }}{% endif %}
+```
+
+`Tags` rides on ntfy's emoji aliasing — `rocket` renders as a rocket, `warning` as a warning sign, so success and failure render with different glyphs.
+
+## Slack incoming webhooks
+
+Slack's [incoming webhooks](https://api.slack.com/messaging/webhooks) take a JSON body with a `text` field. The webhook URL itself is the credential — keep it sealed.
+
+```yaml
+secrets:
+  provider: age
+  recipients: [age1…]
+  # SLACK_WEBHOOK_PATH = services/T0…/B0…/abc123  (the path under hooks.slack.com)
+
+webhooks:
+  - name: slack-deploys
+    url: "https://hooks.slack.com/${secret:SLACK_WEBHOOK_PATH}"
+    on: [run_succeeded, run_failed]
+    headers:
+      Content-Type: application/json
+    body: |
+      {
+        "text": "{% if ok %}:white_check_mark:{% else %}:x:{% endif %} *{{ command }}* {{ services | join(', ') }} ({{ deploy_id }}){% if error %} — `{{ error }}`{% endif %}"
+      }
+```
+
+The full URL is `https://hooks.slack.com/services/T…/B…/…`, but only the path varies between workspaces — splitting at `/services/` keeps the host literal in the config and only the path sealed.
+
+## Grafana annotations
+
+[Grafana's annotations API](https://grafana.com/docs/grafana/latest/developers/http_api/annotations/) marks a vertical line on every dashboard at the moment of the call. Pin deploy events on your latency / error-rate dashboards so the cause of an inflection is one glance away.
+
+```yaml
+webhooks:
+  - name: grafana-annotation
+    url: https://grafana.example.com/api/annotations
+    on: [run_succeeded]
+    headers:
+      Authorization: "Bearer ${secret:GRAFANA_API_TOKEN}"
+      Content-Type: application/json
+    body: |
+      {
+        "tags": ["deploy", "yoink", "{{ command }}"],
+        "text": "{{ services | join(', ') }} → {{ git_sha }} ({{ deploy_id }})"
+      }
+```
+
+Annotations are dashboard-wide unless `dashboardUID:` / `panelId:` are set; see the Grafana API docs.
+
+## Field reference
+
+| field | type | default | notes |
+|---|---|---|---|
+| `name` | string | required | Identifier shown in `WebhookFired` audit events. Must be unique across the `webhooks:` list. |
+| `url` | string | required | Templated. Must resolve to `http(s)://…` after `${secret:NAME}` substitution. |
+| `on` | list of trigger | required | One or more of `run_started`, `run_succeeded`, `run_failed`. |
+| `method` | `GET` \| `POST` \| `PUT` | `POST` |  |
+| `timeout` | duration | `10s` | Per-request timeout, parsed by `humantime` (`5s`, `2m`, …). |
+| `headers` | map of string | `{}` | Each value is templated. |
+| `body` | string | unset | Templated. Omit for GET-style receivers (e.g. ntfy URL-only triggers). |
+
+## Secrets in templates
+
+`${secret:NAME}` inside `url`, any header value, or `body` is replaced with the decrypted value from the sealed bundle before minijinja runs. Two passes, in this order:
+
+1. Literal `${secret:NAME}` → bundle value. Missing key (or no `secrets:` provider configured at all) is an error — no silent empty substitution.
+2. minijinja render with `UndefinedBehavior::Strict`. A typo in a `{{ var }}` fails the render.
+
+Both kinds of error land as `WebhookFired { ok: false, error: "<reason>" }` in the audit log; the deploy proceeds.
+
+The two-pass order matters: secrets resolve first, so a secret value that happens to contain `{{` won't be re-templated.
+
+## Audit trail
+
+Every fire — success or failure — records a [`WebhookFired`](/docs/reference/audit-event-schema#webhookfired) audit event:
+
+```sh
+yoink audit log --event WebhookFired --since 1h
+yoink audit run <deploy-id> | grep WebhookFired
+```
+
+Failure modes captured in `error`:
+
+- `transport: <reqwest message>` — DNS, TCP, TLS.
+- `non-2xx: <code>` — receiver returned a 4xx/5xx.
+- `timed out after <duration>`.
+- `template parse: …` / `template render: …` — minijinja error.
+- `webhook references secret "X" but it is not in the sealed bundle`.
+
+## Verifying without a real deploy
+
+Point one webhook at a local listener and run any deploy that triggers it:
+
+```sh
+nc -l 9000 &
+yoink up    # or any subcommand that emits RunStarted/RunFinished
+```
+
+The body and rendered headers print on stdout, and `yoink audit log --event WebhookFired` shows the corresponding `ok: true, status: 200` line. Stop the listener and re-run to see `ok: false, error: "transport: …"`.
+
+## See also
+
+- [Configuration: webhooks](/docs/reference/config#webhooks) — full schema.
+- [Audit event schema: `WebhookFired`](/docs/reference/audit-event-schema#webhookfired) — what's logged for each fire.
+- [Read the audit log](/docs/how-to/audit-log) — `yoink audit run <id>` reconstructs every event for one deploy, webhooks included.
+- [Sealed secrets workflow](/docs/how-to/sealed-secrets-workflow) — how `${secret:NAME}` values get into the bundle.

--- a/docs/content/docs/reference/audit-event-schema.md
+++ b/docs/content/docs/reference/audit-event-schema.md
@@ -156,6 +156,17 @@ Fired by `yoink prune` for every removed container.
 | `sha256` | string | Content hash — same as the path under `/var/lib/yoink/files/`. |
 | `remote_path` | string | Absolute path on the host. |
 
+### `WebhookFired`
+
+Forensic. One per outbound webhook attempt, success or failure. Always lands `origin: "operator"` — webhooks fire from the operator's machine.
+
+| field | type | notes |
+|---|---|---|
+| `name` | string | The webhook's `name:` from `yoink.yaml`. |
+| `ok` | bool | `true` only on a 2xx response. |
+| `status` | int \| null | HTTP status code when the response was received; `null` when the call never reached a status (DNS / TCP / TLS / timeout / template error). |
+| `error` | string \| null | Failure reason: `transport: …`, `non-2xx: <code>`, `timed out after <duration>`, `template parse: …`, `template render: …`, or a missing-secret message. `null` when `ok=true`. |
+
 ## Forensic vs. progress
 
 The flush policy is per-variant. **Forensic** events bypass the per-host buffer and SSH-flush immediately, so a `kill -9` mid-deploy still lands them on disk. **Progress** events buffer and flush at end of run.
@@ -171,6 +182,7 @@ The flush policy is per-variant. **Forensic** events bypass the per-host buffer 
 | `ContainerPruned` | `AlreadyAtSpec` |
 | `SecretsRotated` |  |
 | `FileUploaded` |  |
+| `WebhookFired` |  |
 
 ## Storage
 

--- a/docs/content/docs/reference/config.md
+++ b/docs/content/docs/reference/config.md
@@ -18,6 +18,7 @@ Full schema for `yoink.yaml`. Canonical source: [`yoink/src/config.rs`](https://
 | `proxy` | [Proxy](#proxy) | unset | Bundled Caddy reverse proxy. Implicitly enabled when any service has a `domain:` set. |
 | `services` | list of [Service](#service) | `[]` | Services to deploy. Can be defined inline or split via `include:`. |
 | `hooks` | [Hooks](#hooks) | `{}` | Top-level hooks not scoped to a single service. Currently: `pre_deploy:`. |
+| `webhooks` | list of [Webhook](#webhooks) | `[]` | Outbound HTTP notifications fired on run-level events. Operator-side, best-effort. |
 | `include` | list of glob | `[]` | Glob paths (relative to the config file) merged into `services`. |
 
 ## Host
@@ -329,6 +330,32 @@ A hook runs in one of two flavors, distinguished by the presence of `image:`:
 | `secrets` | list of string | `[]` | Secret names exposed as env vars of the same name. Often a different role than the runtime (e.g. a migrate role). |
 | `env_from_secrets` | map of string | `{}` | `ENV_NAME: SECRET_NAME` mapping. |
 | `secrets_profile` | string | unset | Reference a named recipe from `secrets.profiles`. Profile's `include` joins `secrets`; profile's `rename` joins `env_from_secrets`. Profile's `unset:` applies on subprocess hooks (via `Command::env_remove`); rejected on container hooks (no parent env to clear). See [Secrets profiles](#secrets-profiles). |
+
+## Webhooks
+
+Outbound HTTP calls fired on `RunStarted` / `RunFinished`. Operator-side: the request goes from the box running `yoink up`, not from each host. Best-effort: every fire records a `WebhookFired` audit event whose `ok` field carries the outcome; a failure never aborts the deploy. See [Notify chat / paging / observability on deploy](/docs/how-to/notify-on-deploy) for templating, secrets, and worked receiver examples (ntfy, Slack, Grafana).
+
+```yaml
+webhooks:
+  - name: slack-deploys
+    url: "https://hooks.slack.com/${secret:SLACK_WEBHOOK_PATH}"
+    on: [run_succeeded, run_failed]
+    headers:
+      Content-Type: application/json
+    body: '{ "text": "{{ command }} {{ services | join(\", \") }}{% if error %} — {{ error }}{% endif %}" }'
+```
+
+| Field | Type | Default | Notes |
+|---|---|---|---|
+| `name` | string | required | Unique across the `webhooks:` list. Appears in `WebhookFired.name`. |
+| `url` | string | required | Templated. Must resolve to `http(s)://…` after `${secret:NAME}` substitution. |
+| `on` | list of trigger | required | Subset of `run_started`, `run_succeeded`, `run_failed`. At least one entry required. |
+| `method` | `GET` \| `POST` \| `PUT` | `POST` |  |
+| `timeout` | duration | `10s` | `humantime` syntax. |
+| `headers` | map of string | `{}` | Each value templated. |
+| `body` | string | unset | Templated. Omit for GET-style receivers. |
+
+Templating runs in two passes per field: `${secret:NAME}` literal substitution from the sealed bundle, then minijinja rendering with `UndefinedBehavior::Strict`. Available template variables: `event`, `ok`, `command`, `services`, `deploy_id`, `actor`, `host`, `git_sha`, `yoink_version`, `error`, `ts`. See [Notify chat / paging / observability on deploy: Template context](/docs/how-to/notify-on-deploy#template-context) for the full table.
 
 ## Tag overrides at deploy time
 

--- a/yoink/src/audit.rs
+++ b/yoink/src/audit.rs
@@ -167,6 +167,14 @@ pub enum AuditEventKind {
         sha256: String,
         remote_path: String,
     },
+    /// Outbound webhook attempt. Recorded for every fire, success or
+    /// failure — a failed webhook never aborts the run, only this event.
+    WebhookFired {
+        name: String,
+        ok: bool,
+        status: Option<u16>,
+        error: Option<String>,
+    },
 }
 
 impl AuditEventKind {
@@ -189,6 +197,7 @@ impl AuditEventKind {
                 | AuditEventKind::ContainerPruned { .. }
                 | AuditEventKind::SecretsRotated { .. }
                 | AuditEventKind::FileUploaded { .. }
+                | AuditEventKind::WebhookFired { .. }
         )
     }
 }
@@ -1078,6 +1087,7 @@ pub fn event_name(kind: &AuditEventKind) -> &'static str {
         K::ContainerPruned { .. } => "ContainerPruned",
         K::SecretsRotated { .. } => "SecretsRotated",
         K::FileUploaded { .. } => "FileUploaded",
+        K::WebhookFired { .. } => "WebhookFired",
     }
 }
 
@@ -1180,6 +1190,19 @@ pub fn event_summary(kind: &AuditEventKind) -> String {
             sha256,
             remote_path,
         } => format!("{service} {sha256} → {remote_path}"),
+        K::WebhookFired {
+            name,
+            ok,
+            status,
+            error,
+        } => {
+            if *ok {
+                let s = status.map_or_else(|| "ok".to_string(), |c| format!("{c}"));
+                format!("{name} {s}")
+            } else {
+                format!("{name} FAILED: {}", error.as_deref().unwrap_or(""))
+            }
+        }
     }
 }
 

--- a/yoink/src/config.rs
+++ b/yoink/src/config.rs
@@ -2197,8 +2197,7 @@ impl Config {
         // Templates are deliberately not parsed here — minijinja errors
         // surface at fire time as `WebhookFired { ok: false }` so a typo
         // in one template doesn't gate every deploy.
-        let mut webhook_names: std::collections::HashSet<&str> =
-            std::collections::HashSet::new();
+        let mut webhook_names: std::collections::HashSet<&str> = std::collections::HashSet::new();
         for (i, wh) in self.webhooks.iter().enumerate() {
             if wh.name.trim().is_empty() {
                 return Err(ConfigError::Invalid(format!(

--- a/yoink/src/config.rs
+++ b/yoink/src/config.rs
@@ -89,6 +89,11 @@ pub struct Config {
     pub config_dir: Option<std::path::PathBuf>,
     #[serde(default)]
     pub hooks: HookConfig,
+    /// Outbound HTTP notifications fired on run-level deploy events.
+    /// Operator-side, best-effort: a failed webhook never aborts the
+    /// run, only records a `WebhookFired { ok: false }` audit event.
+    #[serde(default)]
+    pub webhooks: Vec<WebhookSpec>,
 }
 
 /// Defaults that apply across every service. A service can override most
@@ -1183,6 +1188,73 @@ impl HookSpec {
     }
 }
 
+/// One outbound HTTP webhook entry. See `Config::webhooks`.
+///
+/// `url`, every value in `headers`, and `body` are templated at fire
+/// time: literal `${secret:NAME}` placeholders are resolved against the
+/// loaded sealed-secrets bundle first, then the result is rendered
+/// through minijinja with the run/event context.
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct WebhookSpec {
+    pub name: String,
+    pub url: String,
+    /// Which run-level triggers this webhook fires on. Must contain at
+    /// least one entry; a webhook with no triggers would be silently
+    /// dead config and is rejected.
+    pub on: Vec<WebhookTrigger>,
+    #[serde(default)]
+    pub method: HttpMethod,
+    /// Per-request timeout. Defaults to 10s — long enough for a
+    /// healthy receiver, short enough that a wedged receiver can't
+    /// stall the deploy's audit-flush.
+    #[serde(default = "default_webhook_timeout", with = "humantime_serde")]
+    pub timeout: Duration,
+    #[serde(default)]
+    pub headers: BTreeMap<String, String>,
+    /// Request body. `None` means "no body" — appropriate for GET-style
+    /// webhooks (e.g. ntfy.sh URL-only triggers). For POST/PUT, leave
+    /// it `None` only when the receiver genuinely accepts an empty body.
+    #[serde(default)]
+    pub body: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum WebhookTrigger {
+    /// Fired right after the run's `RunStarted` audit event lands.
+    RunStarted,
+    /// Fired when `RunFinished { ok: true }` lands.
+    RunSucceeded,
+    /// Fired when `RunFinished { ok: false }` lands. The deploy error
+    /// message is exposed to the template as `error`.
+    RunFailed,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "UPPERCASE")]
+pub enum HttpMethod {
+    Get,
+    #[default]
+    Post,
+    Put,
+}
+
+impl HttpMethod {
+    #[must_use]
+    pub const fn as_str(&self) -> &'static str {
+        match self {
+            HttpMethod::Get => "GET",
+            HttpMethod::Post => "POST",
+            HttpMethod::Put => "PUT",
+        }
+    }
+}
+
+fn default_webhook_timeout() -> Duration {
+    Duration::from_secs(10)
+}
+
 fn default_healthcheck_timeout() -> Duration {
     Duration::from_secs(60)
 }
@@ -2119,6 +2191,56 @@ impl Config {
                         hook.name
                     )));
                 }
+            }
+        }
+
+        // Templates are deliberately not parsed here — minijinja errors
+        // surface at fire time as `WebhookFired { ok: false }` so a typo
+        // in one template doesn't gate every deploy.
+        let mut webhook_names: std::collections::HashSet<&str> =
+            std::collections::HashSet::new();
+        for (i, wh) in self.webhooks.iter().enumerate() {
+            if wh.name.trim().is_empty() {
+                return Err(ConfigError::Invalid(format!(
+                    "webhooks[{i}].name must not be empty"
+                )));
+            }
+            if !webhook_names.insert(wh.name.as_str()) {
+                return Err(ConfigError::Invalid(format!(
+                    "duplicate webhook name {:?}",
+                    wh.name
+                )));
+            }
+            if wh.url.trim().is_empty() {
+                return Err(ConfigError::Invalid(format!(
+                    "webhook {:?}.url must not be empty",
+                    wh.name
+                )));
+            }
+            // Full URL parsing happens at fire time, after
+            // `${secret:…}` substitution — a sealed value may carry the
+            // scheme/host.
+            if !(wh.url.starts_with("http://")
+                || wh.url.starts_with("https://")
+                || wh.url.contains("${secret:"))
+            {
+                return Err(ConfigError::Invalid(format!(
+                    "webhook {:?}.url must be http(s) (got {:?})",
+                    wh.name, wh.url
+                )));
+            }
+            if wh.on.is_empty() {
+                return Err(ConfigError::Invalid(format!(
+                    "webhook {:?}.on must list at least one trigger \
+                     (run_started | run_succeeded | run_failed)",
+                    wh.name
+                )));
+            }
+            if wh.timeout.is_zero() {
+                return Err(ConfigError::Invalid(format!(
+                    "webhook {:?}.timeout must be > 0",
+                    wh.name
+                )));
             }
         }
 

--- a/yoink/src/lib.rs
+++ b/yoink/src/lib.rs
@@ -27,3 +27,4 @@ pub mod status;
 pub mod transport;
 pub mod tui;
 pub mod vscode;
+pub mod webhooks;

--- a/yoink/src/main.rs
+++ b/yoink/src/main.rs
@@ -1864,6 +1864,26 @@ async fn do_up_once(config: &Config, up: &UpOptions<'_>, dry_run: bool) -> Resul
         },
     )
     .await;
+    let webhook_http = yoink::webhooks::http_client();
+    let operator_host = run_ctx
+        .actor
+        .split_once('@')
+        .map_or(run_ctx.actor.as_str(), |(_, h)| h)
+        .to_string();
+    let started_ctx = yoink::webhooks::Context::run_started(
+        &run_ctx,
+        &operator_host,
+        selected_service_names.clone(),
+    );
+    yoink::webhooks::dispatch_all(
+        &config.webhooks,
+        &started_ctx,
+        bundle.as_ref(),
+        &webhook_http,
+        &operator_sink,
+        &run_ctx,
+    )
+    .await;
     for host_cfg in &config.hosts {
         let host = Host::from(host_cfg);
         yoink::audit::emit(
@@ -1990,6 +2010,22 @@ async fn do_up_once(config: &Config, up: &UpOptions<'_>, dry_run: bool) -> Resul
             ok,
             error: err_msg.clone(),
         },
+    )
+    .await;
+    let finished_ctx = yoink::webhooks::Context::run_finished(
+        &run_ctx,
+        &operator_host,
+        selected_service_names.clone(),
+        ok,
+        err_msg.clone(),
+    );
+    yoink::webhooks::dispatch_all(
+        &config.webhooks,
+        &finished_ctx,
+        bundle.as_ref(),
+        &webhook_http,
+        &operator_sink,
+        &run_ctx,
     )
     .await;
     audit_sink.flush().await;

--- a/yoink/src/webhooks.rs
+++ b/yoink/src/webhooks.rs
@@ -144,10 +144,7 @@ fn strict_env<'a>() -> Environment<'a> {
     env
 }
 
-fn substitute_secrets(
-    input: &str,
-    secrets: Option<&SecretsBundle>,
-) -> Result<String, String> {
+fn substitute_secrets(input: &str, secrets: Option<&SecretsBundle>) -> Result<String, String> {
     const NEEDLE: &str = "${secret:";
     if !input.contains(NEEDLE) {
         return Ok(input.to_string());
@@ -237,8 +234,8 @@ async fn send(
     let url = render_field_with(&env, &spec.url, ctx, secrets)?;
     let mut headers: BTreeMap<String, String> = BTreeMap::new();
     for (k, v) in &spec.headers {
-        let rendered = render_field_with(&env, v, ctx, secrets)
-            .map_err(|e| format!("header {k:?}: {e}"))?;
+        let rendered =
+            render_field_with(&env, v, ctx, secrets).map_err(|e| format!("header {k:?}: {e}"))?;
         headers.insert(k.clone(), rendered);
     }
     let body = match &spec.body {

--- a/yoink/src/webhooks.rs
+++ b/yoink/src/webhooks.rs
@@ -1,0 +1,402 @@
+//! Outbound HTTP webhooks fired on run-level deploy events.
+//!
+//! Operators declare `webhooks:` entries in `yoink.yaml`; this module
+//! renders their `url` / `headers` / `body` against the run context and
+//! POSTs (or GETs, etc.) to the receiver. Every fire is recorded as a
+//! `WebhookFired` audit event so an operator can correlate "Slack went
+//! silent" with "the deploy that should have pinged it".
+//!
+//! Failures are non-fatal — a flaky receiver must not wedge a deploy.
+//! The audit log carries the diagnostic.
+
+use std::collections::BTreeMap;
+use std::sync::Arc;
+use std::time::Duration;
+
+use minijinja::{Environment, UndefinedBehavior, context};
+
+use crate::audit::{AuditEventKind, AuditSink, RunContext, build_operator_event};
+use crate::config::{HttpMethod, WebhookSpec, WebhookTrigger};
+use crate::secrets::SecretsBundle;
+
+/// Template variables exposed to webhook bodies/headers/url.
+///
+/// Deliberately a fixed flat schema rather than the raw
+/// `AuditEventKind` enum: the audit log evolves (new variants, renamed
+/// fields), but operator-authored webhook templates should not break
+/// when that happens. Add fields here only when there's a clear
+/// notification use case.
+#[derive(Debug, Clone)]
+pub struct Context {
+    pub trigger: WebhookTrigger,
+    pub command: String,
+    pub services: Vec<String>,
+    pub deploy_id: String,
+    pub actor: String,
+    pub host: String,
+    pub git_sha: Option<String>,
+    pub yoink_version: String,
+    pub error: Option<String>,
+    pub ts: String,
+}
+
+impl Context {
+    #[must_use]
+    pub fn run_started(run: &RunContext, host: &str, services: Vec<String>) -> Self {
+        Self::new(WebhookTrigger::RunStarted, run, host, services, None)
+    }
+
+    /// `error` is dropped on success and required (in practice) on failure.
+    #[must_use]
+    pub fn run_finished(
+        run: &RunContext,
+        host: &str,
+        services: Vec<String>,
+        ok: bool,
+        error: Option<String>,
+    ) -> Self {
+        let trigger = if ok {
+            WebhookTrigger::RunSucceeded
+        } else {
+            WebhookTrigger::RunFailed
+        };
+        Self::new(trigger, run, host, services, if ok { None } else { error })
+    }
+
+    fn new(
+        trigger: WebhookTrigger,
+        run: &RunContext,
+        host: &str,
+        services: Vec<String>,
+        error: Option<String>,
+    ) -> Self {
+        Self {
+            trigger,
+            command: run.command.clone(),
+            services,
+            deploy_id: run.deploy_id.clone(),
+            actor: run.actor.clone(),
+            host: host.to_string(),
+            git_sha: run.git_sha.clone(),
+            yoink_version: run.yoink_version.clone(),
+            error,
+            ts: crate::audit::now_rfc3339_millis(),
+        }
+    }
+}
+
+const fn event_str(t: WebhookTrigger) -> &'static str {
+    match t {
+        WebhookTrigger::RunStarted => "run_started",
+        WebhookTrigger::RunSucceeded => "run_succeeded",
+        WebhookTrigger::RunFailed => "run_failed",
+    }
+}
+
+const fn trigger_ok(t: WebhookTrigger) -> bool {
+    !matches!(t, WebhookTrigger::RunFailed)
+}
+
+/// Render a templated string field. Two passes, in order: literal
+/// `${secret:NAME}` substitution against `secrets`, then minijinja
+/// rendering against `ctx`. The order ensures a secret value containing
+/// `{{` won't be re-templated; `UndefinedBehavior::Strict` makes a
+/// typo'd `{{ var }}` an error instead of an empty string.
+pub fn render_field(
+    template: &str,
+    ctx: &Context,
+    secrets: Option<&SecretsBundle>,
+) -> Result<String, String> {
+    render_field_with(&strict_env(), template, ctx, secrets)
+}
+
+fn render_field_with(
+    env: &Environment<'_>,
+    template: &str,
+    ctx: &Context,
+    secrets: Option<&SecretsBundle>,
+) -> Result<String, String> {
+    let with_secrets = substitute_secrets(template, secrets)?;
+    let tmpl = env
+        .template_from_str(&with_secrets)
+        .map_err(|e| format!("template parse: {e}"))?;
+    let event = event_str(ctx.trigger);
+    let ok = trigger_ok(ctx.trigger);
+    tmpl.render(context!(
+        event => event,
+        ok => ok,
+        command => &ctx.command,
+        services => &ctx.services,
+        deploy_id => &ctx.deploy_id,
+        actor => &ctx.actor,
+        host => &ctx.host,
+        git_sha => &ctx.git_sha,
+        yoink_version => &ctx.yoink_version,
+        error => &ctx.error,
+        ts => &ctx.ts,
+    ))
+    .map_err(|e| format!("template render: {e}"))
+}
+
+fn strict_env<'a>() -> Environment<'a> {
+    let mut env = Environment::new();
+    env.set_undefined_behavior(UndefinedBehavior::Strict);
+    env
+}
+
+fn substitute_secrets(
+    input: &str,
+    secrets: Option<&SecretsBundle>,
+) -> Result<String, String> {
+    const NEEDLE: &str = "${secret:";
+    if !input.contains(NEEDLE) {
+        return Ok(input.to_string());
+    }
+    let mut out = String::with_capacity(input.len());
+    let mut rest = input;
+    while let Some(pos) = rest.find(NEEDLE) {
+        out.push_str(&rest[..pos]);
+        let after = &rest[pos + NEEDLE.len()..];
+        let Some(end) = after.find('}') else {
+            return Err(format!(
+                "unterminated `${{secret:…}}` reference near {:?}",
+                snippet(rest, pos)
+            ));
+        };
+        let name = &after[..end];
+        if name.is_empty() {
+            return Err("empty secret name in `${secret:}` reference".into());
+        }
+        let Some(bundle) = secrets else {
+            return Err(format!(
+                "webhook references secret {name:?} but no `secrets:` provider is configured"
+            ));
+        };
+        let Some(val) = bundle.get(name) else {
+            return Err(format!(
+                "webhook references secret {name:?} but it is not in the sealed bundle"
+            ));
+        };
+        out.push_str(val);
+        rest = &after[end + 1..];
+    }
+    out.push_str(rest);
+    Ok(out)
+}
+
+fn snippet(s: &str, pos: usize) -> &str {
+    let start = pos.saturating_sub(8);
+    let end = (pos + 16).min(s.len());
+    &s[start..end]
+}
+
+/// Fire one webhook. Always returns `()` — every failure becomes a
+/// `WebhookFired { ok: false }` audit event instead of propagating, so
+/// dispatch can never abort a deploy.
+pub async fn dispatch(
+    spec: &WebhookSpec,
+    ctx: &Context,
+    secrets: Option<&SecretsBundle>,
+    http: &reqwest::Client,
+    audit: &Arc<dyn AuditSink>,
+    run: &RunContext,
+) {
+    if !spec.on.contains(&ctx.trigger) {
+        return;
+    }
+    let (ok, status, error) = classify(send(spec, ctx, secrets, http).await);
+    audit
+        .record(build_operator_event(
+            run,
+            "",
+            AuditEventKind::WebhookFired {
+                name: spec.name.clone(),
+                ok,
+                status,
+                error,
+            },
+        ))
+        .await;
+}
+
+fn classify(result: Result<u16, String>) -> (bool, Option<u16>, Option<String>) {
+    match result {
+        Ok(code) if (200..300).contains(&code) => (true, Some(code), None),
+        Ok(code) => (false, Some(code), Some(format!("non-2xx: {code}"))),
+        Err(e) => (false, None, Some(e)),
+    }
+}
+
+async fn send(
+    spec: &WebhookSpec,
+    ctx: &Context,
+    secrets: Option<&SecretsBundle>,
+    http: &reqwest::Client,
+) -> Result<u16, String> {
+    let env = strict_env();
+    let url = render_field_with(&env, &spec.url, ctx, secrets)?;
+    let mut headers: BTreeMap<String, String> = BTreeMap::new();
+    for (k, v) in &spec.headers {
+        let rendered = render_field_with(&env, v, ctx, secrets)
+            .map_err(|e| format!("header {k:?}: {e}"))?;
+        headers.insert(k.clone(), rendered);
+    }
+    let body = match &spec.body {
+        Some(b) => Some(render_field_with(&env, b, ctx, secrets)?),
+        None => None,
+    };
+
+    let method = match spec.method {
+        HttpMethod::Get => reqwest::Method::GET,
+        HttpMethod::Post => reqwest::Method::POST,
+        HttpMethod::Put => reqwest::Method::PUT,
+    };
+    let mut req = http.request(method, &url);
+    for (k, v) in &headers {
+        req = req.header(k, v);
+    }
+    if let Some(b) = body {
+        req = req.body(b);
+    }
+    req = req.timeout(spec.timeout);
+
+    // Outer timeout backstops reqwest's per-request timer in the rare
+    // case where a TLS / DNS hang escapes it (documented for some
+    // platforms). +1s slack so reqwest's own error wins on the common path.
+    let resp = tokio::time::timeout(spec.timeout + Duration::from_secs(1), req.send())
+        .await
+        .map_err(|_| format!("timed out after {:?}", spec.timeout))?
+        .map_err(|e| format!("transport: {e}"))?;
+    Ok(resp.status().as_u16())
+}
+
+/// Fan out every configured webhook for the given context. Calls run
+/// concurrently — one slow receiver can't delay another. Awaited so
+/// audit `WebhookFired` events are recorded before the deploy moves on.
+pub async fn dispatch_all(
+    specs: &[WebhookSpec],
+    ctx: &Context,
+    secrets: Option<&SecretsBundle>,
+    http: &reqwest::Client,
+    audit: &Arc<dyn AuditSink>,
+    run: &RunContext,
+) {
+    if specs.is_empty() {
+        return;
+    }
+    let futs = specs
+        .iter()
+        .map(|s| dispatch(s, ctx, secrets, http, audit, run));
+    futures_util::future::join_all(futs).await;
+}
+
+/// Shared HTTP client. One per run, threaded through every dispatch site.
+#[must_use]
+pub fn http_client() -> reqwest::Client {
+    reqwest::Client::builder()
+        .user_agent(format!("yoink/{}", env!("CARGO_PKG_VERSION")))
+        .build()
+        .expect("reqwest client builder with default config never fails")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::audit::MemorySink;
+    use std::collections::BTreeMap;
+    use zeroize::Zeroizing;
+
+    fn ctx() -> Context {
+        Context {
+            trigger: WebhookTrigger::RunSucceeded,
+            command: "up".into(),
+            services: vec!["api".into(), "web".into()],
+            deploy_id: "01HFE9TEST".into(),
+            actor: "alice@laptop".into(),
+            host: "laptop".into(),
+            git_sha: Some("abc1234".into()),
+            yoink_version: "0.20.0".into(),
+            error: None,
+            ts: "2026-05-02T10:00:00.000Z".into(),
+        }
+    }
+
+    fn bundle(pairs: &[(&str, &str)]) -> SecretsBundle {
+        let mut map: BTreeMap<String, Zeroizing<String>> = BTreeMap::new();
+        for (k, v) in pairs {
+            map.insert((*k).into(), Zeroizing::new((*v).into()));
+        }
+        SecretsBundle::new(map)
+    }
+
+    #[test]
+    fn substitute_resolves_secret() {
+        let b = bundle(&[("TOK", "s3cr3t")]);
+        let out = substitute_secrets("Bearer ${secret:TOK}", Some(&b)).unwrap();
+        assert_eq!(out, "Bearer s3cr3t");
+    }
+
+    #[test]
+    fn substitute_errors_on_missing_secret() {
+        let b = bundle(&[]);
+        let err = substitute_secrets("${secret:MISSING}", Some(&b)).unwrap_err();
+        assert!(err.contains("MISSING"));
+    }
+
+    #[test]
+    fn substitute_errors_when_no_bundle_but_referenced() {
+        let err = substitute_secrets("${secret:X}", None).unwrap_err();
+        assert!(err.contains("no `secrets:` provider"));
+    }
+
+    #[test]
+    fn substitute_passes_through_when_no_reference() {
+        assert_eq!(
+            substitute_secrets("plain text", None).unwrap(),
+            "plain text"
+        );
+    }
+
+    #[test]
+    fn render_field_runs_secrets_then_jinja() {
+        let b = bundle(&[("T", "abc")]);
+        let out = render_field(
+            "{{ event }}:{{ services | join(\",\") }}:${secret:T}",
+            &ctx(),
+            Some(&b),
+        )
+        .unwrap();
+        assert_eq!(out, "run_succeeded:api,web:abc");
+    }
+
+    #[test]
+    fn render_field_errors_on_missing_var_strict() {
+        let err = render_field("{{ no_such_var }}", &ctx(), None).unwrap_err();
+        assert!(err.contains("template render"));
+    }
+
+    #[tokio::test]
+    async fn dispatch_skips_non_matching_trigger() {
+        let spec = WebhookSpec {
+            name: "only-failure".into(),
+            url: "http://127.0.0.1:1/".into(),
+            on: vec![WebhookTrigger::RunFailed],
+            method: HttpMethod::Post,
+            timeout: Duration::from_millis(50),
+            headers: BTreeMap::new(),
+            body: None,
+        };
+        let mem: Arc<MemorySink> = Arc::new(MemorySink::new());
+        let sink: Arc<dyn AuditSink> = mem.clone();
+        let run = RunContext {
+            deploy_id: "d".into(),
+            actor: "a".into(),
+            yoink_version: "v".into(),
+            git_sha: None,
+            command: "up".into(),
+        };
+        let http = http_client();
+        dispatch(&spec, &ctx(), None, &http, &sink, &run).await;
+        assert!(mem.events().await.is_empty());
+    }
+}


### PR DESCRIPTION
## Summary

- New top-level `webhooks:` block in `yoink.yaml` fires HTTP requests on run-level deploy events (`run_started`, `run_succeeded`, `run_failed`).
- `url`, `headers`, and `body` are minijinja-templated with `${secret:NAME}` substitution against the sealed bundle so bearer tokens never sit in the config plaintext.
- Operator-side and best-effort: every fire records a `WebhookFired` audit event whose `ok` field carries the outcome; a failure never aborts the deploy.

```yaml
webhooks:
  - name: slack-deploys
    url: "https://hooks.slack.com/${secret:SLACK_WEBHOOK_PATH}"
    on: [run_succeeded, run_failed]
    headers: { Content-Type: application/json }
    body: '{ "text": "{{ command }} {{ services | join(\", \") }}{% if error %} — {{ error }}{% endif %}" }'
```

Worked receivers covered in the new how-to: ntfy.sh, Slack incoming webhooks, Grafana annotations.

## Implementation

- `yoink/src/webhooks.rs` *(new)*: `Context`, `render_field` (secret pass → minijinja), `dispatch` / `dispatch_all`, `http_client`. Strict-undefined templating; `Environment` built once per dispatch and reused across url + each header + body. 7 unit tests.
- `yoink/src/audit.rs`: new forensic `WebhookFired { name, ok, status, error }` variant + display arms.
- `yoink/src/config.rs`: `WebhookSpec` / `WebhookTrigger` / `HttpMethod` + `Config.webhooks` + validation (unique non-empty `name`, http(s) URL or `\${secret:}` placeholder, non-empty `on`, positive `timeout`).
- `yoink/src/main.rs`: dispatch sites bracket the existing `RunStarted` / `RunFinished` audit emissions in `cmd_up`. Shared reqwest client per run.
- Docs: new how-to (`notify-on-deploy`), reference entries in `config.md` (`#webhooks`) and `audit-event-schema.md` (`#webhookfired`), sidebar entry under Operations.

## Test plan

- [x] `cargo test --lib` — 496/496 passing (7 new webhook tests).
- [x] `cargo clippy --lib` — clean (only pre-existing warnings unrelated to this change).
- [x] `cd docs && pnpm build` — 160 pages prerendered, no errors; new anchors `/docs/reference/config#webhooks` and `/docs/how-to/notify-on-deploy#template-context` resolve.
- [x] End-to-end smoke test against `https://ntfy.sh/backtrack` — three notifications delivered (`run_started`, `run_succeeded`, `run_failed`) with rendered Title/Tags headers and templated body; all recorded as `WebhookFired { ok: true, status: 200 }`.
- [ ] Reviewer to spot-check Slack and/or Grafana receivers if they have credentials handy.

## Notes

- Run-level only for now — per-service / per-host triggers (`ContainerCreated`, `DeployFailed`) are intentionally deferred to keep the config surface small. They can be added later without a config break by extending the `WebhookTrigger` enum.
- Webhooks run from the operator's machine, not from each host — the operator already has the decrypted secrets bundle in memory; shipping it to hosts wasn't worth the blast radius.