### PR TITLE
docs(how-to): auto-heal unhealthy containers

### DIFF
--- a/docs/content/docs/how-to/auto-heal.md
+++ b/docs/content/docs/how-to/auto-heal.md
@@ -1,0 +1,91 @@
+---
+title: Auto-heal unhealthy containers
+description: Restart containers Docker marks unhealthy with a small drop-in sidecar — no yoink subcommand, no template.
+---
+
+Docker's `HEALTHCHECK` directive is observability-only. `docker ps` shows `(unhealthy)`; nothing acts on it. yoink's default `restart: unless-stopped` policy reincarnates a container that *exits*, but a process that deadlocks while staying alive sits unhealthy until an operator notices. The fix is a label-driven sidecar that watches the docker socket and restarts unhealthy containers — no yoink-managed code path, just a service fragment you drop in.
+
+## Drop-in service fragment [step]
+
+Save as `services/autoheal.yaml`:
+
+```yaml
+services:
+  - name: autoheal
+    image: willfarrell/autoheal
+    tag: 1.2.0
+    description: Restart containers docker marks unhealthy.
+    env:
+      AUTOHEAL_CONTAINER_LABEL: autoheal
+      AUTOHEAL_INTERVAL: "5"
+      AUTOHEAL_DEFAULT_STOP_TIMEOUT: "10"
+    run:
+      restart: unless-stopped
+      binds:
+        # Read-only socket bind. The `:ro` is cosmetic — anyone who
+        # reaches /var/run/docker.sock can issue `restart` regardless
+        # — but it documents intent.
+        - /var/run/docker.sock:/var/run/docker.sock:ro
+      options:
+        # autoheal needs root to read the docker socket; yoink's
+        # default `nobody` user cannot. cap_drop=ALL stays — talking
+        # to dockerd is privileged via socket access, not raw caps.
+        user: "0:0"
+        read_only: true
+        tmpfs:
+          /tmp: ""
+```
+
+`hosts:` is omitted, so the sidecar lands on every yoink-managed host.
+
+## Opt services in [step]
+
+Auto-heal only acts on containers labelled `autoheal: "true"`. Add the label to any service you want healed:
+
+```yaml
+services:
+  - name: api
+    # ...
+    labels:
+      autoheal: "true"
+```
+
+Services without the label are ignored, including `autoheal` itself.
+
+## Make targets actually heal-able [step]
+
+Auto-heal reads `State.Health.Status`. That field is `null` unless the container declares a `HEALTHCHECK`. Two sources today:
+
+**A. Image-side (Dockerfile).** Bake one in:
+
+```dockerfile
+HEALTHCHECK --interval=10s --timeout=2s \
+  CMD wget -qO- http://localhost:8080/health || exit 1
+```
+
+**B. The bundled `yoink-proxy`** ships a `HEALTHCHECK` already, so the proxy is healed automatically once the sidecar is deployed.
+
+For services whose images don't declare one, add it to the Dockerfile. yoink doesn't yet expose a per-service config knob to inject a `HEALTHCHECK` from the fragment; without one of A or B autoheal sees no signal and the container is silently ignored — the correct fail-quiet behaviour for an indeterminate state.
+
+## Verify [step]
+
+Deploy and confirm the sidecar lands:
+
+```sh
+yoink up
+yoink status        # autoheal running on each host
+```
+
+Manufacture an unhealthy state on a labelled container — freezing PID 1 is the cleanest because the process stays up but stops responding to its `HEALTHCHECK`:
+
+```sh
+ssh $HOST -- docker exec api-XXXX kill -SIGSTOP 1
+```
+
+The container's status flips to `(unhealthy)` after `interval × retries`; autoheal restarts it within `AUTOHEAL_INTERVAL` seconds. `yoink history api` shows the restart.
+
+## See also
+
+- [Defense in depth](./defense-in-depth.md) — yoink's hardened defaults the fragment leans on (cap-drop, read-only rootfs, tmpfs).
+- [Templates](./using-templates.md) — for accessories yoink *does* bundle (postgres, redis, restic, …).
+- [Audit log](./audit-log.mdx) — restart events surface here once the heal fires.

--- a/docs/content/docs/how-to/meta.json
+++ b/docs/content/docs/how-to/meta.json
@@ -27,6 +27,7 @@
     "multi-host-redis-storage",
     "---Operations---",
     "audit-log",
+    "auto-heal",
     "notify-on-deploy",
     "---Developer Tooling---",
     "vscode"


### PR DESCRIPTION
## Summary

New how-to page documenting how operators can drop in a [\`willfarrell/autoheal\`](https://github.com/willfarrell/docker-autoheal) sidecar to close the gap that docker's \`HEALTHCHECK\` is observability-only — yoink's \`restart: unless-stopped\` catches *crashes* but not deadlocks.

Pure documentation: no yoink code change, no template registry change. The fragment relies entirely on yoink's existing schema (per-host services via omitted \`hosts:\`, \`binds:\` for the docker socket, \`tmpfs\` + \`read_only\` overrides for the hardened defaults).

Page sections:

1. **Drop-in service fragment** — copy-paste \`services/autoheal.yaml\`.
2. **Opt services in** — \`labels: { autoheal: "true" }\`.
3. **Make targets actually heal-able** — explains the \`State.Health.Status\` prerequisite, points to the two sources today (image Dockerfile, bundled yoink-proxy). Flags the absence of a per-service \`docker_healthcheck:\` field as a separate follow-up.
4. **Verify** — \`SIGSTOP\` on PID 1 as a clean way to manufacture unhealthy state without exiting the process.

Sidebar entry under \"Operations\" between \`audit-log\` and \`notify-on-deploy\`.

## Test plan

- [x] \`pnpm build\` clean (162 pages prerendered, no errors)
- [x] Banned-phrase grep clean
- [x] Cross-links resolve (\`defense-in-depth.md\`, \`using-templates.md\`, \`audit-log.mdx\`)
- [ ] Live: drop the fragment into a test config, deploy, freeze a labelled container, confirm autoheal restarts it.

## Out of scope

- Per-service \`docker_healthcheck:\` config field (the field exists on \`RunSpec\` but isn't populated for user services). Worth a separate code PR.
- yoink-side reconciler / \`yoink heal\` subcommand. Discussed and rejected — the third-party sidecar is sufficient and aligned with yoink's no-daemon stance.