### PR TITLE
refactor: drop synthetic `local` host injection from TUI

### DIFF
--- a/yoink/src/audit.rs
+++ b/yoink/src/audit.rs
@@ -659,7 +659,7 @@ async fn append_via_ssh(host: &Host, lines: &[String]) -> std::io::Result<()> {
     }
 }
 
-/// Append directly to the local filesystem (the `local` synthetic
+/// Append directly to the local filesystem (the `local` sentinel
 /// host). Writes through the same path layout as remote hosts so a
 /// `yoink audit log --host local` reads back consistently.
 async fn append_local(lines: &[String]) -> std::io::Result<()> {
@@ -995,7 +995,7 @@ pub async fn read_operator_audit_files(include_rotated: bool) -> std::io::Result
 }
 
 /// Cat the active host audit file plus rotated files (when requested)
-/// over SSH (or locally for the synthetic `local` host). Returns the
+/// over SSH (or locally for the `local` sentinel host). Returns the
 /// concatenated JSONL bytes; missing files read as empty. `key_path`
 /// is the operator-side path to the SSH private key when the host
 /// declares `ssh_key_secret:` (decrypted by `ssh_keys::prepare`); pass

--- a/yoink/src/config.rs
+++ b/yoink/src/config.rs
@@ -1325,26 +1325,6 @@ pub struct ConfigFragment {
     pub hosts: Vec<HostConfig>,
 }
 
-/// True when one of the platform-default docker socket paths exists.
-/// Doesn't actually try to connect — that's a config-load fast path
-/// and hangs would be much worse than a stale check.
-fn local_socket_exists() -> bool {
-    // Order matters: rootless / Docker Desktop / OrbStack on macOS
-    // expose `~/.docker/run/docker.sock`; the system daemon symlinks
-    // the same path at `/var/run/docker.sock`. Either one is good.
-    if std::path::Path::new("/var/run/docker.sock").exists() {
-        return true;
-    }
-    if let Some(home) = std::env::var_os("HOME") {
-        let mut p = std::path::PathBuf::from(home);
-        p.push(".docker/run/docker.sock");
-        if p.exists() {
-            return true;
-        }
-    }
-    false
-}
-
 /// Substitute `${NAME}` references in `text` against process env vars.
 /// Applied to YAML text *before* deserialization, so any string field
 /// in the config (host addresses, service domains, env values, …) can
@@ -1736,34 +1716,6 @@ impl Config {
             }
         }
         Ok(())
-    }
-
-    /// Add a synthetic `local` host pointing at the local docker
-    /// socket — for the operator's laptop daemon, k3d/colima/orbstack
-    /// dev environments, or anywhere yoink is run without a real
-    /// fleet. Only fires when (a) the config doesn't already declare
-    /// a `local` host and (b) one of the platform-default socket
-    /// paths exists. No-op on Windows for now (npipe detection
-    /// requires a connect attempt rather than a path check).
-    ///
-    /// Read-only commands (`tui`, `status`, `diff`, `version`) call
-    /// this so the dashboard "just works" pointing at your laptop;
-    /// destructive commands (`up`, `restart`, `prune`, `rollback`)
-    /// don't, since silently deploying to localhost would surprise.
-    pub fn push_local_host_if_socket(&mut self) {
-        let local = crate::docker_ops::Host::LOCAL_ADDRESS;
-        if self.hosts.iter().any(|h| h.address == local) {
-            return;
-        }
-        if !local_socket_exists() {
-            return;
-        }
-        self.hosts.push(HostConfig {
-            address: local.to_string(),
-            address_secret: None,
-            user: local.to_string(),
-            ssh_key_secret: None,
-        });
     }
 
     /// Expand `self.include` globs against `self.config_dir`, parse each

