### PR TITLE
chore: tighten pre-commit setup post-review

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,19 +1,17 @@
+# Local Claude session state is not source-controlled prose; skip
+# whitespace/EOF/JSON-strict checks across that whole subtree.
+exclude: ^\.claude/
+
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.5.0
     hooks:
       - id: trailing-whitespace
-        exclude: ^\.claude/
       - id: end-of-file-fixer
-        exclude: ^\.claude/
       - id: check-toml
       - id: check-merge-conflict
       - id: check-json
-        # Claude session state is not strict JSON.
-        exclude: ^\.claude/
       - id: check-yaml
-        # Fumadocs MDX frontmatter trips the strict YAML parser.
-        exclude: ^docs/content/
 
   - repo: https://github.com/doublify/pre-commit-rust
     rev: v1.0
@@ -21,16 +19,18 @@ repos:
       - id: fmt
         args: ["--all"]
         pass_filenames: false
+      # Workspace clippy is too slow for every commit; runs on push instead.
+      # `cargo check` would be redundant — clippy runs the same frontend.
       - id: clippy
         args: ["--workspace", "--all-targets", "--", "-D", "warnings"]
         pass_filenames: false
-      - id: cargo-check
-        args: ["--workspace", "--all-targets"]
-        pass_filenames: false
+        stages: [pre-push]
 
   - repo: https://github.com/trufflesecurity/trufflehog
     rev: v3.93.0
     hooks:
+      # Pre-push only: `--since-commit HEAD` reads committed history, so a
+      # pre-commit invocation can't see staged content yet.
       - id: trufflehog
         entry: trufflehog git file://. --since-commit HEAD --results=verified --fail --trust-local-git-config
-        stages: [pre-commit, pre-push]
+        stages: [pre-push]

--- a/yoink/src/main.rs
+++ b/yoink/src/main.rs
@@ -1171,7 +1171,6 @@ fn confirm_destructive(prompt: &str) -> Result<()> {
 }
 
 #[tokio::main(flavor = "current_thread")]
