### PR TITLE
fix(deploy): clean up orphans on full no-op reconcile

### DIFF
--- a/yoink/src/deploy.rs
+++ b/yoink/src/deploy.rs
@@ -753,6 +753,7 @@ async fn prepare_one_host(
     })
 }
 
+#[allow(clippy::too_many_lines)] // single linear finalize flow; same rationale as `reconcile`
 async fn finalize_one_host(
     ops: &dyn DockerOps,
     config: &Config,

--- a/yoink/src/deploy.rs
+++ b/yoink/src/deploy.rs
@@ -771,14 +771,25 @@ async fn finalize_one_host(
     let expected_names: std::collections::BTreeSet<String> =
         replicas.iter().map(|r| r.name.clone()).collect();
 
-    // If every replica is already at spec, nothing to do.
+    // No fresh container to start, but a prior partial failure may
+    // have left an old generation running alongside the new — run
+    // orphan cleanup unconditionally so the second reconcile self-heals.
     if replicas.iter().all(|r| r.already_running) {
+        let stopped_old = swap_out_old_containers_by_set(
+            ops,
+            &host,
+            service.run.drain_timeout,
+            &existing,
+            &expected_names,
+            on_event,
+        )
+        .await?;
         let primary = replicas.first().map(|r| r.name.clone()).unwrap_or_default();
         return Ok(HostDeployResult {
             host: host.address,
             container: primary,
             healthcheck_attempts: 0,
-            stopped_old: vec![],
+            stopped_old,
         });
     }
 


### PR DESCRIPTION
## Summary

`finalize_one_host`'s "every replica already at spec → return early" shortcut bypassed `swap_out_old_containers_by_set`. So an old-generation container left running by a prior partial failure (new replicas started + healthcheck passed, then yoink died before the old-stop step) would survive every subsequent same-tag reconcile. Operator workaround was `yoink prune`, but it's the same shape as #88: a convergent fast-path silently skipping a side-effect.

Run orphan cleanup unconditionally. The helper already filters to `existing` (this service's snapshot, from `list_existing_containers`) and only stops running containers not in `expected_names`, so it's a no-op in the common case where the prior reconcile fully completed.

## Test plan

- [x] `cargo clippy -p yoink --all-targets -- -D warnings`
- [x] `cargo test -p yoink` (509 pass, 4 suites)
- [ ] Reproduce the partial-failure shape (manually create an orphan container with the old `yoink.spec_hash` label) and verify the next `yoink up` reaps it without operator intervention.