### PR TITLE
fix(proxy): pass --resume so Caddy survives a host reboot

### DIFF
--- a/yoink/src/proxy/mod.rs
+++ b/yoink/src/proxy/mod.rs
@@ -339,13 +339,23 @@ fn synthesized_proxy_service(p: &ProxyConfig) -> ServiceConfig {
             // Caddy's host-header check by setting Host: yoink-admin
             // on every admin request. The actual routes are pushed
             // via `/load` immediately after the container is healthy.
+            //
+            // `--resume` makes Caddy fall back to its autosaved
+            // runtime config (`/config/caddy/autosave.json` on the
+            // mounted `yoink_caddy_config` volume) when one exists,
+            // ignoring the stdin bootstrap. That's how the site
+            // survives a host reboot: yoink-proxy comes back with
+            // the last-pushed routing table instead of the empty
+            // admin-only bootstrap, even before any operator runs
+            // `yoink up`. On a fresh proxy (no autosave yet) the
+            // bootstrap takes effect as before.
             entrypoint: Some(vec!["sh".to_string(), "-c".to_string()]),
             cmd: vec![
                 concat!(
                     "echo '{\"admin\":{\"listen\":\"0.0.0.0:2019\",",
                     "\"enforce_origin\":false,",
                     "\"origins\":[\"yoink-admin\"]}}'",
-                    " | exec caddy run --config /dev/stdin",
+                    " | exec caddy run --config /dev/stdin --resume",
                 )
                 .to_string(),
             ],


### PR DESCRIPTION
## Summary

yoink-proxy's entrypoint runs `caddy run --config /dev/stdin` with a minimal admin-only bootstrap config. After a host reboot, Caddy reloads only that bootstrap and the routing table previously pushed via `/load` is gone — yoink-proxy is *running + healthy* but serves nothing, producing 521/5xx for every published service until someone notices and runs `yoink up`.

Add `--resume`. Per Caddy's CLI: when both `--config` and `--resume` are passed and an autosave exists, the autosave takes precedence. The autosave already lives on the `yoink_caddy_config` volume, so the proxy now comes back with the last-pushed routing table on its own. On a fresh proxy with no autosave, the bootstrap takes effect as before.

Pairs with #89 (unconditional Caddy push at end of `reconcile`): together they make a host reboot a fully self-healing event for routed services. (#89 alone makes recovery one `yoink up` away; this PR makes it automatic.)

## Test plan

- [x] `cargo clippy -p yoink --all-targets -- -D warnings`
- [x] `cargo test -p yoink --lib proxy` (57 pass)
- [ ] After merge and release: reboot a host with a deployed config, verify the proxy comes back routing to existing backends without operator intervention.
- [ ] Fresh-deploy a new host (no autosave): verify the bootstrap entrypoint still gates the first `/load` correctly.