-#[allow(clippy::large_futures)]
 async fn main() -> ExitCode {
     let cli = Cli::parse();
     let is_tui = matches!(cli.command, Command::Tui { .. });
@@ -1248,7 +1247,7 @@ fn log_file_path() -> PathBuf {
     PathBuf::from("/tmp/yoink-tui.log")
 }
 
-#[allow(clippy::too_many_lines, clippy::large_futures)] // one big match dispatch; splitting buys nothing
+#[allow(clippy::too_many_lines)] // one big match dispatch; splitting buys nothing
 async fn run(cli: Cli) -> Result<()> {
     if let Some(result) = run_bootstrap(&cli.command) {
         return result;
@@ -1487,7 +1486,6 @@ async fn run(cli: Cli) -> Result<()> {
     }
 }
 
-#[allow(clippy::large_futures)]
 async fn cmd_preflight(config: &Config, wait: Option<Duration>) -> Result<()> {
     config.require_hosts()?;
     let ops = build_real_ops(config, None).await?;
@@ -1591,7 +1589,6 @@ struct UpOptions<'a> {
     config_path: &'a std::path::Path,
 }
 
-#[allow(clippy::large_futures)]
 async fn cmd_up(config: &Config, up: UpOptions<'_>) -> Result<()> {
     config.require_hosts()?;
     config.require_services()?;
@@ -1663,7 +1660,7 @@ async fn cmd_up(config: &Config, up: UpOptions<'_>) -> Result<()> {
 
 const WATCH_TICK: std::time::Duration = std::time::Duration::from_secs(2);
 
-#[allow(clippy::too_many_lines, clippy::large_futures)] // single linear up-once flow; splitting fragments the build → push → reconcile sequence
+#[allow(clippy::too_many_lines)] // single linear up-once flow; splitting fragments the build → push → reconcile sequence
 async fn do_up_once(config: &Config, up: &UpOptions<'_>, dry_run: bool) -> Result<()> {
     use yoink::docker_ops::Host;
     use yoink::lock::HostLock;
@@ -2114,7 +2111,6 @@ async fn cmd_build(config: &Config, build: BuildOptions<'_>) -> Result<()> {
     Ok(())
 }
 
-#[allow(clippy::large_futures)]
 async fn cmd_status(config: &Config, json: bool) -> Result<()> {
     let ops = build_real_ops(config, None).await?;
     let report = StatusReport::collect(&ops, config)
@@ -2131,7 +2127,7 @@ async fn cmd_status(config: &Config, json: bool) -> Result<()> {
     Ok(())
 }
 
-#[allow(clippy::large_futures, clippy::too_many_lines)]
+#[allow(clippy::too_many_lines)]
 async fn cmd_rollback(
     config: &Config,
     service_filter: Option<&str>,
@@ -2318,7 +2314,6 @@ fn extract_image_tag(image: &str) -> &str {
         after
     }
 }
-#[allow(clippy::large_futures)]
 async fn cmd_prune(config: &Config, dry_run: bool) -> Result<()> {
     use yoink::prune::{self, PruneReason};
     let ops = build_real_ops(config, None).await?;
@@ -2347,7 +2342,6 @@ async fn cmd_prune(config: &Config, dry_run: bool) -> Result<()> {
     Ok(())
 }
 
-#[allow(clippy::large_futures)]
 async fn load_secrets_bundle(config: &Config) -> Result<Option<SecretsBundle>> {
     secrets::load_bundle(config)
         .await
@@ -2366,7 +2360,6 @@ async fn load_secrets_bundle(config: &Config) -> Result<Option<SecretsBundle>> {
 /// to run before the bundle exists; making the resolver hard-fail
 /// here would block them. Deploy commands that actually consume
 /// `host.address` surface a clear error when it's empty.
-#[allow(clippy::large_futures)]
 async fn resolve_sealed_host_addresses(config: &mut Config) -> Result<()> {
     if !config.any_host_address_sealed() {
         return Ok(());
@@ -2395,7 +2388,6 @@ async fn resolve_sealed_host_addresses(config: &mut Config) -> Result<()> {
 /// already loads it for service-level secrets). Pass `None` when the
 /// caller doesn't otherwise need the bundle — it'll be loaded on
 /// demand only if a host actually declares `ssh_key_secret:`.
-#[allow(clippy::large_futures)]
 async fn build_real_ops(config: &Config, bundle: Option<&SecretsBundle>) -> Result<RealDockerOps> {
     // Fast path: no host needs a managed key. Skip bundle access
     // entirely so commands that don't otherwise touch secrets pay
@@ -2515,7 +2507,6 @@ fn pick_healthy_replica(
     candidates.into_iter().next()
 }
 
-#[allow(clippy::large_futures)]
 async fn cmd_exec(
     config: &Config,
     service: &str,
@@ -2540,7 +2531,6 @@ async fn cmd_exec(
     Ok(())
 }
 
-#[allow(clippy::large_futures)]
 async fn cmd_logs(
     config: &Config,
     service: &str,
@@ -2654,7 +2644,6 @@ async fn cmd_logs_tail(
     Ok(())
 }
 
-#[allow(clippy::large_futures)]
 async fn cmd_version(config: &Config, service: &str) -> Result<()> {
     let ops = build_real_ops(config, None).await?;
     let report = StatusReport::collect_for_service(&ops, config, service)
@@ -2691,11 +2680,7 @@ enum PtyMode {
 /// services that don't expose host ports — the secure-by-default
 /// shape (api/web behind Caddy in production).
 #[allow(clippy::fn_params_excessive_bools)] // operator-facing flags, explicit at the CLI; bundling into a struct hides them.
-#[allow(
-    clippy::too_many_arguments,
-    clippy::too_many_lines,
-    clippy::large_futures
-)] // mirrors the CLI surface 1:1; struct would force a noop builder.
+#[allow(clippy::too_many_arguments, clippy::too_many_lines)] // mirrors the CLI surface 1:1; struct would force a noop builder.
 async fn cmd_pf(
     config: &Config,
     service_name: &str,
@@ -2874,7 +2859,6 @@ fn parse_pf_port_arg(arg: &str) -> Result<(Option<u16>, u16)> {
     Ok((local, container))
 }
 
-#[allow(clippy::large_futures)]
 async fn cmd_pty(
     config: &Config,
     service: &str,
@@ -3045,7 +3029,7 @@ async fn pty_session(
     Ok(())
 }
 
-#[allow(clippy::large_futures, clippy::needless_pass_by_value)]
+#[allow(clippy::needless_pass_by_value)]
 async fn cmd_tui(config: &Config, config_path: PathBuf, mode: Mode, mouse: bool) -> Result<()> {
     let mut config = config.clone();
     config.push_local_host_if_socket();
@@ -3107,7 +3091,6 @@ impl From<DryRunFormat> for yoink::diff::Format {
     }
 }
 
-#[allow(clippy::large_futures)]
 async fn run_dry_run(
     ops: &dyn DockerOps,
     config: &Config,
@@ -3123,7 +3106,6 @@ async fn run_dry_run(
     Ok(())
 }
 
-#[allow(clippy::large_futures)]
 async fn cmd_restart(config: &Config, service: &str, host_filter: Option<&str>) -> Result<()> {
     let ops = build_real_ops(config, None).await?;
     let (host, container) = resolve_running_container(&ops, config, service, host_filter).await?;
@@ -3140,7 +3122,6 @@ async fn cmd_restart(config: &Config, service: &str, host_filter: Option<&str>) 
     Ok(())
 }
 
-#[allow(clippy::large_futures)]
 async fn cmd_kill(
     config: &Config,
     service: &str,
@@ -3162,7 +3143,6 @@ async fn cmd_kill(
     Ok(())
 }
 
-#[allow(clippy::large_futures)]
 async fn cmd_pull(
     config: &Config,
     service: &str,
@@ -3224,7 +3204,6 @@ async fn cmd_pull(
     Ok(())
 }
 
-#[allow(clippy::large_futures)]
 async fn cmd_history(
     config: &Config,
     service: &str,
@@ -3581,7 +3560,6 @@ struct TopRow {
     created: Option<i64>,
 }
 
-#[allow(clippy::large_futures)]
 async fn cmd_top(config: &Config, limit: usize, format: TableFormat) -> Result<()> {
     use yoink::output::{format_bytes, format_relative_time};
     let ops = build_real_ops(config, None).await?;
@@ -3687,7 +3665,6 @@ async fn cmd_top(config: &Config, limit: usize, format: TableFormat) -> Result<(
     Ok(())
 }
 
-#[allow(clippy::large_futures)]
 async fn cmd_networks(config: &Config, host_filter: Option<&str>) -> Result<()> {
     let ops = build_real_ops(config, None).await?;
     let probes = config
@@ -3723,7 +3700,6 @@ async fn cmd_networks(config: &Config, host_filter: Option<&str>) -> Result<()> 
     Ok(())
 }
 
-#[allow(clippy::large_futures)]
 async fn cmd_volumes(config: &Config, host_filter: Option<&str>) -> Result<()> {
     let ops = build_real_ops(config, None).await?;
     let probes = config
@@ -3805,7 +3781,7 @@ fn redact_value(value: &str) -> String {
     )
 }
 
-#[allow(clippy::too_many_lines, clippy::large_futures)]
+#[allow(clippy::too_many_lines)]
 async fn cmd_dump(config: &Config, log_tail: u32) -> Result<()> {
     use serde_json::json;
     use yoink::deploy;
@@ -4057,7 +4033,6 @@ async fn cmd_dump(config: &Config, log_tail: u32) -> Result<()> {
     Ok(())
 }
 
-#[allow(clippy::large_futures)]
 async fn cmd_validate(config: &Config, check_hosts: bool) -> Result<()> {
     // `Config::load_from_path` (called from `run`) already ran the
     // structural checks — duplicate names/addresses, missing fields,
@@ -4081,7 +4056,6 @@ async fn cmd_validate(config: &Config, check_hosts: bool) -> Result<()> {
     Ok(())
 }
 
-#[allow(clippy::large_futures)]
 async fn cmd_doctor(config: &Config, json: bool) -> Result<()> {
     use yoink::doctor::{Severity, run_doctor, tally};
 
@@ -4120,7 +4094,6 @@ async fn cmd_doctor(config: &Config, json: bool) -> Result<()> {
     Ok(())
 }
 
-#[allow(clippy::large_futures)]
 async fn validate_proxy_render(config: &Config) -> Result<()> {
     let bundle = load_secrets_bundle(config).await?;
     let mut config = config.clone();
@@ -4238,7 +4211,6 @@ fn cmd_proxy_dockerfile(config: &Config) -> Result<()> {
     Ok(())
 }
 
-#[allow(clippy::large_futures)]
 async fn cmd_proxy_render(config: &Config) -> Result<()> {
     if !yoink::proxy::proxy_enabled(config) {
         anyhow::bail!(
@@ -4260,7 +4232,6 @@ async fn cmd_proxy_render(config: &Config) -> Result<()> {
     Ok(())
 }
 
-#[allow(clippy::large_futures)]
 async fn cmd_lock(config: &Config, action: LockAction) -> Result<()> {
     use yoink::lock::LOCK_NAME;
     let ops = build_real_ops(config, None).await?;
@@ -4314,7 +4285,6 @@ async fn cmd_lock(config: &Config, action: LockAction) -> Result<()> {
     Ok(())
 }
 
-#[allow(clippy::large_futures)]
 async fn cmd_diff(config: &Config, service: &str, tag_override: Option<&str>) -> Result<()> {
     let svc_cfg = config
         .services

--- a/yoink/src/secrets.rs
+++ b/yoink/src/secrets.rs
@@ -215,7 +215,6 @@ impl fmt::Debug for SecretsBundle {
 /// rather than "you legitimately have zero secrets". `provider:
 /// command` returns its own `CommandEmpty` (we have the command
 /// string for the error message); the age path returns `SealedEmpty`.
-#[allow(clippy::large_futures)]
 pub async fn load_bundle(config: &Config) -> Result<Option<SecretsBundle>, SecretsError> {
     let Some(cfg) = &config.secrets else {
         return Ok(None);
@@ -288,7 +287,6 @@ fn load_age_bundle(
     Ok(SecretsBundle::new(map))
 }
 
-#[allow(clippy::large_futures)]
 async fn load_command_bundle(
     command: &[String],
     format: SecretsFormat,

--- a/yoink/src/tui/app.rs
+++ b/yoink/src/tui/app.rs
@@ -1478,7 +1478,6 @@ impl App {
     /// don't block startup on it — the column shows `?` for the few
     /// seconds the loader takes, then resolves to ✓/⚠ once the
     /// bundle lands.
-    #[allow(clippy::large_futures)]
     fn spawn_secrets_loader(&self) {
         let config = self.config.clone();
         let slot = self.secrets.clone();
@@ -3196,7 +3195,6 @@ impl App {
     /// land via `Update::Doctor`; the modal renders Loading until
     /// they arrive. Idempotent — re-pressing `D` (or `r` while
     /// open) just kicks off another run.
-    #[allow(clippy::large_futures)]
     fn open_doctor(&mut self) {
         self.doctor.mark_loading();
         let ops = self.ops.clone();
@@ -3216,7 +3214,6 @@ impl App {
     /// services where `service.tag` is absent — otherwise
     /// `compute` would error with `TagMissing`, which is correct
     /// for `yoink up` but useless for "what changed".
-    #[allow(clippy::large_futures)]
     fn open_drift(&mut self, host: Host, service: String) {
         self.drift.set_target(host.clone(), service.clone());
         let ops = self.ops.clone();


### PR DESCRIPTION
Follow-up cleanup to #84 from a /simplify pass:

- Hoist `exclude: ^\.claude/` to top-level (was repeated on three hooks).
- Drop the `check-yaml` `^docs/content/` exclude — Fumadocs MDX is `.md`/`.mdx`; check-yaml's default file filter ignores it, so the exclude was a no-op.
- Drop the `cargo-check` hook — clippy already runs the same compiler frontend, so it was a duplicate workspace build per commit.
- Move `clippy` to **pre-push** only — workspace clippy is too slow to gate every commit. Pre-commit keeps the fast hooks (fmt, file hygiene); the slower compiler-driven check runs on push.
- Move TruffleHog to **pre-push** only — `--since-commit HEAD` reads committed history, so the pre-commit invocation couldn't see staged content. Pre-push catches the actual delta.

With `large_futures = "allow"` set workspace-wide in #84, the per-fn `#[allow(clippy::large_futures)]` attributes are now redundant. Strip 19 sites across `main.rs`, `secrets.rs`, `tui/app.rs`, and consolidate three compound `#[allow(...)]` lists that listed it alongside other lints.

## Test plan

- [x] `pre-commit run --all-files --hook-stage pre-commit` — fast hooks green.
- [x] `pre-commit run --all-files --hook-stage pre-push` — fmt + clippy + TruffleHog green.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean.
- [x] `cargo test --workspace` — 502 passing.
- [x] Pre-push hook fired during the actual `git push` and passed.