### PR TITLE
fix(deploy): unconditional Caddy push at end of reconcile (#88)

### DIFF
--- a/yoink/src/deploy.rs
+++ b/yoink/src/deploy.rs
@@ -497,6 +497,34 @@ pub async fn reconcile_with_options(
         }
     }
 
+    // Unconditional Caddy push, after every wave has settled. The
+    // per-service path inside `deploy_to_host` already pushes when
+    // it changes containers; this final push covers the recovery
+    // case where every service is already at spec (full no-op
+    // reconcile) but Caddy's routing table is out of date — e.g.
+    // because a previous run died after replacing containers but
+    // before the in-flight push, leaving the operator with no way
+    // to reach a green state without resorting to `--force` or
+    // bumping a tag. The push is idempotent and cheap, so the
+    // redundant calls in the happy path are fine.
+    //
+    // Only run for proxy-enabled configs, and only against hosts
+    // the proxy service targets. `services_filter` is intentionally
+    // ignored: the operator may have run `yoink up --service web`
+    // on a partially-failed reconcile, and we still want Caddy
+    // resynced to actual on-host state.
+    if crate::proxy::proxy_enabled(config)
+        && let Some(proxy_svc) = config
+            .services
+            .iter()
+            .find(|s| matches!(s.kind, Some(crate::config::ServiceKind::Proxy)))
+    {
+        for host_cfg in proxy_svc.applicable_hosts(&config.hosts) {
+            let host = Host::from(host_cfg);
+            push_caddy_config(ops, &host, config, secrets, None).await?;
+        }
+    }
+
     Ok(reports)
 }
 

--- a/yoink/src/deploy.rs
+++ b/yoink/src/deploy.rs
@@ -497,22 +497,12 @@ pub async fn reconcile_with_options(
         }
     }
 
-    // Unconditional Caddy push, after every wave has settled. The
-    // per-service path inside `deploy_to_host` already pushes when
-    // it changes containers; this final push covers the recovery
-    // case where every service is already at spec (full no-op
-    // reconcile) but Caddy's routing table is out of date — e.g.
-    // because a previous run died after replacing containers but
-    // before the in-flight push, leaving the operator with no way
-    // to reach a green state without resorting to `--force` or
-    // bumping a tag. The push is idempotent and cheap, so the
-    // redundant calls in the happy path are fine.
-    //
-    // Only run for proxy-enabled configs, and only against hosts
-    // the proxy service targets. `services_filter` is intentionally
-    // ignored: the operator may have run `yoink up --service web`
-    // on a partially-failed reconcile, and we still want Caddy
-    // resynced to actual on-host state.
+    // Final unconditional Caddy push: recovers from a prior run that
+    // replaced containers and then died before the in-flight push
+    // (#88), since a follow-up reconcile finds every service already
+    // at spec and otherwise never calls `push_caddy_config`.
+    // `services_filter` is ignored on purpose — a scoped retry like
+    // `yoink up --service web` should still resync Caddy.
     if crate::proxy::proxy_enabled(config)
         && let Some(proxy_svc) = config
             .services


### PR DESCRIPTION
Closes #88.

## Summary

- Adds an idempotent Caddy `/load` push at the end of `reconcile_with_options`, after the wave loop has settled. Iterates the proxy service's applicable hosts. The per-service in-flight push inside `deploy_to_host` still runs first; this final push only matters when no service triggered one (e.g. every service was `already_at_spec`).
- Recovers from the issue-88 failure mode: a previous run replaced containers and then died on the in-flight Caddy push, leaving Caddy routing to dead backends; the next `yoink up` with the same tag would skip the push entirely. Now the no-op reconcile pushes once and routing is restored.

## Test plan

- [x] `cargo clippy -p yoink --all-targets -- -D warnings`
- [x] `cargo test -p yoink --lib deploy` (30 pass)
- [x] Reproduced in prod: site was 521 → ran `yoink up --tag api=… --tag web=…`, every service no-op, final push fired, site → 200.
- [ ] Verify a normal multi-service deploy (real container changes) still emits exactly one in-flight push per service plus the new trailing push (the trailing one is a no-op `/load` of the same JSON, fast on the wire).