### PR TITLE
feat(types): typed ContainerState, HealthStatus, RestartPolicy

### DIFF
--- a/yoink/src/config.rs
+++ b/yoink/src/config.rs
@@ -649,6 +649,39 @@ pub enum ServiceKind {
     Proxy,
 }
 
+/// Docker restart policy. Mirrors the four values docker accepts on
+/// `--restart`. Validated at config-load time (rather than at
+/// container-create) so a typo in `restart:` fails parse instead of
+/// the first deploy.
+///
+/// YAML scalar mapping is kebab-case (`unless-stopped`, `on-failure`).
+/// **`no`** is a YAML boolean false unless quoted — write it as
+/// `restart: 'no'` if you really need it.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum RestartPolicy {
+    No,
+    Always,
+    #[default]
+    UnlessStopped,
+    OnFailure,
+}
+
+impl RestartPolicy {
+    /// Canonical wire form (matches `--restart` and the docker REST API).
+    /// Used by the spec-hash compute so the hash is stable across the
+    /// pre/post-enum-refactor cutover.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::No => "no",
+            Self::Always => "always",
+            Self::UnlessStopped => "unless-stopped",
+            Self::OnFailure => "on-failure",
+        }
+    }
+}
+
 /// `domain:` accepts either a single hostname or a list — a service
 /// can be reachable on multiple domain names (e.g. `api.example.com`
 /// + `api.example.net`).
@@ -1026,7 +1059,7 @@ pub struct RunOptions {
     #[serde(default)]
     pub tmpfs: BTreeMap<String, String>,
     #[serde(default)]
-    pub restart: Option<String>,
+    pub restart: Option<RestartPolicy>,
     /// Override the container's effective user.
     /// **Default: `"65534:65534"` (nobody:nogroup)** — yoink runs every
     /// new container as a non-root unprivileged uid so a process

--- a/yoink/src/docker.rs
+++ b/yoink/src/docker.rs
@@ -119,8 +119,6 @@ pub enum BuildError {
          with absolute paths and `<perms>` drawn from `r`, `w`, `m`"
     )]
     Device(String),
-    #[error("unknown restart policy {0:?}: expected one of no|always|unless-stopped|on-failure")]
-    RestartPolicy(String),
     #[error(
         "invalid publish spec {0:?}: expected \"host_port:container_port[/proto]\" or \"ip:host_port:container_port[/proto]\""
     )]
