### PR TITLE
fix(audit): fsync operator-side audit appends

### DIFF
--- a/yoink/src/audit.rs
+++ b/yoink/src/audit.rs
@@ -582,6 +582,10 @@ async fn append_to_operator_log(line: &str) -> std::io::Result<()> {
         .await?;
     let payload = format!("{line}\n");
     f.write_all(payload.as_bytes()).await?;
+    // Audit is best-effort, but the on-host SSH path is atomic via
+    // `cat >> file` in a single shell — match that durability on the
+    // operator side so a SIGKILL or panic doesn't lose the tail.
+    f.sync_all().await?;
     if let Ok(meta) = f.metadata().await
         && meta.len() > ROTATE_BYTES
     {


### PR DESCRIPTION
Audit finding [D].

## Summary

\`append_to_operator_log\` wrote via tokio's buffered async I/O without a following \`sync_all\`. A laptop SIGKILL or panic would lose the tail of the operator-side audit log.

The on-host SSH path is already atomic (single shell \`cat >> file\`). Match that durability on the operator side with one \`sync_all().await\` after the write — one fsync per yoink invocation, negligible cost.

## Test plan

- [x] \`cargo clippy -p yoink --all-targets -- -D warnings\`
- [x] \`cargo test -p yoink --lib audit\` (21 pass)