### PR TITLE
docs+dogfood: auto-heal recipe (live-tested on yoink.is)

### DIFF
--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -15,8 +15,19 @@ FROM nginx:alpine
 # otherwise Docker's merge-copy leaves index.html from the base image in
 # place (our SPA build has no root index.html — it uses _shell.html).
 RUN rm -rf /usr/share/nginx/html/*
+# curl: needed for the HEALTHCHECK below. Recent nginx:alpine builds
+# don't ship busybox wget reliably (the wget applet is gated on the
+# busybox config), and the equivalent /dev/tcp shell trick isn't in
+# busybox sh either. ~5 MiB to add curl, tiny next to the rest.
+RUN apk add --no-cache curl
 COPY --from=builder /src/.output/public /usr/share/nginx/html
 # SPA routing + Cloudflare cache headers.
 COPY nginx.conf /etc/nginx/conf.d/default.conf
 COPY nginx-cache.conf /etc/nginx/conf.d/cache.conf
 EXPOSE 80
+# Populates State.Health.Status so the autoheal sidecar can act on
+# this container. -fsS = fail on non-2xx, silent, but show errors.
+# The 30s start_period gives nginx time to boot before the first
+# probe lands.
+HEALTHCHECK --interval=10s --timeout=2s --start-period=30s --retries=3 \
+  CMD curl -fsS -o /dev/null http://localhost/ || exit 1

--- a/docs/content/docs/how-to/auto-heal.md
+++ b/docs/content/docs/how-to/auto-heal.md
@@ -1,0 +1,91 @@
+---
+title: Auto-heal unhealthy containers
+description: Restart containers Docker marks unhealthy with a small drop-in sidecar — no yoink subcommand, no template.
+---
+
+Docker's `HEALTHCHECK` directive is observability-only. `docker ps` shows `(unhealthy)`; nothing acts on it. yoink's default `restart: unless-stopped` policy reincarnates a container that *exits*, but a process that deadlocks while staying alive sits unhealthy until an operator notices. The fix is a label-driven sidecar that watches the docker socket and restarts unhealthy containers — no yoink-managed code path, just a service fragment you drop in.
+
+## Drop-in service fragment [step]
+
+Save as `services/autoheal.yaml`:
+
+```yaml
+services:
+  - name: autoheal
+    image: willfarrell/autoheal
+    tag: 1.2.0
+    description: Restart containers docker marks unhealthy.
+    env:
+      AUTOHEAL_CONTAINER_LABEL: autoheal
+      AUTOHEAL_INTERVAL: "5"
+      AUTOHEAL_DEFAULT_STOP_TIMEOUT: "10"
+    run:
+      restart: unless-stopped
+      binds:
+        # Read-only socket bind. The `:ro` is cosmetic — anyone who
+        # reaches /var/run/docker.sock can issue `restart` regardless
+        # — but it documents intent.
+        - /var/run/docker.sock:/var/run/docker.sock:ro
+      options:
+        # autoheal needs root to read the docker socket; yoink's
+        # default `nobody` user cannot. cap_drop=ALL stays — talking
+        # to dockerd is privileged via socket access, not raw caps.
+        user: "0:0"
+        read_only: true
+        tmpfs:
+          /tmp: ""
+```
+
+`hosts:` is omitted, so the sidecar lands on every yoink-managed host.
+
+## Opt services in [step]
+
+Auto-heal only acts on containers labelled `autoheal: "true"`. Add the label to any service you want healed:
+
+```yaml
+services:
+  - name: api
+    # ...
+    labels:
+      autoheal: "true"
+```
+
+Services without the label are ignored, including `autoheal` itself.
+
+## Make targets actually heal-able [step]
+
+Auto-heal reads `State.Health.Status`. That field is `null` unless the container declares a `HEALTHCHECK`. Two sources today:
+
+**A. Image-side (Dockerfile).** Bake one in:
+
+```dockerfile
+HEALTHCHECK --interval=10s --timeout=2s \
+  CMD wget -qO- http://localhost:8080/health || exit 1
+```
+
+**B. The bundled `yoink-proxy`** ships a `HEALTHCHECK` already, so the proxy is healed automatically once the sidecar is deployed.
+
+For services whose images don't declare one, add it to the Dockerfile. yoink doesn't yet expose a per-service config knob to inject a `HEALTHCHECK` from the fragment; without one of A or B autoheal sees no signal and the container is silently ignored — the correct fail-quiet behaviour for an indeterminate state.
+
+## Verify [step]
+
+Deploy and confirm the sidecar lands:
+
+```sh
+yoink up
+yoink status        # autoheal running on each host
+```
+
+Manufacture an unhealthy state on a labelled container — freezing PID 1 is the cleanest because the process stays up but stops responding to its `HEALTHCHECK`:
+
+```sh
+ssh $HOST -- docker exec api-XXXX kill -SIGSTOP 1
+```
+
+The container's status flips to `(unhealthy)` after `interval × retries`; autoheal restarts it within `AUTOHEAL_INTERVAL` seconds. `yoink history api` shows the restart.
+
+## See also
+
+- [Defense in depth](./defense-in-depth.md) — yoink's hardened defaults the fragment leans on (cap-drop, read-only rootfs, tmpfs).
+- [Templates](./using-templates.md) — for accessories yoink *does* bundle (postgres, redis, restic, …).
+- [Audit log](./audit-log.mdx) — restart events surface here once the heal fires.

--- a/docs/content/docs/how-to/auto-heal.md
+++ b/docs/content/docs/how-to/auto-heal.md
@@ -18,15 +18,20 @@ services:
     env:
       AUTOHEAL_CONTAINER_LABEL: autoheal
       AUTOHEAL_INTERVAL: "5"
+      # Wait this many checks before acting after a fresh start —
+      # avoids killing a container whose first probe is still in
+      # the image's `--start-period`. Match this to the largest
+      # `--start-period` across your healthchecked images.
+      AUTOHEAL_START_PERIOD: "30"
       AUTOHEAL_DEFAULT_STOP_TIMEOUT: "10"
     run:
-      restart: unless-stopped
       binds:
         # Read-only socket bind. The `:ro` is cosmetic — anyone who
         # reaches /var/run/docker.sock can issue `restart` regardless
         # — but it documents intent.
         - /var/run/docker.sock:/var/run/docker.sock:ro
       options:
+        restart: unless-stopped
         # autoheal needs root to read the docker socket; yoink's
         # default `nobody` user cannot. cap_drop=ALL stays — talking
         # to dockerd is privileged via socket access, not raw caps.
@@ -59,9 +64,14 @@ Auto-heal reads `State.Health.Status`. That field is `null` unless the container
 **A. Image-side (Dockerfile).** Bake one in:
 
 ```dockerfile
-HEALTHCHECK --interval=10s --timeout=2s \
-  CMD wget -qO- http://localhost:8080/health || exit 1
+# `apk add --no-cache curl` first if your base image (e.g. nginx:alpine)
+# doesn't ship a HTTP client — busybox-wget is gated on the busybox
+# config and isn't reliably present.
+HEALTHCHECK --interval=10s --timeout=2s --start-period=30s --retries=3 \
+  CMD curl -fsS -o /dev/null http://localhost:8080/health || exit 1
 ```
+
+The `--start-period=30s` covers cold-start latency before the first probe counts against `--retries`. Match the autoheal sidecar's `AUTOHEAL_START_PERIOD: "30"` env so the sidecar also waits before acting.
 
 **B. The bundled `yoink-proxy`** ships a `HEALTHCHECK` already, so the proxy is healed automatically once the sidecar is deployed.
 

--- a/docs/content/docs/how-to/meta.json
+++ b/docs/content/docs/how-to/meta.json
@@ -27,6 +27,7 @@
     "multi-host-redis-storage",
     "---Operations---",
     "audit-log",
+    "auto-heal",
     "notify-on-deploy",
     "---Developer Tooling---",
     "vscode"

--- a/docs/yoink.yaml
+++ b/docs/yoink.yaml
@@ -43,6 +43,13 @@ services:
       context: .                      # docs/ — same dir as this yaml
     domain: yoink.is
     networks: [docs]
+    # Picked up by the autoheal sidecar below — the Dockerfile ships a
+    # HEALTHCHECK that hits / via wget, so a deadlocked nginx (or one
+    # whose tmpfs filled up and started 500ing) gets restarted without
+    # operator intervention. The yoink-side `healthcheck_path:` only
+    # gates *deploys*; this label opts into runtime auto-heal too.
+    labels:
+      autoheal: "true"
     run:
       port: 80
       replicas: 4                     # cax11 has 2 cores; 4 × 0.5 = full utilization
@@ -63,3 +70,33 @@ services:
         # Bind low port (80) — re-add the one cap, drop the rest.
         cap_add: [NET_BIND_SERVICE]
         network_aliases: [docs]
+
+  # Restart containers docker marks unhealthy. Filtered by the
+  # `autoheal: "true"` label; operator opts services in. yoink-proxy
+  # (bundled HEALTHCHECK) and the docs service (Dockerfile HEALTHCHECK)
+  # are the two heal-able containers here today. See the how-to:
+  # docs/content/docs/how-to/auto-heal.md.
+  - name: autoheal
+    image: willfarrell/autoheal
+    tag: "1.2.0"
+    description: Restart containers docker marks unhealthy.
+    env:
+      AUTOHEAL_CONTAINER_LABEL: autoheal
+      AUTOHEAL_INTERVAL: "5"
+      # Wait this many checks before acting after a fresh start —
+      # avoids killing a container whose first probe is still in
+      # the image's `--start-period`.
+      AUTOHEAL_START_PERIOD: "30"
+      AUTOHEAL_DEFAULT_STOP_TIMEOUT: "10"
+    run:
+      binds:
+        - /var/run/docker.sock:/var/run/docker.sock:ro
+      options:
+        restart: unless-stopped
+        # autoheal needs root to read the docker socket; cap_drop=ALL
+        # stays — talking to dockerd is a privileged operation by virtue
+        # of socket access, not raw caps.
+        user: "0:0"
+        read_only: true
+        tmpfs:
+          /tmp: ""


### PR DESCRIPTION
Supersedes #104 — same how-to page but with two refinements that surfaced when I deployed it to yoink.is, plus the dogfood config so yoink.is is now self-healing.

## Summary

### Doc commit (\`047a514\`, originally from #104)

New \`docs/content/docs/how-to/auto-heal.md\` page documenting the willfarrell/autoheal sidecar drop-in. Closes the gap that docker's \`HEALTHCHECK\` is observability-only and yoink's \`restart: unless-stopped\` only catches process-exit, not deadlocks.

### Dogfood commit (\`a382b71\`)

Wired the recipe into yoink.is itself, then updated the doc with two gotchas the live test surfaced:

1. **\`nginx:alpine\` doesn't reliably ship busybox-wget.** The wget applet is gated on the busybox build config, and recent rolls have it disabled. The first deploy used \`wget -q -O- http://localhost/\` and every replica went unhealthy immediately — autoheal ate them in a restart loop. Switching to \`curl -fsS\` after \`apk add --no-cache curl\` works first try.

2. **\`start_period\` matters.** Without \`--start-period=30s\` on the HEALTHCHECK and matching \`AUTOHEAL_START_PERIOD: "30"\` on the sidecar, autoheal acts inside the first 30s before nginx has settled. The doc now calls out the symmetry.

Live state on yoink.is after the deploy:
- 4× docs replicas → \`running + healthy\`
- yoink-proxy → \`running + healthy\` (yoink's synthesised HEALTHCHECK; was already heal-able)
- autoheal → \`running + healthy\`, no false positives on stable containers, restart-on-unhealthy verified during the rollout

## Test plan

- [x] \`pnpm build\` clean (162 pages prerendered, no errors)
- [x] Banned-phrase grep clean
- [x] Live deploy to yoink.is — site returns 200, autoheal logs clean, no replicas in restart loop
- [x] During the deploy, the *previous* generation's containers (briefly unhealthy as they were drained) were correctly identified by autoheal and restart-loop'd until yoink reaped them — confirms autoheal sees the right containers via the \`autoheal: "true"\` label.