### PR TITLE
chore: pre-commit hooks + clear clippy backlog (-D warnings)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,9 +32,6 @@ jobs:
 
   clippy:
     runs-on: ubuntu-latest
-    # Pre-existing pedantic warnings exist; fail only on actual errors.
-    # Tighten to `-D warnings` once the backlog is addressed.
-    continue-on-error: true
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
@@ -42,7 +39,7 @@ jobs:
           toolchain: "1.95.0"
           components: clippy
       - uses: Swatinem/rust-cache@v2
-      - run: cargo clippy --workspace --all-targets
+      - run: cargo clippy --workspace --all-targets -- -D warnings
 
   test:
     runs-on: ubuntu-latest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,41 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.5.0
+    hooks:
+      - id: trailing-whitespace
+        exclude: ^\.claude/
+      - id: end-of-file-fixer
+        exclude: ^\.claude/
+      - id: check-toml
+      - id: check-merge-conflict
+      - id: check-json
+        # Claude session state is not strict JSON.
+        exclude: ^\.claude/
+      - id: check-yaml
+        # Fumadocs MDX frontmatter trips the strict YAML parser.
+        exclude: ^docs/content/
+
+  - repo: https://github.com/doublify/pre-commit-rust
+    rev: v1.0
+    hooks:
+      - id: fmt
+        args: ["--all"]
+        pass_filenames: false
+      # Matches CI: warnings are not yet errors. There's a pre-existing
+      # pedantic-lint backlog (audit.rs `many_single_char_names`,
+      # `items_after_statements`, etc.) that the project plans to clear
+      # before tightening to `-D warnings`. Until then, the hook fails
+      # only on actual clippy errors.
+      - id: clippy
+        args: ["--workspace", "--all-targets"]
+        pass_filenames: false
+      - id: cargo-check
+        args: ["--workspace", "--all-targets"]
+        pass_filenames: false
+
+  - repo: https://github.com/trufflesecurity/trufflehog
+    rev: v3.93.0
+    hooks:
+      - id: trufflehog
+        entry: trufflehog git file://. --since-commit HEAD --results=verified --fail --trust-local-git-config
+        stages: [pre-commit, pre-push]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,13 +21,8 @@ repos:
       - id: fmt
         args: ["--all"]
         pass_filenames: false
-      # Matches CI: warnings are not yet errors. There's a pre-existing
-      # pedantic-lint backlog (audit.rs `many_single_char_names`,
-      # `items_after_statements`, etc.) that the project plans to clear
-      # before tightening to `-D warnings`. Until then, the hook fails
-      # only on actual clippy errors.
       - id: clippy
