### PR TITLE
feat(tui): cycle hl --level filter from the logs pane

### DIFF
--- a/yoink/src/tui/app.rs
+++ b/yoink/src/tui/app.rs
@@ -2420,6 +2420,15 @@ impl App {
                 KeyCode::Char('c') => self.logs.clear(),
                 KeyCode::Char('/') => self.logs.begin_filter_input(),
                 KeyCode::Char('w') => self.logs.toggle_wrap(),
+                // Cycle the level filter and respawn each container's
+                // `hl` child against the new floor. `cycle_level`
+                // clears the buffer, so what re-streams in is what
+                // matches the new level.
+                KeyCode::Char('L') => {
+                    self.logs.cycle_level();
+                    self.stop_log_streams();
+                    self.start_service_log_streams().await;
+                }
                 KeyCode::Up => self.logs.scroll_up(1),
                 KeyCode::Down => self.logs.scroll_down(1),
                 KeyCode::PageUp => self.logs.scroll_up(10),
@@ -3627,8 +3636,9 @@ impl App {
             }
         };
         let tx = self.log_tx.clone();
+        let level = self.logs.level();
         let task = if self.hl_available {
-            tokio::spawn(forward_through_hl(container, docker_rx, tx))
+            tokio::spawn(forward_through_hl(container, docker_rx, tx, level))
         } else {
             tokio::spawn(forward_raw(docker_rx, tx))
         };
