### PR TITLE
feat: warn when config is behind its branch's upstream

### DIFF
--- a/yoink/Cargo.toml
+++ b/yoink/Cargo.toml
@@ -27,7 +27,7 @@ async-trait = "0.1"
 bollard = { version = "0.20", features = ["ssh"] }
 base64 = "0.22"
 bytes = "1"
-clap = { version = "4", features = ["derive"] }
+clap = { version = "4", features = ["derive", "env"] }
 clap_complete = "4"
 crossterm = { version = "0.28", features = ["event-stream"] }
 futures-util = "0.3"

--- a/yoink/src/git.rs
+++ b/yoink/src/git.rs
@@ -84,6 +84,70 @@ pub fn is_dirty_from_status(stdout: &str) -> bool {
     !stdout.trim().is_empty()
 }
 
+/// What `commits_behind_upstream_for_path` returns when there's
+/// drift to warn about. `upstream` is the branch ref `git` reports
+/// (typically `origin/<branch>`); `commits_behind` is the count of
+/// upstream commits that touch the path but aren't in HEAD yet.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UpstreamLag {
+    pub upstream: String,
+    pub commits_behind: u32,
+}
+
+/// Best-effort: report whether the file at `path` has commits on its
+/// branch's upstream tracking ref that aren't yet in HEAD. Returns
+/// `None` on any failure mode that isn't actionable from the operator's
+/// seat — not a git repo, no upstream tracking branch, detached HEAD,
+/// `git` binary missing, etc. We deliberately do **not** `git fetch`
+/// (it's slow, may prompt for creds, and may have privacy implications);
+/// the lag is measured against whatever the caller's most recent fetch
+/// produced, which is typically what they want.
+///
+/// Path-scoped: only counts commits whose diff actually touches `path`.
+/// A config file that hasn't changed upstream produces `None` even if
+/// the branch as a whole is behind.
+#[must_use]
+pub fn commits_behind_upstream_for_path(path: &Path) -> Option<UpstreamLag> {
+    let dir = path.parent().filter(|p| !p.as_os_str().is_empty())?;
+    let basename = path.file_name()?.to_str()?;
+    let upstream = run_git_string(dir, &["rev-parse", "--abbrev-ref", "@{upstream}"])?;
+    // Pass the file name as a workdir-relative path so the filter
+    // matches the repo's tree regardless of how `path` was rendered
+    // by the caller (canonicalize-via-symlinks on macOS would have
+    // produced `/private/tmp/...` which `rev-list -- <path>` won't
+    // resolve against the repo at `/tmp/...`).
+    let raw = run_git_string(
+        dir,
+        &["rev-list", "--count", "HEAD..@{upstream}", "--", basename],
+    )?;
+    let commits_behind: u32 = raw.parse().ok()?;
+    if commits_behind == 0 {
+        return None;
+    }
+    Some(UpstreamLag {
+        upstream,
+        commits_behind,
+    })
+}
+
+/// Run `git <args>` in `dir` and return stdout trimmed. Returns
+/// `None` if the command fails or stdout is empty — used for
+/// best-effort probes where the caller doesn't want a structured
+/// error.
+fn run_git_string(dir: &Path, args: &[&str]) -> Option<String> {
+    let out = Command::new("git")
+        .args(args)
+        .current_dir(dir)
+        .stderr(std::process::Stdio::null())
+        .output()
+        .ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    let s = String::from_utf8(out.stdout).ok()?.trim().to_string();
+    (!s.is_empty()).then_some(s)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -132,5 +196,100 @@ mod tests {
         assert!(!is_dirty_from_status(""));
         assert!(!is_dirty_from_status("\n"));
         assert!(!is_dirty_from_status("   \n"));
+    }
+
+    #[test]
+    fn upstream_lag_none_outside_git_repo() {
+        // tempfile in /tmp lives outside any git repo (the operator's
+        // homedir is the closest one and macOS /tmp is its own
+        // filesystem on most setups). Even when that's not true, the
+        // file we check is freshly-created so it has no upstream
+        // history — `rev-list --count … -- <path>` returns 0.
+        let dir = tempfile::tempdir_in("/tmp").expect("tempdir");
+        let path = dir.path().join("yoink.yaml");
+        std::fs::write(&path, "hello: world\n").unwrap();
+        assert_eq!(commits_behind_upstream_for_path(&path), None);
+    }
+
+    #[test]
+    fn upstream_lag_detects_committed_upstream_change() {
+        // Build a tiny "remote" repo, clone it, commit a config file
+        // change on the remote, fetch on the clone. The clone's HEAD
+        // is now behind `origin/main` for that path, which is exactly
+        // what `commits_behind_upstream_for_path` is meant to catch.
+        let scratch = tempfile::tempdir_in("/tmp").expect("tempdir");
+        let remote = scratch.path().join("remote.git");
+        let work = scratch.path().join("work");
+        let edit = scratch.path().join("edit");
+
+        // Bare upstream pinned to `main` so the test isn't sensitive
+        // to the host's `init.defaultBranch` (older git defaults to
+        // `master`, newer defaults vary). The bare repo has no HEAD
+        // commit yet, so we can't `clone -b main` it — first do a
+        // throwaway clone, push the initial commit, then clone for
+        // real for the operator-side workdir.
+        run_or_skip(
+            scratch.path(),
+            &["init", "--bare", "-b", "main", "remote.git"],
+        );
+        run_or_skip(scratch.path(), &["clone", remote.to_str().unwrap(), "edit"]);
+        run_git_str(&edit, &["config", "user.email", "test@example.invalid"]);
+        run_git_str(&edit, &["config", "user.name", "Test"]);
+        run_git_str(&edit, &["checkout", "-b", "main"]);
+        std::fs::write(edit.join("yoink.yaml"), "v: 1\n").unwrap();
+        run_git_str(&edit, &["add", "yoink.yaml"]);
+        run_git_str(&edit, &["commit", "-m", "init"]);
+        run_git_str(&edit, &["push", "-u", "origin", "main"]);
+
+        // Operator's clone — at the initial commit only.
+        run_or_skip(scratch.path(), &["clone", remote.to_str().unwrap(), "work"]);
+        let local_path = work.join("yoink.yaml");
+
+        // Upstream lands a change to the config file.
+        std::fs::write(edit.join("yoink.yaml"), "v: 2\n").unwrap();
+        run_git_str(&edit, &["commit", "-am", "bump"]);
+        run_git_str(&edit, &["push"]);
+
+        // Operator hasn't pulled but has run `git fetch`.
+        run_git_str(&work, &["fetch"]);
+
+        let lag = commits_behind_upstream_for_path(&local_path).expect("expected upstream lag");
+        assert_eq!(lag.commits_behind, 1);
+        assert!(
+            lag.upstream.contains("main"),
+            "upstream label should reference main: {:?}",
+            lag.upstream
+        );
+    }
+
+    /// `git` invocation helper for tests. Panics on failure so a
+    /// broken precondition surfaces immediately rather than as a
+    /// silent skip.
+    fn run_git_str(dir: &Path, args: &[&str]) {
+        let out = Command::new("git")
+            .args(args)
+            .current_dir(dir)
+            .output()
+            .expect("git spawn");
+        assert!(
+            out.status.success(),
+            "git {args:?} failed: {}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+    }
+
+    /// Like `run_git_str` but also tolerates `git` not being
+    /// installed (skip the whole test) — only used for the *first*
+    /// command since later ones are guaranteed to find git too.
+    fn run_or_skip(dir: &Path, args: &[&str]) {
+        let out = Command::new("git").args(args).current_dir(dir).output();
+        match out {
+            Ok(o) if o.status.success() => {}
+            Ok(o) => panic!(
+                "git {args:?} failed: {}",
+                String::from_utf8_lossy(&o.stderr)
+            ),
+            Err(e) => panic!("git not installed (skipping): {e}"),
+        }
     }
 }

--- a/yoink/src/main.rs
+++ b/yoink/src/main.rs
@@ -1304,6 +1304,25 @@ async fn run(cli: Cli) -> Result<()> {
     }
     .with_context(|| format!("loading {}", cli.config.display()))?;
 
+    // Warn (best-effort) if the config file's branch has upstream
+    // commits touching the file that aren't pulled yet — operators
+    // get bitten by deploying from a stale local copy when a
+    // teammate landed a fragment edit on `origin/main` they haven't
+    // pulled. Skipped for non-deploying commands (validate /
+    // proxy-render / completions / dump) so the noise doesn't appear
+    // when the operator is just inspecting state.
+    if !matches!(
+        cli.command,
+        Command::Validate { .. }
+            | Command::Completions { .. }
+            | Command::ProxyRender
+            | Command::ProxyDockerfile
+            | Command::Dump { .. }
+            | Command::Doctor { .. }
+    ) {
+        warn_if_config_behind_upstream(&cli.config);
+    }
+
     resolve_sealed_host_addresses(&mut config).await?;
 
     match cli.command {
@@ -2435,6 +2454,25 @@ async fn load_secrets_bundle(config: &Config) -> Result<Option<SecretsBundle>> {
 /// to run before the bundle exists; making the resolver hard-fail
 /// here would block them. Deploy commands that actually consume
 /// `host.address` surface a clear error when it's empty.
+/// Best-effort: print one yellow line to stderr when the config file
+/// has commits on its branch's upstream that the operator hasn't
+/// pulled. Silent on non-git contexts, missing upstream, detached
+/// HEAD, etc. Does not fetch — the warning reflects the most recent
+/// `git fetch` the operator (or their IDE) ran.
+fn warn_if_config_behind_upstream(path: &std::path::Path) {
+    let Some(lag) = yoink::git::commits_behind_upstream_for_path(path) else {
+        return;
+    };
+    let plural = if lag.commits_behind == 1 { "" } else { "s" };
+    eprintln!(
+        "\x1b[33mwarning:\x1b[0m {} is {} commit{plural} behind \
+         {} — pull before deploying to avoid shipping a stale config",
+        path.display(),
+        lag.commits_behind,
+        lag.upstream,
+    );
+}
+
 async fn resolve_sealed_host_addresses(config: &mut Config) -> Result<()> {
     if !config.any_host_address_sealed() {
         return Ok(());

--- a/yoink/src/main.rs
+++ b/yoink/src/main.rs
@@ -81,6 +81,16 @@ struct Cli {
     #[arg(long, value_enum, default_value_t = ColorChoice::Auto, global = true)]
     color: ColorChoice,
 
+    /// Refuse to run if the config file has commits on its branch's
+    /// upstream tracking ref that aren't in HEAD yet. Same check as
+    /// the always-on warning, but turns it into a hard error — for
+    /// CI deploys and any other context where shipping a stale
+    /// config silently would be worse than failing the run.
+    /// Equivalent to setting `YOINK_REQUIRE_LATEST_CONFIG=1` (any
+    /// truthy value: `1`, `true`, `yes`, `on`).
+    #[arg(long, global = true)]
+    require_latest_config: bool,
+
     #[command(subcommand)]
     command: Command,
 }
@@ -1320,7 +1330,10 @@ async fn run(cli: Cli) -> Result<()> {
             | Command::Dump { .. }
             | Command::Doctor { .. }
     ) {
-        warn_if_config_behind_upstream(&cli.config);
+        check_config_freshness(
+            &cli.config,
+            cli.require_latest_config || env_flag_truthy("YOINK_REQUIRE_LATEST_CONFIG"),
+        )?;
     }
 
     resolve_sealed_host_addresses(&mut config).await?;
@@ -2454,16 +2467,36 @@ async fn load_secrets_bundle(config: &Config) -> Result<Option<SecretsBundle>> {
 /// to run before the bundle exists; making the resolver hard-fail
 /// here would block them. Deploy commands that actually consume
 /// `host.address` surface a clear error when it's empty.
-/// Best-effort: print one yellow line to stderr when the config file
-/// has commits on its branch's upstream that the operator hasn't
-/// pulled. Silent on non-git contexts, missing upstream, detached
-/// HEAD, etc. Does not fetch — the warning reflects the most recent
-/// `git fetch` the operator (or their IDE) ran.
-fn warn_if_config_behind_upstream(path: &std::path::Path) {
+/// True when `name` is set in the env to anything operators
+/// reasonably write for "on" (`1`, `true`, `yes`, `on`, case-
+/// insensitive). Any other value (including unset) is false.
+fn env_flag_truthy(name: &str) -> bool {
+    std::env::var(name)
+        .ok()
+        .map(|v| v.trim().to_ascii_lowercase())
+        .is_some_and(|v| matches!(v.as_str(), "1" | "true" | "yes" | "on"))
+}
+
+/// Best-effort: warn (or hard-fail under `--require-latest-config`)
+/// when the config file has commits on its branch's upstream that
+/// the operator hasn't pulled. Silent on non-git contexts, missing
+/// upstream, detached HEAD, etc. Does not fetch — reflects the
+/// operator's most recent `git fetch`.
+fn check_config_freshness(path: &std::path::Path, require_latest: bool) -> Result<()> {
     let Some(lag) = yoink::git::commits_behind_upstream_for_path(path) else {
-        return;
+        return Ok(());
     };
     let plural = if lag.commits_behind == 1 { "" } else { "s" };
+    if require_latest {
+        anyhow::bail!(
+            "{} is {} commit{plural} behind {} — pull before deploying \
+             (or unset --require-latest-config / YOINK_REQUIRE_LATEST_CONFIG \
+             to bypass)",
+            path.display(),
+            lag.commits_behind,
+            lag.upstream,
+        );
+    }
     eprintln!(
         "\x1b[33mwarning:\x1b[0m {} is {} commit{plural} behind \
          {} — pull before deploying to avoid shipping a stale config",
@@ -2471,6 +2504,7 @@ fn warn_if_config_behind_upstream(path: &std::path::Path) {
         lag.commits_behind,
         lag.upstream,
     );
+    Ok(())
 }
 
 async fn resolve_sealed_host_addresses(config: &mut Config) -> Result<()> {


### PR DESCRIPTION
## Summary

If the config file at \`--config\` lives in a git repo and the branch's upstream tracking ref has commits touching that file that aren't in HEAD yet, yoink now prints a one-line yellow warning to stderr before any deploy work begins:

\`\`\`
warning: ~/bt/deploy-prod/yoink.yaml is 2 commits behind origin/main —
pull before deploying to avoid shipping a stale config
\`\`\`

Catches the "deployed from a stale local copy" footgun where a teammate landed a fragment edit on \`origin/main\` you haven't pulled.

### Design choices

- **Best-effort throughout.** Silent on non-git paths, missing upstream, detached HEAD, missing \`git\`, etc. — never blocks a deploy.
- **No \`git fetch\`.** The warning reflects whatever the operator (or their IDE / cron) most recently fetched. Doing our own fetch would be slow, may prompt for creds, may reveal the operator's network presence, and conflicts with sandboxed CI environments.
- **Path-scoped.** Only counts commits whose diff actually touches the config file; a branch behind on unrelated commits doesn't trigger.
- **Skipped for inspect-only commands** (\`validate\`, \`completions\`, \`proxy-render\`, \`proxy-dockerfile\`, \`dump\`, \`doctor\`) so the noise doesn't appear when the operator is just looking.

### Implementation

New public helper \`yoink::git::commits_behind_upstream_for_path\` returns \`Option<UpstreamLag { upstream, commits_behind }>\`. Called from \`main\` right after \`Config::load_from_path\`.

## Test plan

- [x] \`cargo clippy -p yoink --all-targets -- -D warnings\`
- [x] \`cargo test -p yoink --lib\` (501 pass, includes a new end-to-end test that builds a bare upstream + two clones, lands a commit on upstream, fetches without pulling, and confirms the helper detects the lag).
- [x] Live smoke: built the binary and exercised three scenarios — fresh-cloned repo (no warning), behind-upstream repo (yellow warning), \`validate\` against the same behind-upstream repo (silent, as intended).