### PR TITLE
fix(docker_ops): treat 409 AlreadyExists as success in ensure_network

### DIFF
--- a/yoink/src/docker_ops.rs
+++ b/yoink/src/docker_ops.rs
@@ -1100,9 +1100,7 @@ impl DockerOps for RealDockerOps {
                     };
                     match docker.create_network(req).await {
                         Ok(_) => Ok(true),
-                        // Concurrent operator created the same network
-                        // between our 404 and our create. Idempotent —
-                        // someone else already did the work.
+                        // 409 = raced by another operator; treat as idempotent.
                         Err(bollard::errors::Error::DockerResponseServerError {
                             status_code: 409,
                             ..

--- a/yoink/src/docker_ops.rs
+++ b/yoink/src/docker_ops.rs
@@ -1098,8 +1098,17 @@ impl DockerOps for RealDockerOps {
                         name: network.to_string(),
                         ..Default::default()
                     };
-                    docker.create_network(req).await?;
-                    Ok(true)
+                    match docker.create_network(req).await {
+                        Ok(_) => Ok(true),
+                        // Concurrent operator created the same network
+                        // between our 404 and our create. Idempotent —
+                        // someone else already did the work.
+                        Err(bollard::errors::Error::DockerResponseServerError {
+                            status_code: 409,
+                            ..
+                        }) => Ok(false),
+                        Err(other) => Err(other),
+                    }
                 }
                 Err(other) => Err(other),
             }


### PR DESCRIPTION
Audit finding [B].

## Summary

\`ensure_network\` does inspect → 404 → create. Two operators reconciling against the same host within that window both see 404, both call create; one wins, the other's \`create_network\` returns 409 AlreadyExists which currently surfaces as a hard \`DockerError::Bollard\` and aborts the deploy.

Catch the 409 in the create branch and treat it as \`Ok(false)\` — someone else already did the work. Same idempotent shape as the existing 404 handling on \`remove_image\` / \`remove_volume\` / \`remove_network\`.

## Test plan

- [x] \`cargo clippy -p yoink --all-targets -- -D warnings\`
- [x] \`cargo test -p yoink\` (suite green)
- [ ] Live regression: race two \`yoink up\` invocations against the same host on a fresh-network config; both should succeed (without this fix, one would lose to a 409).