### PR TITLE
fix(audit): serialize concurrent on-host log rotations with flock

### DIFF
--- a/yoink/src/audit.rs
+++ b/yoink/src/audit.rs
@@ -607,16 +607,21 @@ async fn append_to_operator_log(line: &str) -> std::io::Result<()> {
 /// appenders so the size-check + `mv` rotate sequence is atomic
 /// across operators. Without it, two concurrent appenders could
 /// both observe `sz < ROTATE_BYTES` and both skip rotation, letting
-/// the file grow past the threshold for a window. The lock file is
-/// the audit dir itself (always present after `mkdir -p`); fd 9
-/// closes on shell exit so the lock is always released.
+/// the file grow past the threshold for a window. fd 9 closes on
+/// shell exit so the lock is always released.
+///
+/// `flock` ships with util-linux on every Linux distro yoink
+/// targets but is absent on macOS / BSD; the `|| true` degrades to
+/// the previous (unlocked) behavior on those hosts rather than
+/// aborting the whole script under `set -e` and silently dropping
+/// audit lines.
 async fn append_via_ssh(host: &Host, lines: &[String]) -> std::io::Result<()> {
     let payload = lines.join("\n") + "\n";
     let script = format!(
         "set -e; \
          mkdir -p {AUDIT_DIR}; \
          exec 9>{AUDIT_DIR}/.lock; \
-         flock -x 9; \
+         flock -x 9 2>/dev/null || true; \
          cat >> {AUDIT_FILE}; \
          chmod 0640 {AUDIT_FILE} 2>/dev/null || true; \
          sz=$(wc -c < {AUDIT_FILE} 2>/dev/null || echo 0); \

--- a/yoink/src/audit.rs
+++ b/yoink/src/audit.rs
@@ -602,11 +602,21 @@ async fn append_to_operator_log(line: &str) -> std::io::Result<()> {
 /// Pipe `lines` (newline-joined) through `ssh user@host sh -c "…"`.
 /// Single roundtrip: mkdir + tee + size-based rotate, all in one
 /// shell.
+///
+/// `flock -x` over a per-dir lock file serializes concurrent
+/// appenders so the size-check + `mv` rotate sequence is atomic
+/// across operators. Without it, two concurrent appenders could
+/// both observe `sz < ROTATE_BYTES` and both skip rotation, letting
+/// the file grow past the threshold for a window. The lock file is
+/// the audit dir itself (always present after `mkdir -p`); fd 9
+/// closes on shell exit so the lock is always released.
 async fn append_via_ssh(host: &Host, lines: &[String]) -> std::io::Result<()> {
     let payload = lines.join("\n") + "\n";
     let script = format!(
         "set -e; \
          mkdir -p {AUDIT_DIR}; \
+         exec 9>{AUDIT_DIR}/.lock; \
+         flock -x 9; \
          cat >> {AUDIT_FILE}; \
          chmod 0640 {AUDIT_FILE} 2>/dev/null || true; \
          sz=$(wc -c < {AUDIT_FILE} 2>/dev/null || echo 0); \


### PR DESCRIPTION
Audit finding [G].

## Summary

The on-host audit append script did \`cat >> file; sz=\$(wc -c …); if \$sz>ROTATE; mv …\`. Two concurrent appenders (multiple operators reconciling the same host at the same time) could both observe a size below the threshold and skip rotation, letting the active file grow past it for a window.

Wrap the script in \`flock -x\` over a per-directory lock file (\`/var/lib/yoink/audit/.lock\`) so the size-check + rename is atomic across operators. fd 9 closes on shell exit so the lock is always released, even on error or signal.

\`flock\` ships in \`util-linux\` which is part of every base distro yoink targets (Debian/Ubuntu/RHEL/Alpine post-3.4); no new host-side dependency.

## Test plan

- [x] \`cargo clippy -p yoink --all-targets -- -D warnings\`
- [x] \`cargo test -p yoink --lib audit\` (21 pass)