@@ -256,12 +254,11 @@ fn build_host_config(
     let network = spec.networks.first().map_or("bridge", String::as_str);
     let memory = options.memory.as_deref().map(parse_memory).transpose()?;
 
-    let restart_policy = match options.restart.as_deref().unwrap_or("unless-stopped") {
-        "no" => RestartPolicyNameEnum::NO,
-        "always" => RestartPolicyNameEnum::ALWAYS,
-        "unless-stopped" => RestartPolicyNameEnum::UNLESS_STOPPED,
-        "on-failure" => RestartPolicyNameEnum::ON_FAILURE,
-        other => return Err(BuildError::RestartPolicy(other.to_string())),
+    let restart_policy = match options.restart.unwrap_or_default() {
+        crate::config::RestartPolicy::No => RestartPolicyNameEnum::NO,
+        crate::config::RestartPolicy::Always => RestartPolicyNameEnum::ALWAYS,
+        crate::config::RestartPolicy::UnlessStopped => RestartPolicyNameEnum::UNLESS_STOPPED,
+        crate::config::RestartPolicy::OnFailure => RestartPolicyNameEnum::ON_FAILURE,
     };
 
     let tmpfs: Option<HashMap<String, String>> = if options.tmpfs.is_empty() {
@@ -619,7 +616,9 @@ pub fn compute_spec_hash(spec: &RunSpec) -> String {
     feed(
         &mut h,
         "restart",
-        opts.restart.as_deref().unwrap_or("").as_bytes(),
+        opts.restart
+            .map_or("", crate::config::RestartPolicy::as_str)
+            .as_bytes(),
     );
     feed(
         &mut h,
@@ -989,14 +988,6 @@ mod tests {
         assert!(parse_memory("").is_err());
         assert!(parse_memory("abc").is_err());
         assert!(parse_memory("12x").is_err());
-    }
-
-    #[test]
-    fn build_container_propagates_unknown_restart_policy() {
-        let mut spec = sample_spec();
-        spec.options.restart = Some("explode".into());
-        let err = build_container(&spec).unwrap_err();
-        assert!(matches!(err, BuildError::RestartPolicy(_)));
     }
 
     #[test]

--- a/yoink/src/docker_ops.rs
+++ b/yoink/src/docker_ops.rs
@@ -107,6 +107,99 @@ impl From<&YoinkHost> for Host {
 }
 
 /// What we surface for a container after listing/inspect. Independent of
+/// Docker container lifecycle state. Parsed from bollard's typed
+/// `state` field at the boundary so downstream code matches an enum
+/// instead of doing string-equality on `"running"`. `Unknown`
+/// captures values bollard adds in future versions.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum ContainerState {
+    Created,
+    Running,
+    Restarting,
+    Removing,
+    Paused,
+    Exited,
+    Dead,
+    /// Anything bollard reports that we don't recognise. Round-trips
+    /// through `Unknown` rather than mapping to a concrete variant
+    /// because misclassifying a future docker state would be worse
+    /// than rendering it as "unknown" for one yoink release.
+    Unknown,
+}
+
+impl ContainerState {
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Created => "created",
+            Self::Running => "running",
+            Self::Restarting => "restarting",
+            Self::Removing => "removing",
+            Self::Paused => "paused",
+            Self::Exited => "exited",
+            Self::Dead => "dead",
+            Self::Unknown => "unknown",
+        }
+    }
+
+    #[must_use]
+    pub fn parse(raw: &str) -> Self {
+        match raw.to_ascii_lowercase().as_str() {
+            "created" => Self::Created,
+            "running" => Self::Running,
+            "restarting" => Self::Restarting,
+            "removing" => Self::Removing,
+            "paused" => Self::Paused,
+            "exited" => Self::Exited,
+            "dead" => Self::Dead,
+            _ => Self::Unknown,
+        }
+    }
+}
+
+impl std::fmt::Display for ContainerState {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl From<&str> for ContainerState {
+    fn from(s: &str) -> Self {
+        Self::parse(s)
+    }
+}
+
+impl std::fmt::Display for HealthStatus {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// Container healthcheck status. Bollard reports a parallel `health`
+/// field on inspect responses and embeds the status in the
+/// `status_text` line of `list_containers` (e.g. `Up 5 minutes
+/// (healthy)`). yoink reads the latter today; this enum gives that
+/// parse a typed home.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum HealthStatus {
+    Starting,
+    Healthy,
+    Unhealthy,
+}
+
+impl HealthStatus {
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Starting => "starting",
+            Self::Healthy => "healthy",
+            Self::Unhealthy => "unhealthy",
+        }
+    }
+}
+
 /// bollard's `ContainerSummary` so callers don't depend on bollard types.
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
 pub struct ContainerInfo {
@@ -116,7 +209,7 @@ pub struct ContainerInfo {
     /// pulled images, sometimes `sha256:…` for content-addressed
     /// runs, or empty when docker hasn't yet resolved the image name.
     pub image: String,
-    pub state: String,
+    pub state: ContainerState,
     pub status_text: String,
     /// Container creation time as Unix epoch seconds. `None` when the
     /// daemon didn't return one (e.g. a freshly-created container the
@@ -143,18 +236,18 @@ pub struct ContainerInfo {
 impl ContainerInfo {
     #[must_use]
     pub fn is_running(&self) -> bool {
-        self.state.eq_ignore_ascii_case("running")
+        self.state == ContainerState::Running
     }
 
     #[must_use]
-    pub fn health_hint(&self) -> Option<&'static str> {
+    pub fn health_hint(&self) -> Option<HealthStatus> {
         let s = self.status_text.to_lowercase();
         if s.contains("(healthy)") {
-            Some("healthy")
+            Some(HealthStatus::Healthy)
         } else if s.contains("(unhealthy)") {
-            Some("unhealthy")
+            Some(HealthStatus::Unhealthy)
         } else if s.contains("(starting)") {
-            Some("starting")
+            Some(HealthStatus::Starting)
         } else {
             None
         }
@@ -192,10 +285,9 @@ impl ContainerInfo {
             host: host.to_string(),
             name,
             image: summary.image.unwrap_or_default(),
-            state: summary
-                .state
-                .map(|s| format!("{s:?}").to_lowercase())
-                .unwrap_or_default(),
+            state: summary.state.map_or(ContainerState::Unknown, |s| {
+                ContainerState::parse(&format!("{s:?}"))
+            }),
             status_text: summary.status.unwrap_or_default(),
             created_unix: summary.created,
             yoink_service,
@@ -3000,7 +3092,7 @@ mod tests {
         let info = ContainerInfo::from_summary("host-a", summary);
         assert_eq!(info.name, "app-a-a1b2c3d");
         assert!(info.is_running());
-        assert_eq!(info.health_hint(), Some("healthy"));
+        assert_eq!(info.health_hint(), Some(HealthStatus::Healthy));
         assert_eq!(info.yoink_service.as_deref(), Some("app-a"));
         assert_eq!(info.yoink_version.as_deref(), Some("a1b2c3d"));
         assert_eq!(

--- a/yoink/src/main.rs
+++ b/yoink/src/main.rs
@@ -2575,7 +2575,7 @@ fn pick_healthy_replica(
 ) -> Option<(yoink::docker_ops::Host, yoink::docker_ops::ContainerInfo)> {
     if let Some(idx) = candidates
         .iter()
-        .position(|(_, c)| c.health_hint() == Some("healthy"))
+        .position(|(_, c)| c.health_hint() == Some(yoink::docker_ops::HealthStatus::Healthy))
     {
         return candidates.into_iter().nth(idx);
     }
@@ -2959,7 +2959,8 @@ async fn cmd_pty(
             "→ {}/{} ({})",
             host.address,
             container,
-            info.health_hint().unwrap_or("running"),
+            info.health_hint()
+                .map_or("running", yoink::docker_ops::HealthStatus::as_str),
         );
     }
 
@@ -3309,7 +3310,7 @@ async fn cmd_history(
                 host_addr.clone(),
                 c.name,
                 c.yoink_version.unwrap_or_else(|| "?".into()),
-                c.state,
+                c.state.as_str().to_string(),
                 c.yoink_deployed_by.unwrap_or_else(|| "?".into()),
             ));
         }

--- a/yoink/src/output.rs
+++ b/yoink/src/output.rs
@@ -95,8 +95,10 @@ pub fn format_status_table(report: &StatusReport) -> String {
                 host: host.host.clone(),
                 service: c.yoink_service.clone().unwrap_or_else(|| "-".into()),
                 container: c.name.clone(),
-                state: c.state.clone(),
-                health: c.health_hint().unwrap_or("-").into(),
+                state: c.state.as_str().to_string(),
+                health: c
+                    .health_hint()
+                    .map_or_else(|| "-".to_string(), |h| h.as_str().to_string()),
                 version: c.yoink_version.clone().unwrap_or_else(|| "-".into()),
                 created: format_relative_time(c.created_unix),
             });

--- a/yoink/src/tui/container_detail.rs
+++ b/yoink/src/tui/container_detail.rs
@@ -647,10 +647,11 @@ impl ContainerDetailState {
             .split(inner);
 
         let lifecycle = inspect.state.as_deref().unwrap_or("?");
+        let lifecycle_state = crate::docker_ops::ContainerState::parse(lifecycle);
         let health = inspect.labels.get("yoink.health").map(String::as_str);
         let mut left_lines = vec![
             kv("image", inspect.image.as_deref().unwrap_or("?")),
-            kv_styled("state", lifecycle, state_style(lifecycle)),
+            kv_styled("state", lifecycle, state_style(lifecycle_state)),
         ];
         if let Some(h) = health {
             left_lines.push(kv_styled("health", h, health_style(h)));

--- a/yoink/src/tui/dashboard.rs
+++ b/yoink/src/tui/dashboard.rs
@@ -325,7 +325,9 @@ impl DashboardState {
                 if !self.filter.matches(&searchable) {
                     continue;
                 }
-                let health = c.health_hint().unwrap_or("-");
+                let health = c
+                    .health_hint()
+                    .map_or("-", crate::docker_ops::HealthStatus::as_str);
                 let stats = history
                     .get(&(host.host.clone(), c.name.clone()))
                     .and_then(StatsHistory::latest);
@@ -346,7 +348,7 @@ impl DashboardState {
                     Cell::from(host.host.clone()),
                     service_cell,
                     Cell::from(c.name.clone()),
-                    Cell::from(c.state.clone()).style(state_style(&c.state)),
+                    Cell::from(c.state.as_str()).style(state_style(c.state)),
                     Cell::from(health.to_string()).style(health_style(health)),
                     Cell::from(c.yoink_version.clone().unwrap_or_else(|| "-".into())),
                     Cell::from(format_networks(&c.networks)),

--- a/yoink/src/tui/history.rs
+++ b/yoink/src/tui/history.rs
@@ -40,7 +40,7 @@ impl HistoryRow {
             host: host.to_string(),
             container: c.name.clone(),
             version: c.yoink_version.clone().unwrap_or_else(|| "?".to_string()),
-            state: c.state.clone(),
+            state: c.state.as_str().to_string(),
             deployed_by: c
                 .yoink_deployed_by
                 .clone()
@@ -188,7 +188,9 @@ impl HistoryState {
                     Row::new(vec![
                         Cell::from(when),
                         Cell::from(r.version.clone()),
-                        Cell::from(r.state.clone()).style(state_style(&r.state)),
+                        Cell::from(r.state.clone()).style(state_style(
+                            crate::docker_ops::ContainerState::parse(&r.state),
+                        )),
                         Cell::from(r.host.clone()),
                         Cell::from(r.container.clone()),
                         Cell::from(r.deployed_by.clone()),

--- a/yoink/src/tui/host_detail.rs
+++ b/yoink/src/tui/host_detail.rs
@@ -242,7 +242,9 @@ impl HostDetailState {
                     let stats = history
                         .get(&(host_addr.clone(), c.name.clone()))
                         .and_then(StatsHistory::latest);
-                    let health = c.health_hint().unwrap_or("-");
+                    let health = c
+                        .health_hint()
+                        .map_or("-", crate::docker_ops::HealthStatus::as_str);
                     let service_cell = match c.yoink_service.as_deref() {
                         Some(svc) => {
                             let pf = forwards.is_container_forwarded(&host_addr, &c.name)
@@ -262,7 +264,7 @@ impl HostDetailState {
                         }),
                         render_drift_cell(c, config, secrets),
                         Cell::from(c.status_text.clone()),
-                        Cell::from(c.state.clone()).style(state_style(&c.state)),
+                        Cell::from(c.state.as_str()).style(state_style(c.state)),
                         Cell::from(health.to_string()).style(health_style(health)),
                         cell_cpu(stats),
                         cell_mem(stats),

--- a/yoink/src/tui/services.rs
+++ b/yoink/src/tui/services.rs
@@ -266,7 +266,7 @@ fn summarize_health(containers: &[&ContainerInfo]) -> &'static str {
     let mut hints: Vec<&str> = containers
         .iter()
         .filter(|c| c.is_running())
-        .filter_map(|c| c.health_hint())
+        .filter_map(|c| c.health_hint().map(crate::docker_ops::HealthStatus::as_str))
         .collect();
     hints.sort_unstable();
     hints.dedup();
@@ -462,12 +462,15 @@ impl ServiceDetailState {
                 .iter()
                 .map(|i| {
                     let r = &self.rows[*i];
-                    let health = r.container.health_hint().unwrap_or("-");
+                    let health = r
+                        .container
+                        .health_hint()
+                        .map_or("-", crate::docker_ops::HealthStatus::as_str);
                     Row::new(vec![
                         Cell::from(r.host.address.clone()),
                         Cell::from(r.container.name.clone()),
-                        Cell::from(r.container.state.clone())
-                            .style(state_style(&r.container.state)),
+                        Cell::from(r.container.state.as_str())
+                            .style(state_style(r.container.state)),
                         Cell::from(health.to_string()).style(health_style(health)),
                         Cell::from(
                             r.container

--- a/yoink/src/tui/ui.rs
+++ b/yoink/src/tui/ui.rs
@@ -141,13 +141,16 @@ pub fn health_style(health: &str) -> Style {
 /// Lifecycle (running → exited / dead) maps onto the obvious colors;
 /// transient states get yellow so they stand out at a glance.
 #[must_use]
-pub fn state_style(state: &str) -> Style {
-    match state.to_ascii_lowercase().as_str() {
-        "running" => Style::default().fg(Color::Green),
-        "exited" | "dead" => Style::default().fg(Color::DarkGray),
-        "restarting" | "removing" | "paused" => Style::default().fg(Color::Yellow),
-        "created" => Style::default().fg(Color::Cyan),
-        _ => Style::default(),
+pub fn state_style(state: crate::docker_ops::ContainerState) -> Style {
+    use crate::docker_ops::ContainerState;
+    match state {
+        ContainerState::Running => Style::default().fg(Color::Green),
+        ContainerState::Exited | ContainerState::Dead => Style::default().fg(Color::DarkGray),
+        ContainerState::Restarting | ContainerState::Removing | ContainerState::Paused => {
+            Style::default().fg(Color::Yellow)
+        }
+        ContainerState::Created => Style::default().fg(Color::Cyan),
+        ContainerState::Unknown => Style::default(),
     }
 }
 


### PR DESCRIPTION
Design audit findings [M1] + [H1].

## Summary

Three new enums replace stringly-typed domain values at the bollard / serde boundaries:

- **\`config::RestartPolicy\`** (\`No|Always|UnlessStopped|OnFailure\`) — serde-deserialized from kebab-case scalar so a typo in \`restart:\` fails at config load instead of \`build_container\`. Drops \`BuildError::RestartPolicy\` (now unreachable) and its test.
- **\`docker_ops::ContainerState\`** (\`Created|Running|Restarting|Removing|Paused|Exited|Dead|Unknown\`) — parsed once from bollard's state in \`ContainerInfo::from_summary\`; replaces \`ContainerInfo.state: String\` + the \`state.eq_ignore_ascii_case("running")\` check. \`Unknown\` covers future docker states.
- **\`docker_ops::HealthStatus\`** (\`Starting|Healthy|Unhealthy\`) — return type of \`health_hint()\`, replacing \`Option<&'static str>\`.

Wire formats stay unchanged: \`#[serde(rename_all = "lowercase")]\` keeps \`yoink dump\` / \`yoink status --json\` byte-identical. \`From<&str>\` on \`ContainerState\` keeps \`state: "running".into()\` test fixtures building. \`Display\` on both state/health enums lets \`format!("{}", c.state)\` compile unchanged.

\`state_style\` (TUI) takes \`ContainerState\` directly, eliminating the lowercase-string match in the rendering hot path.

## Test plan

- [x] \`cargo clippy -p yoink --all-targets -- -D warnings\`
- [x] \`cargo test -p yoink\` (509 pass)