--- a/yoink/src/docker_ops.rs
+++ b/yoink/src/docker_ops.rs
@@ -61,9 +61,11 @@ pub struct Host {
 }
 
 impl Host {
-    /// Sentinel address marking the synthetic host that talks to the
-    /// local docker socket instead of going over ssh. One constant so
-    /// the magic isn't a stringly-typed sprinkle across the codebase.
+    /// Sentinel address that routes to the operator's local docker
+    /// socket instead of going over ssh. Two callers:
+    /// `transport::unregistry` (image-push source) and `doctor` (arch
+    /// probe). Operators can also write `address: local` in
+    /// `yoink.yaml` to deploy at their own laptop.
     pub const LOCAL_ADDRESS: &'static str = "local";
 
     #[must_use]
@@ -71,16 +73,16 @@ impl Host {
         format!("ssh://{}@{}", self.user, self.address)
     }
 
-    /// True for the magical synthetic local host — bypasses ssh and
+    /// True for the local-docker sentinel host — bypasses ssh and
     /// uses bollard's platform-default unix socket / npipe transport.
     #[must_use]
     pub fn is_local(&self) -> bool {
         self.address == Self::LOCAL_ADDRESS
     }
 
-    /// Construct the synthetic local host. The empty `user` is fine —
-    /// the local-socket transport ignores it. Symmetric with
-    /// [`Self::is_local`].
+    /// Construct a `Host` that points at the operator's local docker
+    /// socket. The empty `user` is fine — the local-socket transport
+    /// ignores it.
     #[must_use]
     pub fn local() -> Self {
         Self {
@@ -973,11 +975,9 @@ impl RealDockerOps {
         // key may both dial — last writer wins, the loser's `Docker`
         // drops harmlessly.
         let docker = if host.is_local() {
-            // The magical "local" host (address == "local", no user)
-            // routes to the local docker socket via bollard's
-            // platform-default unix socket / npipe transport. Lets
-            // the operator run yoink against their laptop's docker
-            // without editing yoink.yaml.
+            // The `local` sentinel host routes to the operator's
+            // docker socket via bollard's platform-default unix-
+            // socket / npipe transport, bypassing ssh entirely.
             Docker::connect_with_local_defaults().map_err(|source| DockerError::Connect {
                 host: host.address.clone(),
                 source,

--- a/yoink/src/main.rs
+++ b/yoink/src/main.rs
@@ -3179,8 +3179,7 @@ async fn pty_session(
 
 #[allow(clippy::needless_pass_by_value)]
 async fn cmd_tui(config: &Config, config_path: PathBuf, mode: Mode, mouse: bool) -> Result<()> {
-    let mut config = config.clone();
-    config.push_local_host_if_socket();
+    let config = config.clone();
     let ops: std::sync::Arc<dyn yoink::docker_ops::DockerOps> =
         std::sync::Arc::new(build_real_ops(&config, None).await?);
     tui::run(&config, config_path, ops, mode, mouse)
@@ -3953,7 +3952,6 @@ async fn cmd_dump(config: &Config, log_tail: u32) -> Result<()> {
         let mut host_obj = json!({
             "address": address,
             "user": host.user,
-            "is_local": host.is_local(),
         });
 
         match ops.version(&host).await {

--- a/yoink/src/tui/app.rs
+++ b/yoink/src/tui/app.rs
@@ -3852,10 +3852,7 @@ impl App {
         if let Some((service, tag)) = &self.reconcile_target {
             let svc_line = format!("service:  {service}");
             let tag_line = format!("tag:      {tag}");
-            let host_count = format!(
-                "hosts:    {} (synthetic local skipped)",
-                self.config.hosts.len(),
-            );
+            let host_count = format!("hosts:    {}", self.config.hosts.len());
             let lines = vec![
                 "About to run `yoink up` for one service.",
                 "",

--- a/yoink/src/tui/app.rs
+++ b/yoink/src/tui/app.rs
@@ -1203,11 +1203,6 @@ impl App {
                 return;
             }
         };
-        // Re-apply the magical local-host injection — load_from_path
-        // returns a fresh disk-shaped config that doesn't know about
-        // it, so without this the synthetic `local` host disappears
-        // every CONFIG_RELOAD_TICK.
-        new_config.push_local_host_if_socket();
         // If the config has any `address_secret:` hosts, resolve them
         // against the cached secrets bundle. The TUI loads the bundle
         // asynchronously via the `secrets` Arc; until that bundle
@@ -4115,7 +4110,7 @@ fn config_host(config: &Config, address: &str) -> Option<Host> {
 /// then sends a final `JobUpdate::Done` regardless of outcome.
 /// Same shape as `cmd_up` in main.rs but without the printlns.
 async fn reconcile_one(
-    mut config: Config,
+    config: Config,
     ops: Arc<dyn DockerOps>,
     secrets: Option<Arc<crate::secrets::SecretsBundle>>,
     service: String,
@@ -4131,15 +4126,8 @@ async fn reconcile_one(
         let _ = tx.send(JobUpdate::Done(result));
     };
 
-    // Drop the synthetic `local` host (auto-injected for read-only
-    // TUI browsing) before any destructive code runs. Operators who
-    // genuinely want to deploy to local can add `address: local` to
-    // yoink.yaml — that entry survives because it was on disk.
-    config.hosts.retain(|h| h.address != Host::LOCAL_ADDRESS);
     if config.hosts.is_empty() {
-        send_done(Err(
-            "no real hosts to deploy to (only the synthetic local host exists)".into(),
-        ));
+        send_done(Err("no hosts configured".into()));
         return;
     }
 
@@ -4194,7 +4182,7 @@ async fn reconcile_one(
 /// `yoink up` with no `--service` filter. Per-service errors stream
 /// in but the run continues; the final Done line summarizes counts.
 async fn reconcile_all(
-    mut config: Config,
+    config: Config,
     ops: Arc<dyn DockerOps>,
     secrets: Option<Arc<crate::secrets::SecretsBundle>>,
     overrides: std::collections::BTreeMap<String, String>,
@@ -4209,11 +4197,8 @@ async fn reconcile_all(
         let _ = tx.send(JobUpdate::Done(result));
     };
 
-    config.hosts.retain(|h| h.address != Host::LOCAL_ADDRESS);
     if config.hosts.is_empty() {
-        send_done(Err(
-            "no real hosts to deploy to (only the synthetic local host exists)".into(),
-        ));
+        send_done(Err("no hosts configured".into()));
         return;
     }
 
@@ -4298,7 +4283,7 @@ async fn reconcile_all(
 
 /// Background prune task. Mirrors `cmd_prune` but pipes each removed
 /// container into the progress modal as a streamed event line.
-async fn prune_all(mut config: Config, ops: Arc<dyn DockerOps>, tx: UnboundedSender<JobUpdate>) {
+async fn prune_all(config: Config, ops: Arc<dyn DockerOps>, tx: UnboundedSender<JobUpdate>) {
     use crate::prune::{self, PruneReason};
 
     let send_event = |line: String| {
@@ -4308,9 +4293,8 @@ async fn prune_all(mut config: Config, ops: Arc<dyn DockerOps>, tx: UnboundedSen
         let _ = tx.send(JobUpdate::Done(result));
     };
 
-    config.hosts.retain(|h| h.address != Host::LOCAL_ADDRESS);
     if config.hosts.is_empty() {
-        send_done(Err("no real hosts to prune".into()));
+        send_done(Err("no hosts to prune".into()));
         return;
     }
 

--- a/yoink/src/tui/resources.rs
+++ b/yoink/src/tui/resources.rs
@@ -198,9 +198,9 @@ impl ResourcesState {
     }
 
     /// Currently-selected target on the active tab, if any. Returns
-    /// `None` for the synthetic local host when the row points at it
-    /// (we don't want operators pruning their laptop's docker by
-    /// accident from a remote-deploy TUI session).
+    /// `None` when the row points at the `local` sentinel host —
+    /// pruning the operator's laptop docker from a remote-deploy
+    /// TUI session is almost always an accident.
     pub fn selected_target(&self, config: &Config) -> Option<ResourceTarget> {
         let visible = self.visible_indices();
         let i = self.active_table_selected()?;

--- a/yoink/src/tui/services.rs
+++ b/yoink/src/tui/services.rs
@@ -197,15 +197,9 @@ fn build_service_row<'a>(
     });
     let running = containers.iter().filter(|c| c.is_running()).count();
     // Expected = replicas × real hosts the service is configured to
-    // run on. The synthetic `local` host the TUI injects for
-    // read-only browsing must be excluded — including it inflates
-    // every service's denominator (e.g. 1-replica on 1 host → 1/2).
+    // run on.
     let expected = cfg_service.map_or(running, |s| {
-        s.applicable_hosts(&config.hosts)
-            .iter()
-            .filter(|h| h.address != crate::docker_ops::Host::LOCAL_ADDRESS)
-            .count()
-            * s.run.replicas as usize
+        s.applicable_hosts(&config.hosts).len() * s.run.replicas as usize
     });
     let running_str = format!("{running}/{expected}");
     let health = summarize_health(&containers);


### PR DESCRIPTION
## Summary

\`Config::push_local_host_if_socket\` auto-appended a fake \`address: local\` host whenever a docker socket existed on the operator's machine, and every read-only TUI / dump / status command called it. The intent was "dashboard just works pointing at your laptop"; the effect was confusion: operators saw a \`local\` row in the hosts pane unrelated to their config, running counts inflated, prune/reconcile paths needed retain-filters to keep it out, and CI logs surfaced it depending on the runner's docker setup.

Removing the injection wholesale.

### What's deleted

- \`Config::push_local_host_if_socket\` + its \`local_socket_exists\` helper.
- The call sites in \`cmd_tui\` and the TUI's config-reload tick.
- The now-redundant \`retain(|h| !LOCAL_ADDRESS)\` filters in the TUI's reconcile / prune paths.
- The running-count exclusion in \`tui::services\`.
- The always-false \`is_local\` field from \`yoink dump\`'s per-host JSON.

### What stays

\`Host::LOCAL_ADDRESS\` / \`Host::local()\` / \`Host::is_local()\` remain — still used internally by:

- \`transport::unregistry\` — the operator's local docker is the source for \`docker save\` during image push.
- \`doctor\` — arch-alignment probe between the operator's docker and remote hosts.

Neither puts \`local\` anywhere user-visible.

### Backwards compatibility

Operators who genuinely want yoink to point at their laptop's docker can still write \`address: local\` in \`yoink.yaml\` directly. The synthetic auto-injection was the source of confusion; the configurable form is unchanged.

## Test plan

- [x] \`cargo clippy -p yoink --all-targets -- -D warnings\`
- [x] \`cargo test -p yoink --lib\` (504 pass)
- [x] \`yoink validate\` against the prod config — clean.
- [x] \`yoink dump\` against the prod config — only the configured host is listed; no \`is_local\` field.

## Net diff

\`+9 / -81\` across 4 files.