@@ -4346,10 +4356,14 @@ async fn forward_raw(
 /// docker log message to its stdin, read the formatted (ANSI-colored)
 /// lines from its stdout, convert escapes to ratatui spans, and forward
 /// to the render channel. Owns the child via `kill_on_drop`.
+///
+/// `level` is the floor `hl --level <X>` filters at; `LogLevel::All`
+/// passes no flag (hl shows everything by default).
 async fn forward_through_hl(
     container: String,
     mut docker_rx: mpsc::UnboundedReceiver<LogLine>,
     out: UnboundedSender<RenderedLine>,
+    level: super::logs::LogLevel,
 ) {
     use ansi_to_tui::IntoText;
     use ratatui::style::{Color, Style};
@@ -4372,12 +4386,16 @@ async fn forward_through_hl(
     } else {
         "--color=always"
     };
-    let mut child = match Command::new("hl")
-        .arg(hl_color)
+    let mut cmd = Command::new("hl");
+    cmd.arg(hl_color)
         .arg("--paging=never")
         .arg("--follow")
         .arg("--sync-interval-ms=100")
-        .arg("--input-info=none")
+        .arg("--input-info=none");
+    if let Some(arg) = level.hl_arg() {
+        cmd.arg(format!("--level={arg}"));
+    }
+    let mut child = match cmd
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())

--- a/yoink/src/tui/logs.rs
+++ b/yoink/src/tui/logs.rs
@@ -18,6 +18,66 @@ use super::ui::{FilterState, bold, pane_layout};
 
 const LINE_LIMIT: usize = 5_000;
 
+/// Log-level filter passed to `hl --level <LEVEL>` (level >= floor).
+/// Mirrors hl's accepted values exactly so we don't need to translate.
+/// `All` is the no-op default (no `--level` flag passed).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum LogLevel {
+    #[default]
+    All,
+    Trace,
+    Debug,
+    Info,
+    Warning,
+    Error,
+}
+
+impl LogLevel {
+    /// Cycle in increasing-strictness order:
+    /// `All → Trace → Debug → Info → Warning → Error → All`. Pressing
+    /// the level key repeatedly walks through the same set the user
+    /// would write on the CLI, ending back at `All` so the binding is
+    /// reversible without a separate "decrease" key.
+    #[must_use]
+    pub fn next(self) -> Self {
+        match self {
+            Self::All => Self::Trace,
+            Self::Trace => Self::Debug,
+            Self::Debug => Self::Info,
+            Self::Info => Self::Warning,
+            Self::Warning => Self::Error,
+            Self::Error => Self::All,
+        }
+    }
+
+    /// Value to pass to `hl --level=<X>`. `None` means "don't pass
+    /// the flag" — hl's default shows everything.
+    #[must_use]
+    pub fn hl_arg(self) -> Option<&'static str> {
+        match self {
+            Self::All => None,
+            Self::Trace => Some("trace"),
+            Self::Debug => Some("debug"),
+            Self::Info => Some("info"),
+            Self::Warning => Some("warning"),
+            Self::Error => Some("error"),
+        }
+    }
+
+    /// Compact label for the header: `all|trace|debug|info|warn|error`.
+    #[must_use]
+    pub const fn label(self) -> &'static str {
+        match self {
+            Self::All => "all",
+            Self::Trace => "trace",
+            Self::Debug => "debug",
+            Self::Info => "info",
+            Self::Warning => "warn",
+            Self::Error => "error",
+        }
+    }
+}
+
 #[derive(Default)]
 pub struct LogsState {
     lines: Vec<RenderedLine>,
@@ -32,6 +92,10 @@ pub struct LogsState {
     filter: FilterState,
     /// Toggled by 'w'. Wraps long lines instead of truncating.
     wrap: bool,
+    /// Cycled by 'L'. Drives the `--level=<X>` flag yoink passes to
+    /// the per-container `hl` children. Stored on the state so the
+    /// label is rendered alongside the filter status.
+    level: LogLevel,
 }
 
 /// One line in the buffer. `plain` is what the filter matches against;
@@ -130,6 +194,22 @@ impl LogsState {
         self.wrap = !self.wrap;
     }
 
+    /// Step the level filter forward and clear the buffer — the
+    /// existing lines were rendered by the previous `hl` instances
+    /// without the new filter, so keeping them around would be
+    /// misleading. Caller is responsible for restarting the streams
+    /// so each container's `hl` child gets re-spawned with the new
+    /// `--level` arg.
+    pub fn cycle_level(&mut self) {
+        self.level = self.level.next();
+        self.clear();
+    }
+
+    #[must_use]
+    pub fn level(&self) -> LogLevel {
+        self.level
+    }
+
     // ─── filter input ──────────────────────────────────────────────────
 
     pub fn input_mode(&self) -> bool {
@@ -195,11 +275,12 @@ impl LogsState {
             .collect::<Vec<_>>()
             .join(",");
         let header_text = format!(
-            "yoink logs · services: {services} · {} lines{} · {}",
+            "yoink logs · services: {services} · {} lines · level: {}{} · {}",
             total,
+            self.level.label(),
             self.filter
                 .current()
-                .map(|f| format!(" (filter: {f})"))
+                .map(|f| format!(" · filter: {f}"))
                 .unwrap_or_default(),
             if self.auto_follow { "follow" } else { "paused" },
         );
@@ -241,7 +322,8 @@ impl LogsState {
 
         let wrap_hint = if self.wrap { "w wrap*" } else { "w wrap" };
         let default_help = format!(
-            "q quit · k clear · / filter · ↑↓ scroll · g top · G bottom · {wrap_hint} · d dashboard · h hosts",
+            "q quit · k clear · / filter · L level ({}) · ↑↓ scroll · g top · G bottom · {wrap_hint} · d dashboard · h hosts",
+            self.level.label(),
         );
         frame.render_widget(
             super::ui::filter_footer(&self.filter, &default_help),
@@ -353,6 +435,43 @@ mod tests {
         s.filter_cancel();
         assert!(!s.input_mode());
         assert_eq!(s.current_filter(), None);
+    }
+
+    #[test]
+    fn level_cycle_walks_full_set_and_loops() {
+        let mut s = LogsState::new();
+        assert_eq!(s.level(), LogLevel::All);
+        let order = [
+            LogLevel::Trace,
+            LogLevel::Debug,
+            LogLevel::Info,
+            LogLevel::Warning,
+            LogLevel::Error,
+            LogLevel::All,
+        ];
+        for expected in order {
+            s.cycle_level();
+            assert_eq!(s.level(), expected);
+        }
+    }
+
+    #[test]
+    fn level_hl_arg_emits_none_for_all_some_for_others() {
+        assert_eq!(LogLevel::All.hl_arg(), None);
+        assert_eq!(LogLevel::Trace.hl_arg(), Some("trace"));
+        assert_eq!(LogLevel::Debug.hl_arg(), Some("debug"));
+        assert_eq!(LogLevel::Info.hl_arg(), Some("info"));
+        assert_eq!(LogLevel::Warning.hl_arg(), Some("warning"));
+        assert_eq!(LogLevel::Error.hl_arg(), Some("error"));
+    }
+
+    #[test]
+    fn level_cycle_clears_buffer() {
+        let mut s = LogsState::new();
+        s.push_line(&line("c", LogStream::Stdout, "hi"));
+        assert_eq!(s.lines.len(), 1);
+        s.cycle_level();
+        assert!(s.lines.is_empty(), "cycling level must clear stale lines");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Press \`L\` from the Logs pane to cycle the level floor through \`all → trace → debug → info → warning → error → all\`. The active level is passed to each container's \`hl\` child as \`--level=<X>\` (hl filters at \"level >= floor\"); \`all\` skips the flag.

\`\`\`
yoink logs · services: api,web · 142 lines · level: warn · follow
…
q quit · k clear · / filter · L level (warn) · ↑↓ scroll · g top · G bottom · w wrap · d dashboard · h hosts
\`\`\`

### Behaviour

- Cycling clears the buffer and restarts every per-container \`hl\` with the new flag — keeping pre-cycle lines would be misleading because they were rendered without the filter.
- Header + footer surface the active level so the operator doesn't lose track of why some lines went missing.
- No \`hl\` available → the keybinding is still wired but the raw forwarder ignores it (the pane already says \"raw\" when hl is absent).

### Implementation

- New \`LogLevel\` enum in \`tui/logs.rs\` mirrors hl's accepted values (\`error|warning|info|debug|trace\`) plus an \`All\` no-op default. \`hl_arg()\` returns the literal hl expects; \`label()\` is the compact header form.
- \`LogsState::cycle_level()\` advances and clears.
- \`forward_through_hl\` takes a new \`level: LogLevel\` arg, plumbed from \`LogsState::level()\` at spawn time.

## Test plan

- [x] \`cargo clippy -p yoink --all-targets -- -D warnings\`
- [x] \`cargo test -p yoink --lib\` (504 pass — three new tests cover cycle order, hl_arg mapping, and clear-on-cycle)
- [ ] Live: open the TUI logs pane, press \`L\` repeatedly, verify the header reflects the level and noisier services drop out at \`info\`/\`warn\`.