### PR TITLE
fix(deploy): recover from poisoned event-sink Mutex

### DIFF
--- a/yoink/src/deploy.rs
+++ b/yoink/src/deploy.rs
@@ -445,7 +445,9 @@ pub async fn reconcile_with_options(
                             &desired_hash,
                         )
                     {
-                        let mut g = sink_ref.lock().expect("sink poisoned");
+                        let mut g = sink_ref
+                            .lock()
+                            .unwrap_or_else(std::sync::PoisonError::into_inner);
                         for r in &host_results {
                             for index in 0..service.run.replicas {
                                 let name = container_name(
@@ -473,7 +475,9 @@ pub async fn reconcile_with_options(
 
                     // Lock-per-event sink that injects the service tag.
                     let mut local_sink = |e: DeployEvent| {
-                        let mut g = sink_ref.lock().expect("sink poisoned");
+                        let mut g = sink_ref
+                            .lock()
+                            .unwrap_or_else(std::sync::PoisonError::into_inner);
                         g(Some(&svc_name), e);
                     };
                     deploy_service(


### PR DESCRIPTION
Audit finding [C].

## Summary

The wave-loop's \`std::sync::Mutex\` event-sink had two \`.lock().expect("sink poisoned")\` call sites (\`deploy.rs:448\`, \`:476\`). If any wave task panicked while holding the lock, every subsequent wave task in the same reconcile would also panic on \`.expect\`, masking the original panic with a generic poisoned-mutex message and aborting the entire reconcile.

Swap the \`.expect\` for \`.unwrap_or_else(PoisonError::into_inner)\` so we recover the inner sink and let downstream events flow. The on_event closure is short and idempotent — it appends to the caller's event log — so reading through a poisoning is safe.

## Test plan

- [x] \`cargo clippy -p yoink --all-targets -- -D warnings\`
- [x] \`cargo test -p yoink\`