-        args: ["--workspace", "--all-targets"]
+        args: ["--workspace", "--all-targets", "--", "-D", "warnings"]
         pass_filenames: false
       - id: cargo-check
         args: ["--workspace", "--all-targets"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,11 @@ missing_panics_doc = "allow"
 # Test fixtures use `r#"..."#` for YAML strings; the hash count
 # uniformity is more readable than per-string trimming.
 needless_raw_string_hashes = "allow"
+# CLI subcommand handlers compose through several `await` points and end
+# up with futures > the pedantic 16 KiB threshold. Each is invoked once
+# per process, so the stack-size concern doesn't apply — boxing every
+# handler would be churn for no real win.
+large_futures = "allow"
 
 [workspace.lints.rust]
 unsafe_code = "deny"

--- a/README.md
+++ b/README.md
@@ -31,6 +31,15 @@ Or `cargo install --git https://github.com/oddur/yoink yoink`. Or curl-pipe-sh: 
 
 See the [install page](https://yoink.is/docs/start/install) for the full list and prerequisites.
 
+## Contributing
+
+```sh
+devbox shell        # rust + tools (pre-commit, trufflehog, …)
+task hooks:install  # wire up pre-commit + pre-push hooks
+task check          # cargo check + fmt + clippy
+task test           # unit + integration (DinD e2e excluded)
+```
+
 ## License
 
 MIT — see [LICENSE](LICENSE).

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -67,3 +67,14 @@ tasks:
     desc: Clean build artifacts
     cmds:
       - cargo clean
+
+  hooks:install:
+    desc: Install git pre-commit + pre-push hooks
+    cmds:
+      - pre-commit install --install-hooks
+      - pre-commit install --install-hooks --hook-type pre-push
+
+  hooks:run:
+    desc: Run all pre-commit hooks against every file
+    cmds:
+      - pre-commit run --all-files

--- a/devbox.json
+++ b/devbox.json
@@ -8,7 +8,9 @@
     "go-task@latest",
     "sccache@latest",
     "hugo@latest",
-    "go@1.23"
+    "go@1.23",
+    "pre-commit@latest",
+    "trufflehog@latest"
   ],
   "shell": {
     "init_hook": [

--- a/docs/content/docs/reference/tui.md
+++ b/docs/content/docs/reference/tui.md
@@ -101,7 +101,7 @@ If your image is distroless or otherwise has no shell, `!` will fail. **Fall bac
 When the dashboard / host detail / service detail / container detail view shows ⚠ on a row, press **`~`** to open a modal that explains *what* drifted, the same per-field diff `yoink up --plan` produces on the CLI side:
 
 ```
- drift: api on host-a (esc to close) 
+ drift: api on host-a (esc to close)
    image  ghcr.io/me/api  (unchanged)
    spec   a1b2c3d → e5f6a7b
     tag   v1.2.4

--- a/yoink/src/add/mod.rs
+++ b/yoink/src/add/mod.rs
@@ -18,6 +18,7 @@ use std::io::{self, IsTerminal, Write};
 use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result};
+use zeroize::Zeroizing;
 
 use crate::config::{Config, SecretsConfig};
 use crate::sealed;
@@ -409,7 +410,6 @@ fn seal_new_secrets(config: &Config, new_secrets: &[render::RenderedSecret]) -> 
 
     // Merge with existing sealed contents if the file already exists.
     // Try-read directly (avoids a TOCTOU race between exists() and read).
-    use zeroize::Zeroizing;
     let mut values: BTreeMap<String, Zeroizing<String>> = match std::fs::read(&path) {
         Ok(bytes) => {
             let identity = sealed::load_identity(recipients)?;

--- a/yoink/src/audit.rs
+++ b/yoink/src/audit.rs
@@ -1395,6 +1395,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(clippy::many_single_char_names)] // mirrors the variable names in unix_to_components
     fn unix_to_components_known_value() {
         // 1_777_999_321 → 2026-05-05T16:42:01Z. Sanity-check Hinnant.
         let t = 1_777_999_321_u64;

--- a/yoink/src/config.rs
+++ b/yoink/src/config.rs
@@ -2714,6 +2714,12 @@ hosts:
     /// See issue #79.
     #[test]
     fn include_glob_resolves_when_config_dir_is_empty() {
+        struct CwdGuard(std::path::PathBuf);
+        impl Drop for CwdGuard {
+            fn drop(&mut self) {
+                let _ = std::env::set_current_dir(&self.0);
+            }
+        }
         let dir = write_temp_tree(&[
             (
                 "yoink.yaml",
@@ -2741,12 +2747,6 @@ services:
         // test must not run alongside others that also tweak cwd —
         // none currently do. RAII guard restores even on panic so a
         // load failure can't leave the test runner with a dangling cwd.
-        struct CwdGuard(std::path::PathBuf);
-        impl Drop for CwdGuard {
-            fn drop(&mut self) {
-                let _ = std::env::set_current_dir(&self.0);
-            }
-        }
         let _guard = CwdGuard(std::env::current_dir().unwrap());
         std::env::set_current_dir(&dir).unwrap();
         let cfg = Config::load_from_path(std::path::Path::new("yoink.yaml")).unwrap();

--- a/yoink/src/main.rs
+++ b/yoink/src/main.rs
@@ -3377,13 +3377,13 @@ async fn cmd_audit_log(
     // Resolve `ssh_key_secret:` keypair tempfiles only when we'll
     // actually SSH out — `--origin operator` reads the local file
     // and never touches a host, so skip the bundle load entirely.
-    let ops = if origin_filter == Some("operator") {
+    let docker_ops = if origin_filter == Some("operator") {
         None
     } else {
         Some(build_real_ops(config, None).await?)
     };
     let outcome = fetch_events(&hosts, &opts, |h| {
-        ops.as_ref().and_then(|o| o.ssh_keyfile(h))
+        docker_ops.as_ref().and_then(|o| o.ssh_keyfile(h))
     })
     .await;
     for (source, msg) in &outcome.errors {
@@ -5423,6 +5423,10 @@ fn open_in_editor(initial: &str) -> Result<Option<String>> {
 /// from completing its primary operation or cleaning up.
 fn secure_wipe_tempfile(f: &mut tempfile::NamedTempFile) {
     use std::io::{Seek, SeekFrom, Write as _};
+    // Use a fixed-size zero chunk and repeat writes to avoid a u64→usize
+    // truncation on 32-bit targets (secret files are small in practice,
+    // but the cast would be unsound on platforms where usize < u64).
+    const CHUNK: usize = 4096;
     // Obtain file length; bail silently on any error.
     let Ok(meta) = f.as_file().metadata() else {
         return;
@@ -5431,10 +5435,6 @@ fn secure_wipe_tempfile(f: &mut tempfile::NamedTempFile) {
     if file_len == 0 {
         return;
     }
-    // Use a fixed-size zero chunk and repeat writes to avoid a u64→usize
-    // truncation on 32-bit targets (secret files are small in practice,
-    // but the cast would be unsound on platforms where usize < u64).
-    const CHUNK: usize = 4096;
     let zeros = [0u8; CHUNK];
     let file = f.as_file_mut();
     let _ = file.seek(SeekFrom::Start(0));

--- a/yoink/src/sealed.rs
+++ b/yoink/src/sealed.rs
@@ -392,7 +392,7 @@ pub fn ssh_keygen_into_bundle(
     if bundle.contains_key(seal_as) {
         return Err(SealedError::SecretAlreadySealed(seal_as.to_string()));
     }
-    bundle.insert(seal_as.to_string(), Zeroizing::new((*priv_pem).to_string()));
+    bundle.insert(seal_as.to_string(), Zeroizing::new((*priv_pem).clone()));
 
     let canonical = render_dotenv(&bundle);
     let sealed_bytes = seal(canonical.as_bytes(), recipients)?;
@@ -940,7 +940,7 @@ BAZ=plain
         write_key_file(&keys, &format!("{public}.key"), &secret);
         let legacy = tmp.path().join("nonexistent-legacy.key");
 
-        let id = load_identity_resolved(None, None, &keys, &legacy, &[public.clone()])
+        let id = load_identity_resolved(None, None, &keys, &legacy, std::slice::from_ref(&public))
             .expect("scan match");
         assert_eq!(id.to_public().to_string(), public);
     }
@@ -1059,7 +1059,7 @@ BAZ=plain
             Some("\t".to_string()),
             &keys,
             &legacy,
-            &[public.clone()],
+            std::slice::from_ref(&public),
         )
         .expect("fallthrough past blank env");
         assert_eq!(id.to_public().to_string(), public);

--- a/yoink/src/tui/logs.rs
+++ b/yoink/src/tui/logs.rs
@@ -130,11 +130,6 @@ impl LogsState {
         self.wrap = !self.wrap;
     }
 
-    #[cfg(test)]
-    pub fn wrap_enabled(&self) -> bool {
-        self.wrap
-    }
-
     // ─── filter input ──────────────────────────────────────────────────
 
     pub fn input_mode(&self) -> bool {


### PR DESCRIPTION
## Summary

Two related changes, one PR:

1. **Adopt pre-commit hooks** (commit 1) — file hygiene + cargo fmt/clippy/check + TruffleHog. `devbox.json` picks up `pre-commit` and `trufflehog`; Taskfile gains `task hooks:install` / `task hooks:run`; README has a Contributing block.
2. **Clear the pedantic-lint backlog and enforce `-D warnings`** (commit 2). Both the pre-commit clippy hook and CI now treat warnings as errors; CI loses its `continue-on-error: true`.

Adapted from the bt repo's setup, trimmed to what yoink has — single-crate Cargo workspace + docs site, no proto/terraform/SQL/React.

## Backlog cleanup (commit 2)

| Lint | Fix |
|---|---|
| `items_after_statements` (×4) | Hoist `use` / `struct` to top of scope (add/mod.rs, main.rs, config.rs) |
| `many_single_char_names` | `#[allow]` on the test — names mirror `unix_to_components` |
| `similar_names` | Rename `ops` → `docker_ops` to separate from `opts` (cmd_audit_log) |
| `implicit_clone` | `(*priv_pem).to_string()` → `.clone()` (sealed.rs) |
| `cloned_ref_to_slice_refs` (×2) | `&[x.clone()]` → `std::slice::from_ref(&x)` (sealed.rs tests) |
| Dead code | Drop unused `wrap_enabled` test helper (tui/logs.rs) |
| `large_futures` | Workspace-allow with rationale: CLI subcommand handlers run once per process; the 16 KiB stack threshold doesn't apply, and boxing every handler would be churn |

## Test plan

- [x] `pre-commit run --all-files` — all 10 hooks pass.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- [x] `cargo test --workspace` — 502 passing.
- [x] Hooks fire on real-world bad commits; each was caught and auto-fixed.
- [ ] Reviewer: `task hooks:install` and confirm hooks fire on a sample edit.

## What's deliberately left out

- **`docs/` types:check** — `pnpm types:check` reports pre-existing TS errors on main. Worth a follow-up PR to fix the TS issues, then add the hook.
